### PR TITLE
feat: add run_id to combined results

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -244,6 +244,10 @@ def _join_pivots(source, target, differences, join_on_fields):
 
 
 def _add_metadata(joined, run_metadata):
-    joined = joined[joined, ibis.literal(run_metadata.start_time).name("start_time")]
-    joined = joined[joined, ibis.literal(run_metadata.end_time).name("end_time")]
+    joined = joined[
+        joined,
+        ibis.literal(run_metadata.run_id).name("run_id"),
+        ibis.literal(run_metadata.start_time).name("start_time"),
+        ibis.literal(run_metadata.end_time).name("end_time"),
+    ]
     return joined

--- a/samples/bq_result_handler.py
+++ b/samples/bq_result_handler.py
@@ -19,7 +19,8 @@ from google.cloud import bigquery
 from data_validation import data_validation
 from data_validation.result_handlers import bigquery as bqhandler
 
-BQ_CONN = {"source_type": "BigQuery", "project_id": os.environ["PROJECT_ID"]}
+PROJECT_ID = os.environ["PROJECT_ID"]
+BQ_CONN = {"source_type": "BigQuery", "project_id": PROJECT_ID}
 CONFIG_COUNT_VALID = {
     # BigQuery Specific Connection Config
     "source_conn": BQ_CONN,
@@ -57,7 +58,7 @@ CONFIG_COUNT_VALID = {
     ],
 }
 
-bqclient = bigquery.Client()
+bqclient = bigquery.Client(project=PROJECT_ID)
 result_handler = bqhandler.BigQueryResultHandler(bqclient)
 validator = data_validation.DataValidation(
     CONFIG_COUNT_VALID, verbose=True, result_handler=result_handler

--- a/samples/bq_result_handler_grouped.py
+++ b/samples/bq_result_handler_grouped.py
@@ -20,9 +20,8 @@ from data_validation import data_validation
 from data_validation.result_handlers import bigquery as bqhandler
 
 
-BQ_CONN = {"source_type": "BigQuery", "project_id": os.environ["PROJECT_ID"]}
-
-
+PROJECT_ID = os.environ["PROJECT_ID"]
+BQ_CONN = {"source_type": "BigQuery", "project_id": PROJECT_ID}
 GROUPED_CONFIG_COUNT_VALID = {
     # BigQuery Specific Connection Config
     "source_conn": BQ_CONN,
@@ -50,7 +49,7 @@ GROUPED_CONFIG_COUNT_VALID = {
     ],
 }
 
-bqclient = bigquery.Client()
+bqclient = bigquery.Client(project=PROJECT_ID)
 result_handler = bqhandler.BigQueryResultHandler(bqclient)
 validator = data_validation.DataValidation(
     GROUPED_CONFIG_COUNT_VALID, verbose=True, result_handler=result_handler

--- a/tests/unit/test_combiner.py
+++ b/tests/unit/test_combiner.py
@@ -87,9 +87,11 @@ def test_generate_report_with_too_many_rows(module_under_test):
                 },
                 start_time=datetime.datetime(1998, 9, 4, 7, 30, 1),
                 end_time=datetime.datetime(1998, 9, 4, 7, 31, 42),
+                run_id="test-run",
             ),
             pandas.DataFrame(
                 {
+                    "run_id": ["test-run"],
                     "start_time": [datetime.datetime(1998, 9, 4, 7, 30, 1)],
                     "end_time": [datetime.datetime(1998, 9, 4, 7, 31, 42)],
                     "source_table_name": ["test_source"],
@@ -127,9 +129,11 @@ def test_generate_report_with_too_many_rows(module_under_test):
                 },
                 start_time=datetime.datetime(1998, 9, 4, 7, 30, 1),
                 end_time=datetime.datetime(1998, 9, 4, 7, 31, 42),
+                run_id="test-run",
             ),
             pandas.DataFrame(
                 {
+                    "run_id": ["test-run"],
                     "start_time": [datetime.datetime(1998, 9, 4, 7, 30, 1)],
                     "end_time": [datetime.datetime(1998, 9, 4, 7, 31, 42)],
                     "source_table_name": ["test_source"],
@@ -171,9 +175,11 @@ def test_generate_report_with_too_many_rows(module_under_test):
                 },
                 start_time=datetime.datetime(1998, 9, 4, 7, 30, 1),
                 end_time=datetime.datetime(1998, 9, 4, 7, 31, 42),
+                run_id="test-run",
             ),
             pandas.DataFrame(
                 {
+                    "run_id": ["test-run"] * 2,
                     "start_time": [datetime.datetime(1998, 9, 4, 7, 30, 1)] * 2,
                     "end_time": [datetime.datetime(1998, 9, 4, 7, 31, 42)] * 2,
                     "source_table_name": ["test_source", "test_source"],
@@ -253,9 +259,11 @@ def test_generate_report_without_group_by(
                 },
                 start_time=datetime.datetime(1998, 9, 4, 7, 30, 1),
                 end_time=datetime.datetime(1998, 9, 4, 7, 31, 42),
+                run_id="grouped-test",
             ),
             pandas.DataFrame(
                 {
+                    "run_id": ["grouped-test"] * 4,
                     "start_time": [datetime.datetime(1998, 9, 4, 7, 30, 1)] * 4,
                     "end_time": [datetime.datetime(1998, 9, 4, 7, 31, 42)] * 4,
                     "source_table_name": ["test_source"] * 4,
@@ -295,9 +303,11 @@ def test_generate_report_without_group_by(
                 },
                 start_time=datetime.datetime(1998, 9, 4, 7, 30, 1),
                 end_time=datetime.datetime(1998, 9, 4, 7, 31, 42),
+                run_id="grouped-test",
             ),
             pandas.DataFrame(
                 {
+                    "run_id": ["grouped-test"] * 2,
                     "start_time": [datetime.datetime(1998, 9, 4, 7, 30, 1)] * 2,
                     "end_time": [datetime.datetime(1998, 9, 4, 7, 31, 42)] * 2,
                     "source_table_name": ["test_source"] * 2,
@@ -344,9 +354,11 @@ def test_generate_report_without_group_by(
                 },
                 start_time=datetime.datetime(1998, 9, 4, 7, 30, 1),
                 end_time=datetime.datetime(1998, 9, 4, 7, 31, 42),
+                run_id="grouped-test",
             ),
             pandas.DataFrame(
                 {
+                    "run_id": ["grouped-test"] * 6,
                     "start_time": [datetime.datetime(1998, 9, 4, 7, 30, 1)] * 6,
                     "end_time": [datetime.datetime(1998, 9, 4, 7, 31, 42)] * 6,
                     "source_table_name": [


### PR DESCRIPTION
Behavior can be verified with the following query:

```sql
SELECT *
FROM `pso-kokoro-resources.pso_data_validator.results`
WHERE run_id = "a2078c56-09f5-4935-aa50-9619bc0966d0"
```

Towards #22 