### PR TITLE
fix: FileSystem to BQ validation error

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -288,6 +288,10 @@ class ConfigManager(object):
             consts.CONFIG_SOURCE_CONN: source_conn,
             consts.CONFIG_TARGET_CONN: target_conn,
             consts.CONFIG_TABLE_NAME: table_obj[consts.CONFIG_TABLE_NAME],
+            consts.CONFIG_SCHEMA_NAME: table_obj[consts.CONFIG_SCHEMA_NAME],
+            consts.CONFIG_TARGET_SCHEMA_NAME: table_obj.get(
+                consts.CONFIG_TARGET_SCHEMA_NAME, table_obj[consts.CONFIG_SCHEMA_NAME]
+            ),
             consts.CONFIG_TARGET_TABLE_NAME: table_obj.get(
                 consts.CONFIG_TARGET_TABLE_NAME, table_obj[consts.CONFIG_TABLE_NAME]
             ),
@@ -298,14 +302,7 @@ class ConfigManager(object):
             consts.CONFIG_FILTERS: filter_config,
         }
 
-        # Only FileSystem connections do not require schemas
-        if source_conn["source_type"] != "FileSystem":
-            config[consts.CONFIG_SCHEMA_NAME] = table_obj[consts.CONFIG_SCHEMA_NAME]
-            config[consts.CONFIG_TARGET_SCHEMA_NAME] = table_obj.get(
-                consts.CONFIG_TARGET_SCHEMA_NAME, table_obj[consts.CONFIG_SCHEMA_NAME]
-            )
-        else:
-            config[consts.CONFIG_SCHEMA_NAME] = None
+        if target_conn["source_type"] == "FileSystem":
             config[consts.CONFIG_TARGET_SCHEMA_NAME] = None
 
         return ConfigManager(config, source_client, target_client, verbose=verbose)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -121,9 +121,11 @@ data-validation validate schema -sc my_bq_conn -tc my_bq_conn -tbls bigquery-pub
 pip install gcsfs
 pip install fsspec
 
-data-validation connections add --connection-name file_conn FileSystem --table-name my_local_file --file-path gs://path/to/file --file-type csv
+data-validation connections add --connection-name file_conn FileSystem --table-name $FILE_NAME --file-path gs://path/to/file --file-type csv
+data-validation connections add --connection-name my_bq_conn BigQuery --project-id $YOUR_PROJECT_ID
 
-data-validation validate column -sc file_conn -tc file_conn -tbls my_local_file --count name
+# Validate GCS CSV file with BigQuery table
+data-validation validate column -sc file_conn -tc my_bq_conn -tbls $FILE_NAME=$YOUR_PROJECT_ID.dataset.table --count $COLUMN
 ````
 
 #### Run custom SQL 


### PR DESCRIPTION
Closes Issue #305 

- Updated code so that BQ target schema would not set the target schema to 'None' for FileSystem to BQ validations
- Updated FileSystem validation example