### PR TITLE
bug: improve env vars management in tests to avoid errors

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -70,3 +70,10 @@ steps:
   - 'NOX_SESSION=integration_spanner'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
+- id: integration_state
+  name: 'gcr.io/pso-kokoro-resources/python-multi'
+  args: ['bash', './ci/build.sh']
+  env:
+  - 'NOX_SESSION=integration_state'
+  - 'PROJECT_ID=pso-kokoro-resources'
+  waitFor: ['-']

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -87,7 +87,7 @@ class StateManager(object):
         if self.file_system == FileSystem.LOCAL:
             return self.file_system_root_path
 
-        return os.path.join(self.file_system_root_path, "connections")
+        return os.path.join(self.file_system_root_path, "connections/")
 
     def _get_connection_path(self, name: str) -> str:
         """Returns the full path to a connection.

--- a/noxfile.py
+++ b/noxfile.py
@@ -175,7 +175,7 @@ def integration_bigquery(session):
     test_path = "tests/system/data_sources/test_bigquery.py"
     env_vars = {"PROJECT_ID": os.environ.get("PROJECT_ID", "pso-kokoro-resources")}
     for env_var in env_vars:
-      if not env_vars[env_var]:
+        if not env_vars[env_var]:
             raise Exception("Expected Env Var: %s" % env_var)
 
     session.run("pytest", test_path, env=env_vars, *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -195,3 +195,20 @@ def integration_spanner(session):
 
     session.run("pytest", "third_party/ibis/ibis_cloud_spanner/tests", *session.posargs)
     session.run("pytest", "tests/system/data_sources/test_spanner.py", *session.posargs)
+
+
+@nox.session(python=DEFAULT_PYTHON_VERSION, venv_backend="venv")
+def integration_state(session):
+    """Run StateManager integration tests.
+    Ensure the StateManager is running as expected.
+    """
+    _setup_session_requirements(session, extra_packages=[])
+
+    test_path = "tests/system/test_state_manager.py"
+    # env_vars = {"PSO_DV_CONFIG_HOME": os.environ.get("PSO_DV_CONFIG_HOME", "gs://pso-kokoro-resources/state/")}
+    # for env_var in env_vars:
+    #     if not env_vars[env_var]:
+    #         raise Exception("Expected Env Var: %s" % env_var)
+
+    # session.run("pytest", test_path, env=env_vars, *session.posargs)
+    session.run("pytest", test_path, *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,6 +60,7 @@ def unit(session):
         "--cov-config=.coveragerc",
         "--cov-report=term",
         os.path.join("tests", "unit"),
+        env={"PSO_DV_CONFIG_HOME": ""},
         *session.posargs,
     )
 
@@ -172,12 +173,12 @@ def integration_bigquery(session):
     _setup_session_requirements(session, extra_packages=[])
 
     test_path = "tests/system/data_sources/test_bigquery.py"
-    expected_env_vars = ["PROJECT_ID"]
-    for env_var in expected_env_vars:
-        if not os.environ.get(env_var, ""):
+    env_vars = {"PROJECT_ID": os.environ.get("PROJECT_ID", "pso-kokoro-resources")}
+    for env_var in env_vars:
+      if not env_vars[env_var]:
             raise Exception("Expected Env Var: %s" % env_var)
 
-    session.run("pytest", test_path, *session.posargs)
+    session.run("pytest", test_path, env=env_vars, *session.posargs)
 
 
 @nox.session(python=PYTHON_VERSIONS, venv_backend="venv")

--- a/tests/system/test_state_manager.py
+++ b/tests/system/test_state_manager.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from data_validation import state_manager
 
 
@@ -44,3 +46,10 @@ def test_list_connections():
     connections = manager.list_connections()
 
     assert set(connections) == expected
+
+def test_create_invalid_gcs_path_raises():
+    # Unknown file paths will be created by the state manager
+    files_directory = "gs://!!bucket!!/this/path/"
+
+    with pytest.raises(ValueError, match=r"GCS Path Failure .*"):
+        state_manager.StateManager(files_directory)

--- a/tests/system/test_state_manager.py
+++ b/tests/system/test_state_manager.py
@@ -36,3 +36,11 @@ def test_gcs_create_and_get_connection_config():
 
     config = manager.get_connection_config(TEST_CONN_NAME)
     assert config == TEST_CONN
+
+def test_list_connections():
+    manager = state_manager.StateManager(GCS_STATE_PATH)
+    expected = set(["example", "my_bq_conn"])
+
+    connections = manager.list_connections()
+
+    assert set(connections) == expected

--- a/tests/system/test_state_manager.py
+++ b/tests/system/test_state_manager.py
@@ -39,6 +39,7 @@ def test_gcs_create_and_get_connection_config():
     config = manager.get_connection_config(TEST_CONN_NAME)
     assert config == TEST_CONN
 
+
 def test_list_connections():
     manager = state_manager.StateManager(GCS_STATE_PATH)
     expected = set(["example", "my_bq_conn"])
@@ -46,6 +47,7 @@ def test_list_connections():
     connections = manager.list_connections()
 
     assert set(connections) == expected
+
 
 def test_create_invalid_gcs_path_raises():
     # Unknown file paths will be created by the state manager

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from data_validation import state_manager
 
 
@@ -52,11 +50,3 @@ def test_create_unknown_filepath(capsys, fs):
     file_path = manager._get_connection_path(TEST_CONN_NAME)
     expected_file_path = files_directory + f"{TEST_CONN_NAME}.connection.json"
     assert file_path == expected_file_path
-
-
-def test_create_invalid_gcs_path_raises(fs):
-    # Unknown file paths will be created by the state manager
-    files_directory = "gs://!!bucket!!/this/path/"
-
-    with pytest.raises(ValueError, match=r"GCS Path Failure .*"):
-        state_manager.StateManager(files_directory)


### PR DESCRIPTION
- Fixed path join bug causing connections not to list (and added testing to state manager)
- Force the PSO home env var to be empty at the start of tests (expected state, change the environ on a test by test basis if required)
- Supply default Project for BigQuery (since its the only integration thats easy to run locally)