### PR TITLE
feat: add table matching score as a param incase adjusted is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,32 @@
 # Data Validation Tool
 
-The Data Validation Tool (DVT) is an open sourced Python CLI tool based on the [Ibis framework](https://ibis-project.org/docs/tutorial/01-Introduction-to-Ibis.html) that compares heterogeneous data source tables with multi-leveled validation functions. 
+The Data Validation Tool (DVT) is an open sourced Python CLI tool based on the
+[Ibis framework](https://ibis-project.org/docs/tutorial/01-Introduction-to-Ibis.html)
+that compares heterogeneous data source tables with multi-leveled validation
+functions.
 
-Data validation is a critical step in a Data Warehouse, Database or Data Lake migration project, where structured or semi-structured data from both the source and the destination tables are compared to ensure they are matched and correct after each migration step (e.g. data and schema migration, SQL script translation, ETL migration, etc.). The Data Validation Tool provides an automated and repeatable solution to perform this task.
+Data validation is a critical step in a Data Warehouse, Database or Data Lake
+migration project, where structured or semi-structured data from both the source
+and the destination tables are compared to ensure they are matched and correct
+after each migration step (e.g. data and schema migration, SQL script
+translation, ETL migration, etc.). The Data Validation Tool provides an
+automated and repeatable solution to perform this task.
 
-DVT supports the following validation types:
-- Table level
-  - Table row count
-  - Group by row count
-  - Column aggregation
-  - Filters and limits
+DVT supports the following validation types: - Table level - Table row count -
+Group by row count - Column aggregation - Filters and limits
 
-- Column level
-  - Full column data type
-  - Selected column data type
+-   Column level
 
-- Row level hash comparison  (BigQuery tables only)
+    -   Full column data type
+    -   Selected column data type
 
-- Schema validation
+-   Row level hash comparison (BigQuery tables only)
 
-- Raw SQL exploration
-  - Run custom queries on different data sources
+-   Schema validation
+
+-   Raw SQL exploration
+
+    -   Run custom queries on different data sources
 
 ## Installation
 
@@ -65,8 +71,8 @@ data-validation run
   --target-conn or -tc TARGET_CONN
                         Target connection details
                         See: *Connections* section for each data source
-  --tables-list or -tbls SOURCE_SCHEMA.SOURCE_TABLE=TARGET_SCHEMA.TARGET_TABLE  
-                        Comma separated list of tables in the form schema.table=target_schema.target_table 
+  --tables-list or -tbls SOURCE_SCHEMA.SOURCE_TABLE=TARGET_SCHEMA.TARGET_TABLE
+                        Comma separated list of tables in the form schema.table=target_schema.target_table
                         Target schema name and table name are optional.
                         i.e 'bigquery-public-data.new_york_citibike.citibike_trips'
   --grouped-columns or -gc GROUPED_COLUMNS
@@ -74,7 +80,7 @@ data-validation run
                         (Optional) Only used in GroupedColumn validations
   --primary-keys or -pc PRIMARY_KEYS
                         Comma separated list of columns to use as primary keys
-                        (Optional) Only use in Row validations 
+                        (Optional) Only use in Row validations
   --count COLUMNS       Comma separated list of columns for count or * for all columns
   --sum COLUMNS         Comma separated list of columns for sum or * for all numeric
   --min COLUMNS         Comma separated list of columns for min or * for all numeric
@@ -98,8 +104,8 @@ data-validation run
   --verbose or -v       Verbose logging will print queries executed
 ```
 
-The default aggregation type is a 'COUNT *'. If no aggregation flag 
-(i.e count, sum , min, etc.) is provided, the default aggregation will run.
+The default aggregation type is a 'COUNT *'. If no aggregation flag (i.e count,
+sum , min, etc.) is provided, the default aggregation will run.
 
 The [Examples](docs/examples.md) page provides many examples of how a tool can
 used to run powerful validations without writing any queries.
@@ -108,10 +114,10 @@ used to run powerful validations without writing any queries.
 
 There are many occasions where you need to explore a data source while running
 validations. To avoid the need to open and install a new client, the CLI allows
-you to run custom queries. 
+you to run custom queries.
 
 ```
-data-validation query 
+data-validation query
   --conn or -c CONN
           The connection name to be queried
   --query or -q QUERY
@@ -189,15 +195,14 @@ validations:
 
 ### Filters
 
-Filters let you apply a WHERE statement to your validation query 
-(ie. `SELECT * FROM table WHERE created_at > 30 days ago AND region_id = 71;`).
-The filter is written in the syntax of the given source. 
+Filters let you apply a WHERE statement to your validation query (ie. `SELECT *
+FROM table WHERE created_at > 30 days ago AND region_id = 71;`). The filter is
+written in the syntax of the given source.
 
 Note that you are writing the query to execute, which does not have to match
 between source and target as long as the results can be expected to align. If
-the target filter is omitted, the source filter will run on both the source
-and target tables.
-
+the target filter is omitted, the source filter will run on both the source and
+target tables.
 
 ### Grouped Columns
 
@@ -338,26 +343,35 @@ validation. By default the handler will print to stdout.
 ### Configure tool to output to BigQuery
 
 ```
-data-validation run 
-  -t Column 
-  -sc bq_conn 
-  -tc bq_conn 
-  -tbls bigquery-public-data.new_york_citibike.citibike_trips 
+data-validation run
+  -t Column
+  -sc bq_conn
+  -tc bq_conn
+  -tbls bigquery-public-data.new_york_citibike.citibike_trips
   -bqrh project_id.dataset.table
   -sa service-acct@project.iam.gserviceaccount.com
 ```
 
 ## Building Matched Table Lists
 
-Creating the list of matched tables can be a hassle.  We have added a feature which may help you to match all of the tables together between source and target.
-The find-tables tool:
+Creating the list of matched tables can be a hassle. We have added a feature
+which may help you to match all of the tables together between source and
+target. The find-tables tool:
 
-- Pulls all tables in the source (applying a supplied allowed-schemas filter)
-- Pulls all tables from the target
-- Uses Levenshtein distance to match tables
-- Finally, it prints a JSON list of tables which can be a reference for the validation run config.
+-   Pulls all tables in the source (applying a supplied allowed-schemas filter)
+-   Pulls all tables from the target
+-   Uses Levenshtein distance to match tables
+-   Finally, it prints a JSON list of tables which can be a reference for the
+    validation run config.
 
-`data-validation find-tables --source-conn source --target-conn target --allowed-schemas pso_data_validator`
+Note that our score cutoff default is a 0.8, which was manually tested to be an
+accurate value. If no matches occur, reduce this value.
+
+```
+data-validation find-tables --source-conn source --target-conn target \
+    --allowed-schemas pso_data_validator \
+    --score-cutoff 0.8
+```
 
 ## Add Support for an existing Ibis Data Source
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -237,8 +237,9 @@ def find_tables_using_string_matching(args):
     source_table_map = get_table_map(source_client, allowed_schemas=allowed_schemas)
     target_table_map = get_table_map(target_client)
 
-    table_configs = _compare_match_tables(source_table_map, target_table_map,
-                                          score_cutoff=score_cutoff)
+    table_configs = _compare_match_tables(
+        source_table_map, target_table_map, score_cutoff=score_cutoff
+    )
     return json.dumps(table_configs)
 
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -178,7 +178,7 @@ def build_config_managers_from_yaml(args):
     return config_managers
 
 
-def _compare_match_tables(source_table_map, target_table_map):
+def _compare_match_tables(source_table_map, target_table_map, score_cutoff=0.8):
     """Return dict config object from matching tables."""
     # TODO(dhercher): evaluate if improved comparison and score cutoffs should be used.
     table_configs = []
@@ -186,7 +186,7 @@ def _compare_match_tables(source_table_map, target_table_map):
     target_keys = target_table_map.keys()
     for source_key in source_table_map:
         target_key = jellyfish_distance.extract_closest_match(
-            source_key, target_keys, score_cutoff=0.8
+            source_key, target_keys, score_cutoff=score_cutoff
         )
         if target_key is None:
             continue
@@ -228,6 +228,7 @@ def find_tables_using_string_matching(args):
     """Return JSON String with matched tables for use in validations."""
     source_conn = cli_tools.get_connection(args.source_conn)
     target_conn = cli_tools.get_connection(args.target_conn)
+    score_cutoff = args.score_cutoff or 0.8
 
     source_client = clients.get_data_client(source_conn)
     target_client = clients.get_data_client(target_conn)
@@ -236,7 +237,8 @@ def find_tables_using_string_matching(args):
     source_table_map = get_table_map(source_client, allowed_schemas=allowed_schemas)
     target_table_map = get_table_map(target_client)
 
-    table_configs = _compare_match_tables(source_table_map, target_table_map)
+    table_configs = _compare_match_tables(source_table_map, target_table_map,
+                                          score_cutoff=score_cutoff)
     return json.dumps(table_configs)
 
 

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -170,6 +170,10 @@ def _configure_find_tables(subparsers):
     find_tables_parser.add_argument(
         "--allowed-schemas", "-as", help="List of source schemas to match."
     )
+    find_tables_parser.add_argument(
+        "--score-cutoff", "-score",
+        help="The minimum distance score allowed to match tables (0 to 1)."
+    )
 
 
 def _configure_raw_query(subparsers):

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -171,7 +171,7 @@ def _configure_find_tables(subparsers):
         "--allowed-schemas", "-as", help="List of source schemas to match."
     )
     find_tables_parser.add_argument(
-        "--score-cutoff", "-score",
+        "--score-cutoff", "-score", type=float,
         help="The minimum distance score allowed to match tables (0 to 1)."
     )
 

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -171,8 +171,10 @@ def _configure_find_tables(subparsers):
         "--allowed-schemas", "-as", help="List of source schemas to match."
     )
     find_tables_parser.add_argument(
-        "--score-cutoff", "-score", type=float,
-        help="The minimum distance score allowed to match tables (0 to 1)."
+        "--score-cutoff",
+        "-score",
+        type=float,
+        help="The minimum distance score allowed to match tables (0 to 1).",
     )
 
 


### PR DESCRIPTION
The distance score is calculated between 0 and 1.  Generally the default, 80%, works for most cases.  If you find the default is not working well, this feature allows the value to be overridden