### PR TITLE
Fix proto-plus version to align with spanner reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ PyMySQL==1.0.2
 psycopg2-binary==2.8.6
 PyYAML==5.4.1
 pandas==1.2.1
+proto-plus==1.13.0
 pyarrow==3.0.0
 pydata-google-auth==1.1.0
 google-cloud-bigquery==2.7.0


### PR DESCRIPTION
require proto-plus==1.13.0 to avoid spanner issues


I was hitting:
```
Traceback (most recent call last):
  File "/usr/local/google/home/dhercher/Desktop/professional-services-data-validator/venv/bin/data-validation", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/google/home/dhercher/Desktop/professional-services-data-validator/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3252, in <module>
    def _initialize_master_working_set():
  File "/usr/local/google/home/dhercher/Desktop/professional-services-data-validator/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/google/home/dhercher/Desktop/professional-services-data-validator/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/google/home/dhercher/Desktop/professional-services-data-validator/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 585, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/local/google/home/dhercher/Desktop/professional-services-data-validator/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/local/google/home/dhercher/Desktop/professional-services-data-validator/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'proto-plus==1.13.0' distribution was not found and is required by google-cloud-spanner
```