### PR TITLE
Fix: Include StringIO into teradata ibis compiler.py

### DIFF
--- a/third_party/ibis/ibis_teradata/compiler.py
+++ b/third_party/ibis/ibis_teradata/compiler.py
@@ -1,5 +1,6 @@
 import datetime
 from functools import partial
+from io import StringIO
 
 import numpy as np
 import toolz


### PR DESCRIPTION
This small updated makes sure StringIO is included into compiler.py. Referencing issue #335 in which Teradata queries are breaking on V1.5.0