### PR TITLE
Shift Requirements to Extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=dependencies,
+    extras_require=extras_require,
     entry_points={
         "console_scripts": ["data-validation=data_validation.__main__:main",]
     },


### PR DESCRIPTION
Moving packages which are not required by default to extras to avoid excess imports