### PR TITLE
feat: add state manager client

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,24 @@ after each migration step (e.g. data and schema migration, SQL script
 translation, ETL migration, etc.). The Data Validation Tool provides an
 automated and repeatable solution to perform this task.
 
-DVT supports the following validation types:
-* Table level
-  * Table row count
-  * Group by row count
-  * Column aggregation
-  * Filters and limits
-* Column level
-  * Full column data type
-* Row level hash comparison  (BigQuery tables only)
-* Raw SQL exploration
-  * Run custom queries on different data sources
+DVT supports the following validation types: * Table level * Table row count *
+Group by row count * Column aggregation * Filters and limits * Column level *
+Full column data type * Row level hash comparison (BigQuery tables only) * Raw
+SQL exploration * Run custom queries on different data sources
 
 DVT supports the following connection types:
 
-* [BigQuery](docs/connections.md#google-bigquery)
-* [Spanner](docs/connections.md#google-spanner)
-* [Teradata](docs/connections.md#teradata)
-* [Oracle](docs/connections.md#oracle)
-* [MSSQL](docs/connections.md#mssql-server)
-* [Snowflake](docs/connections.md#snowflake)
-* [Postgres](docs/connections.md#postgres)
-* [MySQL](docs/connections.md#mysql)
-* [Redshift](docs/connections.md#redshift)
-* [FileSystem](docs/connections.md#filesystem)
-* [Impala](docs/connections.md#impala)
+*   [BigQuery](docs/connections.md#google-bigquery)
+*   [Spanner](docs/connections.md#google-spanner)
+*   [Teradata](docs/connections.md#teradata)
+*   [Oracle](docs/connections.md#oracle)
+*   [MSSQL](docs/connections.md#mssql-server)
+*   [Snowflake](docs/connections.md#snowflake)
+*   [Postgres](docs/connections.md#postgres)
+*   [MySQL](docs/connections.md#mysql)
+*   [Redshift](docs/connections.md#redshift)
+*   [FileSystem](docs/connections.md#filesystem)
+*   [Impala](docs/connections.md#impala)
 
 The [Connections](docs/connections.md) page provides details about how to create
 and list connections for the validation tool.
@@ -54,6 +47,18 @@ those tables. Validation results can be printed to stdout (default) or outputted
 to BigQuery. The validation tool also allows you to save or edit validation
 configurations in a YAML file. This is useful for running common validations or
 updating the configuration.
+
+### Managing Connections
+
+The Data Validation Tool expects to recieve a source and target connection for
+each validation which is run.
+
+These connections can be supplied directly to the configuration, but more often
+you want to manage connections separately and reference them by name.
+
+Connections can be stored locally or in a GCS directory.
+
+To create connections please review the [Connections](docs/connections.md) page.
 
 ### Running CLI Validations
 
@@ -75,11 +80,11 @@ DVT supports column (including grouped column) and schema validations.
 
 #### Column Validations
 
-Below is the command syntax for column validations. To run a grouped column validation,
-simply specify the `--grouped-columns` flag. You can also take grouped column validations
-a step further by providing the `--primary-key` flag. With this flag, if a mismatch was found,
-DVT will dive deeper into the slice with the error and find the row (primary key value) with the
-inconsistency. 
+Below is the command syntax for column validations. To run a grouped column
+validation, simply specify the `--grouped-columns` flag. You can also take
+grouped column validations a step further by providing the `--primary-key` flag.
+With this flag, if a mismatch was found, DVT will dive deeper into the slice
+with the error and find the row (primary key value) with the inconsistency.
 
 ```
 data-validation (--verbose or -v) validate column
@@ -129,8 +134,9 @@ The [Examples](docs/examples.md) page provides many examples of how a tool can
 used to run powerful validations without writing any queries.
 
 #### Schema Validations
-Below is the syntax for schema validations. These can be used to compare column types between source
-and target.
+
+Below is the syntax for schema validations. These can be used to compare column
+types between source and target.
 
 ```
 data-validation (--verbose or -v) validate schema
@@ -151,7 +157,7 @@ data-validation (--verbose or -v) validate schema
                         Service account to use for BigQuery result handler output.
   [--config-file or -c CONFIG_FILE]
                         YAML Config File Path to be used for storing validations.
-  [--format or -fmt]    Format for stdout output. Supported formats are (text, csv, json, table). 
+  [--format or -fmt]    Format for stdout output. Supported formats are (text, csv, json, table).
                         Defaults  to table.
 ```
 
@@ -175,11 +181,9 @@ You can customize the configuration for any given validation by providing use
 case specific CLI arguments or editing the saved YAML configuration file.
 
 For example, the following command creates a YAML file for the validation of the
-`new_york_citibike` table: 
-```
-data-validation validate column -sc my_bq_conn -tc my_bq_conn -tbls
-bigquery-public-data.new_york_citibike.citibike_trips -c citibike.yaml
-```
+`new_york_citibike` table: `data-validation validate column -sc my_bq_conn -tc
+my_bq_conn -tbls bigquery-public-data.new_york_citibike.citibike_trips -c
+citibike.yaml`
 
 Here is the generated YAML file named `citibike.yaml`:
 
@@ -212,8 +216,8 @@ validation:
 data-validation run-config -c citibike.yaml
 ```
 
-View the complete YAML file for a GroupedColumn validation on the [examples](docs/examples.md#)
-page.
+View the complete YAML file for a GroupedColumn validation on the
+[examples](docs/examples.md#) page.
 
 ### Aggregated Fields
 
@@ -385,12 +389,11 @@ FROM (
 
 ## Validation Reports
 
-The output handlers tell the data validation tool where to store the results of each
-validation. The tool can write the results of a validation run to Google
+The output handlers tell the data validation tool where to store the results of
+each validation. The tool can write the results of a validation run to Google
 BigQuery or print to stdout (default).
 
 View the schema of the results [here](terraform/results_schema.json).
-
 
 ### Configure tool to output to BigQuery
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -16,7 +16,7 @@
 import json
 from yaml import dump, load, Dumper, Loader
 
-from data_validation import cli_tools, clients, consts, jellyfish_distance
+from data_validation import cli_tools, clients, consts, jellyfish_distance, state_manager
 from data_validation.config_manager import ConfigManager
 from data_validation.data_validation import DataValidation
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -16,7 +16,13 @@
 import json
 from yaml import dump, load, Dumper, Loader
 
-from data_validation import cli_tools, clients, consts, jellyfish_distance, state_manager
+from data_validation import (
+    cli_tools,
+    clients,
+    consts,
+    jellyfish_distance,
+    state_manager,
+)
 from data_validation.config_manager import ConfigManager
 from data_validation.data_validation import DataValidation
 
@@ -129,14 +135,12 @@ def build_config_managers_from_args(args):
         labels = cli_tools.get_labels(args.labels)
 
     mgr = state_manager.StateManager()
-    source_client = clients.get_data_client(
-        mgr.get_connection_config(args.source_conn))
-    target_client = clients.get_data_client(
-        mgr.get_connection_config(args.source_conn))
+    source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
+    target_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
 
     format = args.format if args.format else "table"
 
-    is_filesystem = True if source_conn["source_type"] == "FileSystem" else False
+    is_filesystem = source_client._source_type == "FileSystem"
     tables_list = cli_tools.get_tables_list(
         args.tables_list, default_value=[], is_filesystem=is_filesystem
     )

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -136,7 +136,7 @@ def build_config_managers_from_args(args):
 
     mgr = state_manager.StateManager()
     source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
-    target_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
+    target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
 
     format = args.format if args.format else "table"
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -109,9 +109,6 @@ def build_config_managers_from_args(args):
     else:
         config_type = args.type
 
-    source_conn = cli_tools.get_connection(args.source_conn)
-    target_conn = cli_tools.get_connection(args.target_conn)
-
     result_handler_config = None
     if args.bq_result_handler:
         result_handler_config = cli_tools.get_result_handler(
@@ -131,8 +128,11 @@ def build_config_managers_from_args(args):
             threshold = args.threshold
         labels = cli_tools.get_labels(args.labels)
 
-    source_client = clients.get_data_client(source_conn)
-    target_client = clients.get_data_client(target_conn)
+    mgr = state_manager.StateManager()
+    source_client = clients.get_data_client(
+        mgr.get_connection_config(args.source_conn))
+    target_client = clients.get_data_client(
+        mgr.get_connection_config(args.source_conn))
 
     format = args.format if args.format else "table"
 
@@ -144,14 +144,14 @@ def build_config_managers_from_args(args):
     for table_obj in tables_list:
         config_manager = ConfigManager.build_config_manager(
             config_type,
-            source_conn,
-            target_conn,
-            source_client,
-            target_client,
+            args.source_conn,
+            args.target_conn,
             table_obj,
             labels,
             threshold,
             format,
+            source_client=source_client,
+            target_client=target_client,
             result_handler_config=result_handler_config,
             filter_config=filter_config,
             verbose=args.verbose,
@@ -171,8 +171,9 @@ def build_config_managers_from_yaml(args):
     config_file_path = _get_arg_config_file(args)
     yaml_configs = _get_yaml_config_from_file(config_file_path)
 
-    source_conn = cli_tools.get_connection(yaml_configs[consts.YAML_SOURCE])
-    target_conn = cli_tools.get_connection(yaml_configs[consts.YAML_TARGET])
+    mgr = state_manager.StateManager()
+    source_conn = mgr.get_connection_config(yaml_configs[consts.YAML_SOURCE])
+    target_conn = mgr.get_connection_config(yaml_configs[consts.YAML_TARGET])
 
     source_client = clients.get_data_client(source_conn)
     target_client = clients.get_data_client(target_conn)
@@ -238,12 +239,11 @@ def get_table_map(client, allowed_schemas=None):
 
 def find_tables_using_string_matching(args):
     """Return JSON String with matched tables for use in validations."""
-    source_conn = cli_tools.get_connection(args.source_conn)
-    target_conn = cli_tools.get_connection(args.target_conn)
     score_cutoff = args.score_cutoff or 0.8
 
-    source_client = clients.get_data_client(source_conn)
-    target_client = clients.get_data_client(target_conn)
+    mgr = state_manager.StateManager()
+    source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
+    target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
 
     allowed_schemas = cli_tools.get_arg_list(args.allowed_schemas)
     source_table_map = get_table_map(source_client, allowed_schemas=allowed_schemas)
@@ -257,8 +257,8 @@ def find_tables_using_string_matching(args):
 
 def run_raw_query_against_connection(args):
     """Return results of raw query for adhoc usage."""
-    conn = cli_tools.get_connection(args.conn)
-    client = clients.get_data_client(conn)
+    mgr = state_manager.StateManager()
+    client = clients.get_data_client(mgr.get_connection_config(args.conn))
 
     with client.raw_sql(args.query, results=True) as cur:
         return cur.fetchall()

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-""" The Data Validation CLI tool is intended to help to build and execute
+"""The Data Validation CLI tool is intended to help to build and execute
 data validation runs with ease.
 
 The Data Validator can be called either using:
@@ -47,11 +47,11 @@ data-validation run-config -c ex_yaml.yaml
 import argparse
 import csv
 import json
-import os
 import sys
 import uuid
 
-from data_validation import consts, state_manager
+from data_validation import consts
+from data_validation import state_manager
 
 
 CONNECTION_SOURCE_FIELDS = {
@@ -507,6 +507,7 @@ def store_connection(connection_name, conn):
     mgr = state_manager.StateManager()
     mgr.create_connection(connection_name, conn)
 
+
 #     connection_name = connection_name or _generate_random_name(conn)
 #     file_path = _get_connection_file(connection_name)
 
@@ -543,6 +544,8 @@ def get_connection(connection_name):
     """ Return dict connection details for a specific connection."""
     mgr = state_manager.StateManager()
     return mgr.get_connection_config(connection_name)
+
+
 #     with open(file_path, "r") as file:
 #         conn_str = file.read()
 #     return json.loads(conn_str)

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -51,7 +51,7 @@ import os
 import sys
 import uuid
 
-from data_validation import consts
+from data_validation import consts, state_manager
 
 
 CONNECTION_SOURCE_FIELDS = {
@@ -481,22 +481,20 @@ def threshold_float(x):
     return x
 
 
-def _get_data_validation_directory():
-    raw_dir_path = (
-        os.environ.get(consts.ENV_DIRECTORY_VAR) or consts.DEFAULT_ENV_DIRECTORY
-    )
-    dir_path = os.path.expanduser(raw_dir_path)
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
+# def _get_data_validation_directory():
+#     raw_dir_path = (
+#         os.environ.get(consts.ENV_DIRECTORY_VAR) or consts.DEFAULT_ENV_DIRECTORY
+#     )
+#     dir_path = os.path.expanduser(raw_dir_path)
+#     if not os.path.exists(dir_path):
+#         os.makedirs(dir_path)
+#     return dir_path
 
-    return dir_path
 
-
-def _get_connection_file(connection_name):
-    dir_path = _get_data_validation_directory()
-    file_name = f"{connection_name}.connection.json"
-
-    return os.path.join(dir_path, file_name)
+# def _get_connection_file(connection_name):
+#     dir_path = _get_data_validation_directory()
+#     file_name = f"{connection_name}.connection.json"
+#     return os.path.join(dir_path, file_name)
 
 
 def _generate_random_name(conn):
@@ -506,32 +504,36 @@ def _generate_random_name(conn):
 
 def store_connection(connection_name, conn):
     """ Store the connection config under the given name."""
-    connection_name = connection_name or _generate_random_name(conn)
-    file_path = _get_connection_file(connection_name)
+    mgr = state_manager.StateManager()
+    mgr.create_connection(connection_name, conn)
 
-    with open(file_path, "w") as file:
-        file.write(json.dumps(conn))
+#     connection_name = connection_name or _generate_random_name(conn)
+#     file_path = _get_connection_file(connection_name)
+
+#     with open(file_path, "w") as file:
+#         file.write(json.dumps(conn))
 
 
-def get_connections():
-    """ Return dict with connection name and path key pairs."""
-    connections = {}
+# def get_connections():
+#     """ Return dict with connection name and path key pairs."""
+#     connections = {}
 
-    dir_path = _get_data_validation_directory()
-    all_config_files = os.listdir(dir_path)
-    for config_file in all_config_files:
-        if config_file.endswith(".connection.json"):
-            config_file_path = os.path.join(dir_path, config_file)
-            conn_name = config_file.split(".")[0]
+#     dir_path = _get_data_validation_directory()
+#     all_config_files = os.listdir(dir_path)
+#     for config_file in all_config_files:
+#         if config_file.endswith(".connection.json"):
+#             config_file_path = os.path.join(dir_path, config_file)
+#             conn_name = config_file.split(".")[0]
 
-            connections[conn_name] = config_file_path
+#             connections[conn_name] = config_file_path
 
-    return connections
+#     return connections
 
 
 def list_connections():
     """ List all saved connections."""
-    connections = get_connections()
+    mgr = state_manager.StateManager()
+    connections = mgr.list_connections()
 
     for conn_name in connections:
         print(f"Connection Name: {conn_name}")
@@ -539,11 +541,11 @@ def list_connections():
 
 def get_connection(connection_name):
     """ Return dict connection details for a specific connection."""
-    file_path = _get_connection_file(connection_name)
-    with open(file_path, "r") as file:
-        conn_str = file.read()
-
-    return json.loads(conn_str)
+    mgr = state_manager.StateManager()
+    return mgr.get_connection_config(connection_name)
+#     with open(file_path, "r") as file:
+#         conn_str = file.read()
+#     return json.loads(conn_str)
 
 
 def get_labels(arg_labels):

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -201,6 +201,7 @@ def get_data_client(connection_config):
 
     try:
         data_client = CLIENT_LOOKUP[source_type](**connection_config)
+        data_client._source_type = source_type
     except Exception as e:
         msg = 'Connection Type "{source_type}" could not connect: {error}'.format(
             source_type=source_type, error=str(e)

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -257,10 +257,13 @@ class ConfigManager(object):
         """Return Dict object formatted for a Yaml file."""
         config = copy.deepcopy(self.config)
 
-        del config[consts.CONFIG_SOURCE_CONN]
-        del config[consts.CONFIG_TARGET_CONN]
-        if consts.CONFIG_RESULT_HANDLER in config:
-            del config[consts.CONFIG_RESULT_HANDLER]
+        config.pop(consts.CONFIG_SOURCE_CONN, None)
+        config.pop(consts.CONFIG_TARGET_CONN, None)
+
+        config.pop(consts.CONFIG_SOURCE_CONN_NAME, None)
+        config.pop(consts.CONFIG_TARGET_CONN_NAME, None)
+
+        config.pop(consts.CONFIG_RESULT_HANDLER, None)
 
         return config
 

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -47,13 +47,11 @@ class ConfigManager(object):
         self._state_manager = state_manager.StateManager()
         self._config = config
 
-        self.source_client = (
-            source_client or
-            clients.get_data_client(self.get_source_connection())
+        self.source_client = source_client or clients.get_data_client(
+            self.get_source_connection()
         )
-        self.target_client = (
-            target_client or
-            clients.get_data_client(self.get_target_connection())
+        self.target_client = target_client or clients.get_data_client(
+            self.get_target_connection()
         )
         if not self.process_in_memory():
             self.target_client = source_client
@@ -72,8 +70,7 @@ class ConfigManager(object):
                 self._source_conn = self._config.get(consts.CONFIG_SOURCE_CONN)
             else:
                 conn_name = self._config.get(consts.CONFIG_SOURCE_CONN_NAME)
-                self._source_conn = self._state_manager.get_connection_config(
-                    conn_name)
+                self._source_conn = self._state_manager.get_connection_config(conn_name)
 
         return self._source_conn
 
@@ -84,8 +81,7 @@ class ConfigManager(object):
                 self._target_conn = self._config.get(consts.CONFIG_TARGET_CONN)
             else:
                 conn_name = self._config.get(consts.CONFIG_TARGET_CONN_NAME)
-                self._target_conn = self._state_manager.get_connection_config(
-                    conn_name)
+                self._target_conn = self._state_manager.get_connection_config(conn_name)
 
         return self._target_conn
 
@@ -162,6 +158,8 @@ class ConfigManager(object):
     @property
     def source_schema(self):
         """Return string value of source schema."""
+        if self.source_client._source_type == "FileSystem":
+            return None
         return self._config.get(consts.CONFIG_SCHEMA_NAME, None)
 
     @property
@@ -172,6 +170,8 @@ class ConfigManager(object):
     @property
     def target_schema(self):
         """Return string value of target schema."""
+        if self.target_client._source_type == "FileSystem":
+            return None
         return self._config.get(consts.CONFIG_TARGET_SCHEMA_NAME, self.source_schema)
 
     @property
@@ -326,13 +326,12 @@ class ConfigManager(object):
             consts.CONFIG_FILTERS: filter_config,
         }
 
-        if target_conn["source_type"] == "FileSystem":
-            config[consts.CONFIG_TARGET_SCHEMA_NAME] = None
-
-        return ConfigManager(config,
-                             source_client=source_client,
-                             target_client=target_client,
-                             verbose=verbose)
+        return ConfigManager(
+            config,
+            source_client=source_client,
+            target_client=target_client,
+            verbose=verbose,
+        )
 
     def build_config_grouped_columns(self, grouped_columns):
         """Return list of grouped column config objects."""

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -62,9 +62,11 @@ GROUPED_COLUMN_VALIDATION = "GroupedColumn"
 ROW_VALIDATION = "Row"
 SCHEMA_VALIDATION = "Schema"
 
-# Yaml File Config Fields
-ENV_DIRECTORY_VAR = "PSO_DV_CONFIG_HOME"
+# State Manager Fields
 DEFAULT_ENV_DIRECTORY = "~/.config/google-pso-data-validator/"
+ENV_DIRECTORY_VAR = "PSO_DV_CONFIG_HOME"
+
+# Yaml File Config Fields
 YAML_RESULT_HANDLER = "result_handler"
 YAML_SOURCE = "source"
 YAML_TARGET = "target"

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -16,6 +16,8 @@
 # Configuration Fields
 SOURCE_TYPE = "source_type"
 CONFIG = "config"
+CONFIG_SOURCE_CONN_NAME = "source_conn_name"
+CONFIG_TARGET_CONN_NAME = "target_conn_name"
 CONFIG_SOURCE_CONN = "source_conn"
 CONFIG_TARGET_CONN = "target_conn"
 CONFIG_TYPE = "type"

--- a/data_validation/data_validation.py
+++ b/data_validation/data_validation.py
@@ -21,7 +21,7 @@ import ibis.backends.pandas
 import pandas
 import numpy
 
-from data_validation import consts, combiner, metadata, clients
+from data_validation import consts, combiner, metadata
 from data_validation.config_manager import ConfigManager
 from data_validation.validation_builder import ValidationBuilder
 from data_validation.schema_validation import SchemaValidation
@@ -58,15 +58,8 @@ class DataValidation(object):
         # Data Client Management
         self.config = config
 
-        self.source_client = clients.get_data_client(
-            self.config[consts.CONFIG_SOURCE_CONN]
-        )
-        self.target_client = clients.get_data_client(
-            self.config[consts.CONFIG_TARGET_CONN]
-        )
-
         self.config_manager = ConfigManager(
-            config, self.source_client, self.target_client, verbose=self.verbose
+            config, verbose=self.verbose
         )
 
         self.run_metadata = metadata.RunMetadata()
@@ -256,8 +249,8 @@ class DataValidation(object):
         join_on_fields = validation_builder.get_group_aliases()
 
         if process_in_memory:
-            source_df = self.source_client.execute(source_query)
-            target_df = self.target_client.execute(target_query)
+            source_df = self.config_manager.source_client.execute(source_query)
+            target_df = self.config_manager.target_client.execute(target_query)
             pd_schema = self._get_pandas_schema(
                 source_df, target_df, join_on_fields, verbose=self.verbose
             )
@@ -286,7 +279,7 @@ class DataValidation(object):
                 raise e
         else:
             result_df = combiner.generate_report(
-                self.source_client,
+                self.config_manager.source_client,
                 self.run_metadata,
                 source_query,
                 target_query,

--- a/data_validation/data_validation.py
+++ b/data_validation/data_validation.py
@@ -58,9 +58,7 @@ class DataValidation(object):
         # Data Client Management
         self.config = config
 
-        self.config_manager = ConfigManager(
-            config, verbose=self.verbose
-        )
+        self.config_manager = ConfigManager(config, verbose=self.verbose)
 
         self.run_metadata = metadata.RunMetadata()
         self.run_metadata.labels = self.config_manager.labels

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -83,6 +83,9 @@ class StateManager(object):
 
     def _get_connections_directory(self) -> str:
         """Returns the connections directory path."""
+        if self.file_system == FileSystem.LOCAL:
+            return self.file_system_root_path
+
         return os.path.join(self.file_system_root_path, "connections")
 
     def _get_connection_path(self, name: str) -> str:

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" The StateManager is a utility to help manage Data Validations long-lived
+"""The StateManager is a utility to help manage Data Validations long-lived
 configurations and state. The majority of this work is file system management
 of connections and validation files.
 """

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -134,7 +134,10 @@ class StateManager(object):
     # GCS File Management Section
     def setup_gcs(self):
         self.storage_client = storage.Client()
-        self.gcs_bucket = self._get_gcs_bucket()
+        try:
+            self.gcs_bucket = self._get_gcs_bucket()
+        except ValueError as e:
+           raise ValueError("GCS Path Failure {} -> {}".format(self.file_system_root_path, e))
 
     def _get_gcs_bucket(self):
         bucket_name = self.file_system_root_path[5:].split("/")[0]

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -16,27 +16,20 @@ configurations and state. The majority of this work is file system management
 of connections and validation files.
 """
 
-import copy
+import enum
 import json
-import logging
 import os
-from enum import Enum
 
 from data_validation import consts
-from data_validation import clients
-from data_validation.result_handlers.bigquery import BigQueryResultHandler
-from data_validation.result_handlers.text import TextResultHandler
-from data_validation.validation_builder import ValidationBuilder
 
 
-class FileSystem(Enum):
+class FileSystem(enum.Enum):
     LOCAL = 1
     GCS = 2
 
 
 class StateManager(object):
-
-    def __init__(self, file_system_root_path: str=None, verbose: bool=False):
+    def __init__(self, file_system_root_path: str = None, verbose: bool = False):
         """Initialize a StateManager which handles configuration
         and state management files.
 
@@ -45,10 +38,10 @@ class StateManager(object):
                 eg. "gs://bucket/data-validation/" or "/path/to/files/"
         """
         raw_dir_path = (
-          file_system_root_path
+            file_system_root_path
             or os.environ.get(consts.ENV_DIRECTORY_VAR)
             or consts.DEFAULT_ENV_DIRECTORY
-          )
+        )
         self.file_system_root_path = os.path.expanduser(raw_dir_path)
         self.file_system = self._get_file_system()
         self.verbose = verbose
@@ -80,19 +73,25 @@ class StateManager(object):
     def list_connections(self) -> list[str]:
         """Returns a list of the connection names that exist."""
         file_names = self._list_directory(self._get_connections_directory())
-        return [file_name.split(".")[0] for file_name in file_names if file_name.endswith(".connection.json")]
+        return [
+            file_name.split(".")[0]
+            for file_name in file_names
+            if file_name.endswith(".connection.json")
+        ]
 
     def _get_connections_directory(self) -> str:
-      """Returns the connections directory path."""
-      return os.path.join(self.file_system_root_path, "connections")
+        """Returns the connections directory path."""
+        return os.path.join(self.file_system_root_path, "connections")
 
     def _get_connection_path(self, name: str) -> str:
-      """Returns the full path to a connection.
+        """Returns the full path to a connection.
 
       Args:
           name: The name of the connection.
       """
-      return os.path.join(self._get_connections_directory(), f"{name}.connection.json")
+        return os.path.join(
+            self._get_connections_directory(), f"{name}.connection.json"
+        )
 
     def _read_file(self, file_path: str):
         if self.file_system == FileSystem.GCS:

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -137,7 +137,9 @@ class StateManager(object):
         try:
             self.gcs_bucket = self._get_gcs_bucket()
         except ValueError as e:
-           raise ValueError("GCS Path Failure {} -> {}".format(self.file_system_root_path, e))
+            raise ValueError(
+                "GCS Path Failure {} -> {}".format(self.file_system_root_path, e)
+            )
 
     def _get_gcs_bucket(self):
         bucket_name = self.file_system_root_path[5:].split("/")[0]

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -1,0 +1,128 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" The StateManager is a utility to help manage Data Validations long-lived
+configurations and state. The majority of this work is file system management
+of connections and validation files.
+"""
+
+import copy
+import json
+import logging
+import os
+from enum import Enum
+
+from data_validation import consts
+from data_validation import clients
+from data_validation.result_handlers.bigquery import BigQueryResultHandler
+from data_validation.result_handlers.text import TextResultHandler
+from data_validation.validation_builder import ValidationBuilder
+
+
+class FileSystem(Enum):
+    LOCAL = 1
+    GCS = 2
+
+
+class StateManager(object):
+
+    def __init__(self, file_system_root_path: str=None, verbose: bool=False):
+        """Initialize a StateManager which handles configuration
+        and state management files.
+
+        Args:
+            file_system_root_path (String): A root file system path
+                eg. "gs://bucket/data-validation/" or "/path/to/files/"
+        """
+        raw_dir_path = (
+          file_system_root_path
+            or os.environ.get(consts.ENV_DIRECTORY_VAR)
+            or consts.DEFAULT_ENV_DIRECTORY
+          )
+        self.file_system_root_path = os.path.expanduser(raw_dir_path)
+        self.file_system = self._get_file_system()
+        self.verbose = verbose
+        self._validate_path_requirements()
+
+    def create_connection(self, name: str, config: dict[str]):
+        """Create a connection file and store the given config as JSON.
+
+        Args:
+            name (String): The name of the connection.
+            config (Dict): A dictionary with the connection details.
+        """
+        connection_path = self._get_connection_path(name)
+        self._write_file(connection_path, json.dumps(config))
+
+    def get_connection_config(self, name: str) -> dict[str]:
+        """Get a connection configuration from the expected file.
+
+        Args:
+            name: The name of the connection.
+        Returns:
+            A dict of the connection values from the file.
+        """
+        connection_path = self._get_connection_path(name)
+        conn_str = self._read_file(connection_path)
+
+        return json.loads(conn_str)
+
+    def list_connections(self) -> list[str]:
+        """Returns a list of the connection names that exist."""
+        file_names = self._list_directory(self._get_connections_directory())
+        return [file_name.split(".")[0] for file_name in file_names if file_name.endswith(".connection.json")]
+
+    def _get_connections_directory(self) -> str:
+      """Returns the connections directory path."""
+      return os.path.join(self.file_system_root_path, "connections")
+
+    def _get_connection_path(self, name: str) -> str:
+      """Returns the full path to a connection.
+
+      Args:
+          name: The name of the connection.
+      """
+      return os.path.join(self._get_connections_directory(), f"{name}.connection.json")
+
+    def _read_file(self, file_path: str):
+        if self.file_system == FileSystem.GCS:
+            raise Exception("GCS File read not supported")
+        else:
+            return open(file_path, "r").read()
+
+    def _write_file(self, file_path: str, data: str):
+        if self.file_system == FileSystem.GCS:
+            raise Exception("GCS File write not supported")
+        else:
+            with open(file_path, "w") as file:
+                file.write(data)
+
+    def _list_directory(self, directory_path: str) -> list[str]:
+        if self.file_system == FileSystem.GCS:
+            raise Exception("GCS File list not supported")
+        else:
+            return os.listdir(directory_path)
+
+    def _get_file_system(self) -> FileSystem:
+        if self.file_system_root_path.startswith("gs://"):
+            return FileSystem.GCS
+        else:
+            return FileSystem.LOCAL
+
+    def _validate_path_requirements(self):
+        if self.file_system == FileSystem.GCS:
+            # No current GCS validations are run
+            pass
+        else:
+            if not os.path.exists(self._get_connections_directory()):
+                os.makedirs(self._get_connections_directory())

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -112,7 +112,7 @@ class StateManager(object):
             with open(file_path, "w") as file:
                 file.write(data)
 
-    def _list_directory(self, directory_path: str) -> list[str]:
+    def _list_directory(self, directory_path: str) -> List[str]:
         if self.file_system == FileSystem.GCS:
             return self._list_gcs_directory(directory_path)
         else:

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -21,6 +21,7 @@ import enum
 import json
 import os
 from google.cloud import storage
+from typing import Dict, List
 
 from data_validation import consts
 
@@ -49,7 +50,7 @@ class StateManager(object):
         self.verbose = verbose
         self.setup()
 
-    def create_connection(self, name: str, config: dict[str]):
+    def create_connection(self, name: str, config: Dict[str, str]):
         """Create a connection file and store the given config as JSON.
 
         Args:
@@ -59,7 +60,7 @@ class StateManager(object):
         connection_path = self._get_connection_path(name)
         self._write_file(connection_path, json.dumps(config))
 
-    def get_connection_config(self, name: str) -> dict[str, str]:
+    def get_connection_config(self, name: str) -> Dict[str, str]:
         """Get a connection configuration from the expected file.
 
         Args:
@@ -72,7 +73,7 @@ class StateManager(object):
 
         return json.loads(conn_str)
 
-    def list_connections(self) -> list[str]:
+    def list_connections(self) -> List[str]:
         """Returns a list of the connection names that exist."""
         file_names = self._list_directory(self._get_connections_directory())
         return [
@@ -153,7 +154,7 @@ class StateManager(object):
         blob = self.gcs_bucket.blob(gcs_file_path)
         blob.upload_from_string(data)
 
-    def _list_gcs_directory(self, directory_path: str) -> list[str]:
+    def _list_gcs_directory(self, directory_path: str) -> List[str]:
         gcs_prefix = self._get_gcs_file_path(directory_path)
         blobs = [
             f.name.replace(gcs_prefix, "")

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -59,7 +59,7 @@ class StateManager(object):
         connection_path = self._get_connection_path(name)
         self._write_file(connection_path, json.dumps(config))
 
-    def get_connection_config(self, name: str) -> dict[str]:
+    def get_connection_config(self, name: str) -> dict[str, str]:
         """Get a connection configuration from the expected file.
 
         Args:

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -5,7 +5,15 @@ create these connections using the CLI.
 These connections will automatically be saved either to `~/.config/google-pso-data-validator/` or 
 a directory specified by the env variable `PSO_DV_CONFIG_HOME`.
 
-These commands can be used to create connections:
+## GCS Connection Management
+
+The connections can also be stored in GCS using `PSO_DV_CONFIG_HOME`.
+To do so simply add the GCS path to the environment.
+
+eg.
+`PSO_DV_CONFIG_HOME=gs://my-bucket/my/connections/path/`
+
+The following commands can be used to create connections:
 
 ## Command template to create a connection:
 ```

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ dependencies = [
     "google-cloud-bigquery==2.11.0",
     "google-cloud-bigquery-storage==2.3.0",
     "google-cloud-spanner==3.1.0",
+    "google-cloud-storage==1.42.2",
     "setuptools>=34.0.0",
     "jellyfish==0.8.2",
     "tabulate==0.8.9",

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -18,7 +18,9 @@ from data_validation import cli_tools, consts, data_validation
 from data_validation import __main__ as main
 
 
-BQ_CONN = {"source_type": "BigQuery", "project_id": os.environ["PROJECT_ID"]}
+PROJECT_ID = os.environ["PROJECT_ID"]
+os.environ[consts.ENV_DIRECTORY_VAR] = f"gs://{PROJECT_ID}/integration_tests/"
+BQ_CONN = {"source_type": "BigQuery", "project_id": PROJECT_ID}
 CONFIG_COUNT_VALID = {
     # BigQuery Specific Connection Name
     consts.CONFIG_SOURCE_CONN: BQ_CONN,
@@ -257,7 +259,7 @@ def test_cli_store_yaml_then_run():
     main.run_validations(run_config_args, config_managers)
 
     os.remove(yaml_file_path)
-    _remove_bq_conn()
+    # _remove_bq_conn()
 
 
 def test_cli_find_tables():
@@ -269,7 +271,7 @@ def test_cli_find_tables():
     assert isinstance(tables_json, str)
     assert STRING_MATCH_RESULT in tables_json
 
-    _remove_bq_conn()
+    # _remove_bq_conn()
 
 
 def _store_bq_conn():
@@ -278,6 +280,6 @@ def _store_bq_conn():
     main.run_connections(mock_args)
 
 
-def _remove_bq_conn():
-    file_path = cli_tools._get_connection_file(BQ_CONN_NAME)
-    os.remove(file_path)
+# def _remove_bq_conn():
+#     file_path = cli_tools._get_connection_file(BQ_CONN_NAME)
+#     os.remove(file_path)

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -20,6 +20,7 @@ import pytest
 
 from data_validation import cli_tools, consts, data_validation
 from data_validation import __main__ as main
+from data_validation import state_manager
 from third_party.ibis.ibis_cloud_spanner.tests import conftest
 
 
@@ -240,5 +241,6 @@ def _store_spanner_conn(spanner_connection_args):
 
 
 def _remove_spanner_conn():
-    file_path = cli_tools._get_connection_file(SPANNER_CONN_NAME)
+    mgr = state_manager.StateManager()
+    file_path = mgr._get_connection_path(SPANNER_CONN_NAME)
     os.remove(file_path)

--- a/tests/system/test_state_manager.py
+++ b/tests/system/test_state_manager.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from data_validation import state_manager
+
+
+GCS_STATE_PATH = "gs://pso-kokoro-resources/state/"
+TEST_CONN_NAME = "example"
+TEST_CONN = {
+    "source_type": "BigQuery",
+    "project_id": "my-project",
+}
+
+
+def test_get_gcs_file_path():
+    manager = state_manager.StateManager(GCS_STATE_PATH)
+    result_path = manager._get_gcs_file_path(
+      GCS_STATE_PATH + "file/path/name.json")
+
+    assert result_path == "state/file/path/name.json"
+
+
+def test_gcs_create_and_get_connection_config():
+    manager = state_manager.StateManager(GCS_STATE_PATH)
+    manager.create_connection(TEST_CONN_NAME, TEST_CONN)
+
+    config = manager.get_connection_config(TEST_CONN_NAME)
+    assert config == TEST_CONN

--- a/tests/system/test_state_manager.py
+++ b/tests/system/test_state_manager.py
@@ -25,8 +25,7 @@ TEST_CONN = {
 
 def test_get_gcs_file_path():
     manager = state_manager.StateManager(GCS_STATE_PATH)
-    result_path = manager._get_gcs_file_path(
-      GCS_STATE_PATH + "file/path/name.json")
+    result_path = manager._get_gcs_file_path(GCS_STATE_PATH + "file/path/name.json")
 
     assert result_path == "state/file/path/name.json"
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -60,6 +60,8 @@ GROUPED_COLUMN_CONFIG_A = {
 
 
 class MockIbisClient(object):
+    _source_type = "BigQuery"
+
     def table(self, table, database=None):
         return MockIbisTable()
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -120,21 +120,21 @@ def test_filters_property(module_under_test):
     ]
 
 
-def test_source_connection_property(module_under_test):
+def test_get_source_connection(module_under_test):
     """Test getting config copy."""
     config_manager = module_under_test.ConfigManager(
         SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
     )
-    source_connection = config_manager.source_connection
+    source_connection = config_manager.get_source_connection()
     assert source_connection == SAMPLE_CONFIG[consts.CONFIG_SOURCE_CONN]
 
 
-def test_target_connection_property(module_under_test):
+def test_get_target_connection(module_under_test):
     """Test getting config copy."""
     config_manager = module_under_test.ConfigManager(
         SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
     )
-    target_connection = config_manager.target_connection
+    target_connection = config_manager.get_target_connection()
     assert target_connection == SAMPLE_CONFIG[consts.CONFIG_TARGET_CONN]
 
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import pytest
+from unittest import mock
+
+from data_validation import state_manager
+
+
+TEST_CONN_NAME = "example"
+TEST_CONN = {
+    "source_type":"BigQuery",
+    "project_id": "my-project",
+}
+
+
+def test_create_and_get_connection_config(capsys, fs):
+    manager = state_manager.StateManager()
+    manager.create_connection(TEST_CONN_NAME, TEST_CONN)
+
+    config = manager.get_connection_config(TEST_CONN_NAME)
+    assert config == TEST_CONN
+
+
+def test_create_and_list_connection(capsys, fs):
+    manager = state_manager.StateManager()
+    manager.create_connection(TEST_CONN_NAME, TEST_CONN)
+
+    connections = manager.list_connections()
+    assert connections == [TEST_CONN_NAME]

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from data_validation import state_manager
 
 
@@ -36,3 +38,25 @@ def test_create_and_list_connection(capsys, fs):
 
     connections = manager.list_connections()
     assert connections == [TEST_CONN_NAME]
+
+
+def test_create_unknown_filepath(capsys, fs):
+    # Unknown file paths will be created by the state manager
+    files_directory = "create/this/path/"
+    manager = state_manager.StateManager(files_directory)
+    manager.create_connection(TEST_CONN_NAME, TEST_CONN)
+
+    connections = manager.list_connections()
+    assert connections == [TEST_CONN_NAME]
+
+    file_path = manager._get_connection_path(TEST_CONN_NAME)
+    expected_file_path = files_directory + f"{TEST_CONN_NAME}.connection.json"
+    assert file_path == expected_file_path
+
+
+def test_create_invalid_gcs_path_raises(fs):
+    # Unknown file paths will be created by the state manager
+    files_directory = "gs://!!bucket!!/this/path/"
+
+    with pytest.raises(ValueError, match=r"GCS Path Failure .*"):
+        state_manager.StateManager(files_directory)

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-import pytest
-from unittest import mock
-
 from data_validation import state_manager
 
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -21,7 +21,7 @@ from data_validation import state_manager
 
 TEST_CONN_NAME = "example"
 TEST_CONN = {
-    "source_type":"BigQuery",
+    "source_type": "BigQuery",
     "project_id": "my-project",
 }
 

--- a/tests/unit/test_validation_builder.py
+++ b/tests/unit/test_validation_builder.py
@@ -118,7 +118,7 @@ CALCULATED_MULTIPLE_TEST = [
 
 
 class MockIbisClient(object):
-    pass
+    _source_type = "BigQuery"
 
 
 @pytest.fixture


### PR DESCRIPTION
Adding a client to manage state (connections and configurations)

The client should transparently know which file system/source to use for the state.
Then have helper commands for any stateful operations we run, currently CRUD for connection management