### PR TITLE
fixed the issue with long column names being truncated

### DIFF
--- a/third_party/ibis/ibis_teradata/client.py
+++ b/third_party/ibis/ibis_teradata/client.py
@@ -136,12 +136,6 @@ class TeradataClient(SQLClient):
     TABLE_SCHEMA_SQL = """
     HELP COLUMN {database}.{table}.*;
     """  # TODO move somewhere better
-    # TABLE_SCHEMA_SQL = """
-    # SELECT  ColumnName as "Column Name", ColumnType as "Type", Nullable, ColumnFormat as "Format"
-    #    FROM    DBC.ColumnsV
-    # WHERE   DatabaseName = '{database}'
-    #    AND     TableName = '{table}';
-    # """
 
     def _get_teradata_schema(self, database, table):
         table_schema_sql = self.TABLE_SCHEMA_SQL.format(database=database, table=table)


### PR DESCRIPTION
Field names longer than 30 characters get truncated. Here's the link:
https://downloads.teradata.com/forum/database/help-tables-shows-truncated-column-names-0

Now, I am using a different field name returned by HELP COLUMN to fix this issue.