### PR TITLE
issue127/Bug causing null aggregates to break validations

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -181,7 +181,12 @@ def _as_json(expr):
 
     https://stackoverflow.com/a/3020108/101923
     """
-    return expr.cast("string").fillna("null").re_replace(r"\\", r"\\\\").re_replace('"', '\\"')
+    return (
+        expr.cast("string")
+        .fillna("null")
+        .re_replace(r"\\", r"\\\\")
+        .re_replace('"', '\\"')
+    )
 
 
 def _join_pivots(source, target, differences, join_on_fields):


### PR DESCRIPTION
Our current design to write grouped values to JSON is currently failing because it involves using regex to cleanup the values
https://github.com/ibis-project/ibis/blob/master/ibis/backends/pandas/execution/strings.py#L284

However, regex throws an error when it get a `None` value.  Null values in grouped columns are thus causing failures.

The fix I have suggested here is to replace None with null (I was hoping this would align with JSON, but the null is translated as a string).  
This solution resolves the issue and we could put a warning that grouped columns should be non-null and null values could cause hazardous duplication if null is a string value in the column