### PR TITLE
feat: GCS support for validation configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ case specific CLI arguments or editing the saved YAML configuration file.
 For example, the following command creates a YAML file for the validation of the
 `new_york_citibike` table: `data-validation validate column -sc my_bq_conn -tc
 my_bq_conn -tbls bigquery-public-data.new_york_citibike.citibike_trips -c
-citibike.yaml`
+citibike.yaml`. 
+
+The vaildation config file is saved to the GCS path specified by the `PSO_DV_CONFIG_HOME` env variable if that has been set; otherwise, it is saved to wherever the tool is run. 
 
 Here is the generated YAML file named `citibike.yaml`:
 
@@ -218,6 +220,8 @@ data-validation run-config -c citibike.yaml
 
 View the complete YAML file for a GroupedColumn validation on the
 [examples](docs/examples.md#) page.
+
+You can view a list of all saved validation YAML files using `data-validation run-config list`. 
 
 ### Aggregated Fields
 

--- a/README.md
+++ b/README.md
@@ -215,13 +215,13 @@ Once the file is updated and saved, the following command runs the new
 validation:
 
 ```
-data-validation run-config -c citibike.yaml
+data-validation configs run -c citibike.yaml
 ```
 
 View the complete YAML file for a GroupedColumn validation on the
 [examples](docs/examples.md#) page.
 
-You can view a list of all saved validation YAML files using `data-validation run-config list`. 
+You can view a list of all saved validation YAML files using `data-validation configs list`, and print a YAML config using `data-validation configs get -c citibike.yaml`. 
 
 ### Aggregated Fields
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -24,6 +24,9 @@ from data_validation import (
 from data_validation.config_manager import ConfigManager
 from data_validation.data_validation import DataValidation
 
+from yaml import dump
+import sys
+
 
 def _get_arg_config_file(args):
     """Return String yaml config file path."""
@@ -333,7 +336,7 @@ def run(args):
 
 
 def run_connections(args):
-    """ Run commands related to connection management."""
+    """Run commands related to connection management."""
     if args.connect_cmd == "list":
         cli_tools.list_connections()
     elif args.connect_cmd == "add":
@@ -345,17 +348,29 @@ def run_connections(args):
         raise ValueError(f"Connections Argument '{args.connect_cmd}' is not supported")
 
 
-def run_validation_config(args):
-    """ Run commands related to validation config YAMLs."""
-    if args.run_config_cmd == "list":
-        cli_tools.list_validations()
-    else:
+def run_config(args):
+    """Run commands related to validation config YAMLs (legacy - superceded by run_validation_configs)."""
+    config_managers = build_config_managers_from_yaml(args)
+    run_validations(args, config_managers)
+
+
+def run_validation_configs(args):
+    """Run commands related to validation config YAMLs."""
+    if args.validation_config_cmd == "run":
         config_managers = build_config_managers_from_yaml(args)
         run_validations(args, config_managers)
+    elif args.validation_config_cmd == "list":
+        cli_tools.list_validations()
+    elif args.validation_config_cmd == "get":
+        # Get and print yaml file config.
+        yaml = cli_tools.get_validation(_get_arg_config_file(args))
+        dump(yaml, sys.stdout)
+    else:
+        raise ValueError(f"Configs argument '{args.validate_cmd}' is not supported")
 
 
 def validate(args):
-    """ Run commands related to data validation."""
+    """Run commands related to data validation."""
     if args.validate_cmd == "column" or args.validate_cmd == "schema":
         run(args)
     else:
@@ -371,7 +386,9 @@ def main():
     elif args.command == "connections":
         run_connections(args)
     elif args.command == "run-config":
-        run_validation_config(args)
+        run_config(args)
+    elif args.command == "configs":
+        run_validation_configs(args)
     elif args.command == "find-tables":
         print(find_tables_using_string_matching(args))
     elif args.command == "query":

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -48,30 +48,30 @@ def get_aggregate_config(args, config_manager):
     aggregate_configs = [config_manager.build_config_count_aggregate()]
 
     if args.count:
-        col_args = None if args.count == "*" else cli_tools.get_arg_list(
-            args.count)
+        col_args = None if args.count == "*" else cli_tools.get_arg_list(args.count)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "count", col_args, None)
+            "count", col_args, None
+        )
     if args.sum:
-        col_args = None if args.sum == "*" else cli_tools.get_arg_list(
-            args.sum)
+        col_args = None if args.sum == "*" else cli_tools.get_arg_list(args.sum)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "sum", col_args, consts.NUMERIC_DATA_TYPES)
+            "sum", col_args, consts.NUMERIC_DATA_TYPES
+        )
     if args.avg:
-        col_args = None if args.avg == "*" else cli_tools.get_arg_list(
-            args.avg)
+        col_args = None if args.avg == "*" else cli_tools.get_arg_list(args.avg)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "avg", col_args, consts.NUMERIC_DATA_TYPES)
+            "avg", col_args, consts.NUMERIC_DATA_TYPES
+        )
     if args.min:
-        col_args = None if args.min == "*" else cli_tools.get_arg_list(
-            args.min)
+        col_args = None if args.min == "*" else cli_tools.get_arg_list(args.min)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "min", col_args, consts.NUMERIC_DATA_TYPES)
+            "min", col_args, consts.NUMERIC_DATA_TYPES
+        )
     if args.max:
-        col_args = None if args.max == "*" else cli_tools.get_arg_list(
-            args.max)
+        col_args = None if args.max == "*" else cli_tools.get_arg_list(args.max)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "max", col_args, consts.NUMERIC_DATA_TYPES)
+            "max", col_args, consts.NUMERIC_DATA_TYPES
+        )
     return aggregate_configs
 
 
@@ -81,8 +81,7 @@ def build_config_from_args(args, config_manager):
     Args:
         config_manager (ConfigManager): Validation config manager instance.
     """
-    config_manager.append_aggregates(get_aggregate_config(
-        args, config_manager))
+    config_manager.append_aggregates(get_aggregate_config(args, config_manager))
     if args.primary_keys and not args.grouped_columns:
         raise ValueError(
             "Grouped columns must be specified for primary key level validation."
@@ -90,12 +89,13 @@ def build_config_from_args(args, config_manager):
     if args.grouped_columns:
         grouped_columns = cli_tools.get_arg_list(args.grouped_columns)
         config_manager.append_query_groups(
-            config_manager.build_config_grouped_columns(grouped_columns))
+            config_manager.build_config_grouped_columns(grouped_columns)
+        )
     if args.primary_keys:
-        primary_keys = cli_tools.get_arg_list(args.primary_keys,
-                                              default_value=[])
+        primary_keys = cli_tools.get_arg_list(args.primary_keys, default_value=[])
         config_manager.append_primary_keys(
-            config_manager.build_config_grouped_columns(primary_keys))
+            config_manager.build_config_grouped_columns(primary_keys)
+        )
 
     # TODO(GH#18): Add query filter config logic
 
@@ -114,10 +114,12 @@ def build_config_managers_from_args(args):
     result_handler_config = None
     if args.bq_result_handler:
         result_handler_config = cli_tools.get_result_handler(
-            args.bq_result_handler, args.service_account)
+            args.bq_result_handler, args.service_account
+        )
     elif args.result_handler_config:
         result_handler_config = cli_tools.get_result_handler(
-            args.result_handler_config, args.service_account)
+            args.result_handler_config, args.service_account
+        )
 
     # Schema validation will not accept filters, labels, or threshold as flags
     filter_config, labels, threshold = [], [], 0.0
@@ -129,17 +131,15 @@ def build_config_managers_from_args(args):
         labels = cli_tools.get_labels(args.labels)
 
     mgr = state_manager.StateManager()
-    source_client = clients.get_data_client(
-        mgr.get_connection_config(args.source_conn))
-    target_client = clients.get_data_client(
-        mgr.get_connection_config(args.target_conn))
+    source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
+    target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
 
     format = args.format if args.format else "table"
 
     is_filesystem = source_client._source_type == "FileSystem"
-    tables_list = cli_tools.get_tables_list(args.tables_list,
-                                            default_value=[],
-                                            is_filesystem=is_filesystem)
+    tables_list = cli_tools.get_tables_list(
+        args.tables_list, default_value=[], is_filesystem=is_filesystem
+    )
 
     for table_obj in tables_list:
         config_manager = ConfigManager.build_config_manager(
@@ -181,21 +181,17 @@ def build_config_managers_from_yaml(args):
     for config in yaml_configs[consts.YAML_VALIDATIONS]:
         config[consts.CONFIG_SOURCE_CONN] = source_conn
         config[consts.CONFIG_TARGET_CONN] = target_conn
-        config[consts.CONFIG_RESULT_HANDLER] = yaml_configs[
-            consts.YAML_RESULT_HANDLER]
-        config_manager = ConfigManager(config,
-                                       source_client,
-                                       target_client,
-                                       verbose=args.verbose)
+        config[consts.CONFIG_RESULT_HANDLER] = yaml_configs[consts.YAML_RESULT_HANDLER]
+        config_manager = ConfigManager(
+            config, source_client, target_client, verbose=args.verbose
+        )
 
         config_managers.append(config_manager)
 
     return config_managers
 
 
-def _compare_match_tables(source_table_map,
-                          target_table_map,
-                          score_cutoff=0.8):
+def _compare_match_tables(source_table_map, target_table_map, score_cutoff=0.8):
     """Return dict config object from matching tables."""
     # TODO(dhercher): evaluate if improved comparison and score cutoffs should be used.
     table_configs = []
@@ -203,19 +199,24 @@ def _compare_match_tables(source_table_map,
     target_keys = target_table_map.keys()
     for source_key in source_table_map:
         target_key = jellyfish_distance.extract_closest_match(
-            source_key, target_keys, score_cutoff=score_cutoff)
+            source_key, target_keys, score_cutoff=score_cutoff
+        )
         if target_key is None:
             continue
 
         table_config = {
-            consts.CONFIG_SCHEMA_NAME:
-            source_table_map[source_key][consts.CONFIG_SCHEMA_NAME],
-            consts.CONFIG_TABLE_NAME:
-            source_table_map[source_key][consts.CONFIG_TABLE_NAME],
-            consts.CONFIG_TARGET_SCHEMA_NAME:
-            target_table_map[target_key][consts.CONFIG_SCHEMA_NAME],
-            consts.CONFIG_TARGET_TABLE_NAME:
-            target_table_map[target_key][consts.CONFIG_TABLE_NAME],
+            consts.CONFIG_SCHEMA_NAME: source_table_map[source_key][
+                consts.CONFIG_SCHEMA_NAME
+            ],
+            consts.CONFIG_TABLE_NAME: source_table_map[source_key][
+                consts.CONFIG_TABLE_NAME
+            ],
+            consts.CONFIG_TARGET_SCHEMA_NAME: target_table_map[target_key][
+                consts.CONFIG_SCHEMA_NAME
+            ],
+            consts.CONFIG_TARGET_TABLE_NAME: target_table_map[target_key][
+                consts.CONFIG_TABLE_NAME
+            ],
         }
         table_configs.append(table_config)
 
@@ -225,8 +226,7 @@ def _compare_match_tables(source_table_map,
 def get_table_map(client, allowed_schemas=None):
     """Return dict with searchable keys for table matching."""
     table_map = {}
-    table_objs = clients.get_all_tables(client,
-                                        allowed_schemas=allowed_schemas)
+    table_objs = clients.get_all_tables(client, allowed_schemas=allowed_schemas)
     for table_obj in table_objs:
         table_key = ".".join([t for t in table_obj if t])
         table_map[table_key] = {
@@ -242,19 +242,16 @@ def find_tables_using_string_matching(args):
     score_cutoff = args.score_cutoff or 0.8
 
     mgr = state_manager.StateManager()
-    source_client = clients.get_data_client(
-        mgr.get_connection_config(args.source_conn))
-    target_client = clients.get_data_client(
-        mgr.get_connection_config(args.target_conn))
+    source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
+    target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
 
     allowed_schemas = cli_tools.get_arg_list(args.allowed_schemas)
-    source_table_map = get_table_map(source_client,
-                                     allowed_schemas=allowed_schemas)
+    source_table_map = get_table_map(source_client, allowed_schemas=allowed_schemas)
     target_table_map = get_table_map(target_client)
 
-    table_configs = _compare_match_tables(source_table_map,
-                                          target_table_map,
-                                          score_cutoff=score_cutoff)
+    table_configs = _compare_match_tables(
+        source_table_map, target_table_map, score_cutoff=score_cutoff
+    )
     return json.dumps(table_configs)
 
 
@@ -282,7 +279,8 @@ def convert_config_to_yaml(args, config_managers):
 
     for config_manager in config_managers:
         yaml_config[consts.YAML_VALIDATIONS].append(
-            config_manager.get_yaml_validation_block())
+            config_manager.get_yaml_validation_block()
+        )
     return yaml_config
 
 
@@ -344,8 +342,7 @@ def run_connections(args):
         _ = clients.get_data_client(conn)
         cli_tools.store_connection(args.connection_name, conn)
     else:
-        raise ValueError(
-            f"Connections Argument '{args.connect_cmd}' is not supported")
+        raise ValueError(f"Connections Argument '{args.connect_cmd}' is not supported")
 
 
 def run_validation_config(args):
@@ -362,8 +359,7 @@ def validate(args):
     if args.validate_cmd == "column" or args.validate_cmd == "schema":
         run(args)
     else:
-        raise ValueError(
-            f"Validation Argument '{args.validate_cmd}' is not supported")
+        raise ValueError(f"Validation Argument '{args.validate_cmd}' is not supported")
 
 
 def main():
@@ -383,8 +379,7 @@ def main():
     elif args.command == "validate":
         validate(args)
     else:
-        raise ValueError(
-            f"Positional Argument '{args.command}' is not supported")
+        raise ValueError(f"Positional Argument '{args.command}' is not supported")
 
 
 if __name__ == "__main__":

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 """The Data Validation CLI tool is intended to help to build and execute
 data validation runs with ease.
 
@@ -52,7 +50,6 @@ import uuid
 
 from data_validation import consts
 from data_validation import state_manager
-
 
 CONNECTION_SOURCE_FIELDS = {
     "BigQuery": [
@@ -122,7 +119,10 @@ CONNECTION_SOURCE_FIELDS = {
         ["host", "Desired Impala host"],
         ["port", "Desired Imapala port (10000 if not provided)"],
         ["database", "Desired Impala database (default if not provided)"],
-        ["auth_mechanism", "Desired Impala auth mechanism (PLAIN if not provided)"],
+        [
+            "auth_mechanism",
+            "Desired Impala auth mechanism (PLAIN if not provided)"
+        ],
         [
             "kerberos_service_name",
             "Desired Kerberos service name ('impala' if not provided)",
@@ -140,10 +140,12 @@ def get_parsed_args():
 def configure_arg_parser():
     """Extract Args for Run."""
     parser = argparse.ArgumentParser(
-        usage=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+        usage=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
+    parser.add_argument("--verbose",
+                        "-v",
+                        action="store_true",
+                        help="Verbose logging")
 
     # beta feature only available in run/validate command
     if "beta" in sys.argv:
@@ -171,17 +173,16 @@ def configure_arg_parser():
 def _configure_find_tables(subparsers):
     """Configure arguments for text search table matching."""
     find_tables_parser = subparsers.add_parser(
-        "find-tables", help="Build tables list using approx string matching"
-    )
-    find_tables_parser.add_argument(
-        "--source-conn", "-sc", help="Source connection name"
-    )
-    find_tables_parser.add_argument(
-        "--target-conn", "-tc", help="Target connection name"
-    )
-    find_tables_parser.add_argument(
-        "--allowed-schemas", "-as", help="List of source schemas to match."
-    )
+        "find-tables", help="Build tables list using approx string matching")
+    find_tables_parser.add_argument("--source-conn",
+                                    "-sc",
+                                    help="Source connection name")
+    find_tables_parser.add_argument("--target-conn",
+                                    "-tc",
+                                    help="Target connection name")
+    find_tables_parser.add_argument("--allowed-schemas",
+                                    "-as",
+                                    help="List of source schemas to match.")
     find_tables_parser.add_argument(
         "--score-cutoff",
         "-score",
@@ -193,8 +194,7 @@ def _configure_find_tables(subparsers):
 def _configure_raw_query(subparsers):
     """Configure arguments for text search table matching."""
     query_parser = subparsers.add_parser(
-        "query", help="Run an adhoc query against the supplied connection"
-    )
+        "query", help="Run an adhoc query against the supplied connection")
     query_parser.add_argument("--conn", "-c", help="Connection name to query")
     query_parser.add_argument("--query", "-q", help="Raw query to execute")
 
@@ -202,12 +202,17 @@ def _configure_raw_query(subparsers):
 def _configure_run_config_parser(subparsers):
     """ Configure arguments to run a data validation YAML config."""
     run_config_parser = subparsers.add_parser(
-        "run-config", help="Run validations stored in a YAML config file"
-    )
+        "run-config", help="Run validations stored in a YAML config file")
+    run_config_subparsers = run_config_parser.add_subparsers(
+        dest="run_config_cmd")
+    _ = run_config_subparsers.add_parser("list",
+                                         help="List your validation configs")
+
     run_config_parser.add_argument(
         "--config-file",
         "-c",
-        help="YAML Config File Path to be used for building or running validations.",
+        help=
+        "YAML Config File Path to be used for building or running validations.",
     )
 
 
@@ -217,45 +222,55 @@ def _configure_run_parser(subparsers):
     # subparsers = parser.add_subparsers(dest="command")
 
     run_parser = subparsers.add_parser(
-        "run", help="Run a validation and optionally store to config (deprecated)"
-    )
+        "run",
+        help="Run a validation and optionally store to config (deprecated)")
 
     run_parser.add_argument(
         "--type",
         "-t",
         help="Type of Data Validation (Column, GroupedColumn, Row, Schema)",
     )
-    run_parser.add_argument("--source-conn", "-sc", help="Source connection name")
-    run_parser.add_argument("--target-conn", "-tc", help="Target connection name")
+    run_parser.add_argument("--source-conn",
+                            "-sc",
+                            help="Source connection name")
+    run_parser.add_argument("--target-conn",
+                            "-tc",
+                            help="Target connection name")
     run_parser.add_argument(
         "--tables-list",
         "-tbls",
-        help="Comma separated tables list in the form 'schema.table=target_schema.target_table'",
+        help=
+        "Comma separated tables list in the form 'schema.table=target_schema.target_table'",
     )
     run_parser.add_argument(
         "--count",
         "-count",
-        help="Comma separated list of columns for count 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for count 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--sum",
         "-sum",
-        help="Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--avg",
         "-avg",
-        help="Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--min",
         "-min",
-        help="Comma separated list of columns for min 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for min 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--max",
         "-max",
-        help="Comma separated list of columns for max 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for max 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--grouped-columns",
@@ -267,19 +282,21 @@ def _configure_run_parser(subparsers):
         "-pk",
         help="Comma separated list of primary key columns 'col_a,col_b'",
     )
-    run_parser.add_argument(
-        "--result-handler-config", "-rc", help="Result handler config details"
-    )
-    run_parser.add_argument(
-        "--bq-result-handler", "-bqrh", help="BigQuery result handler config details"
-    )
+    run_parser.add_argument("--result-handler-config",
+                            "-rc",
+                            help="Result handler config details")
+    run_parser.add_argument("--bq-result-handler",
+                            "-bqrh",
+                            help="BigQuery result handler config details")
     run_parser.add_argument(
         "--config-file",
         "-c",
         help="Store the validation in the YAML Config File Path specified",
     )
     run_parser.add_argument(
-        "--labels", "-l", help="Key value pair labels for validation run",
+        "--labels",
+        "-l",
+        help="Key value pair labels for validation run",
     )
     run_parser.add_argument(
         "--service-account",
@@ -301,7 +318,8 @@ def _configure_run_parser(subparsers):
         "--format",
         "-fmt",
         default="table",
-        help="Set the format for printing command output, Supported formats are (text, csv, json, table). It defaults "
+        help=
+        "Set the format for printing command output, Supported formats are (text, csv, json, table). It defaults "
         "to table",
     )
 
@@ -309,15 +327,15 @@ def _configure_run_parser(subparsers):
 def _configure_connection_parser(subparsers):
     """ Configure the Parser for Connection Management. """
     connection_parser = subparsers.add_parser(
-        "connections", help="Manage & Store connections to your Databases"
-    )
+        "connections", help="Manage & Store connections to your Databases")
     connect_subparsers = connection_parser.add_subparsers(dest="connect_cmd")
     _ = connect_subparsers.add_parser("list", help="List your connections")
 
-    add_parser = connect_subparsers.add_parser("add", help="Store a new connection")
-    add_parser.add_argument(
-        "--connection-name", "-c", help="Name of connection used as reference"
-    )
+    add_parser = connect_subparsers.add_parser("add",
+                                               help="Store a new connection")
+    add_parser.add_argument("--connection-name",
+                            "-c",
+                            help="Name of connection used as reference")
     _configure_database_specific_parsers(add_parser)
 
 
@@ -326,14 +344,12 @@ def _configure_database_specific_parsers(parser):
     subparsers = parser.add_subparsers(dest="connect_type")
 
     raw_parser = subparsers.add_parser(
-        "Raw", help="Supply Raw JSON config for a connection"
-    )
+        "Raw", help="Supply Raw JSON config for a connection")
     raw_parser.add_argument("--json", "-j", help="Json string config")
 
     for database in CONNECTION_SOURCE_FIELDS:
         db_parser = subparsers.add_parser(
-            database, help=f"Store a {database} connection"
-        )
+            database, help=f"Store a {database} connection")
 
         for field_obj in CONNECTION_SOURCE_FIELDS[database]:
             arg_field = "--" + field_obj[0].replace("_", "-")
@@ -344,25 +360,24 @@ def _configure_database_specific_parsers(parser):
 def _configure_validate_parser(subparsers):
     """Configure arguments to run validations."""
     validate_parser = subparsers.add_parser(
-        "validate", help="Run a validation and optionally store to config"
-    )
+        "validate", help="Run a validation and optionally store to config")
 
     # Keep these in order to support data-validation run command for backwards-compatibility
-    validate_parser.add_argument("--type", "-t", help="Type of Data Validation")
-    validate_parser.add_argument(
-        "--result-handler-config", "-rc", help="Result handler config details"
-    )
+    validate_parser.add_argument("--type",
+                                 "-t",
+                                 help="Type of Data Validation")
+    validate_parser.add_argument("--result-handler-config",
+                                 "-rc",
+                                 help="Result handler config details")
 
     validate_subparsers = validate_parser.add_subparsers(dest="validate_cmd")
 
     column_parser = validate_subparsers.add_parser(
-        "column", help="Run a column validation"
-    )
+        "column", help="Run a column validation")
     _configure_column_parser(column_parser)
 
     schema_parser = validate_subparsers.add_parser(
-        "schema", help="Run a schema validation"
-    )
+        "schema", help="Run a schema validation")
     _configure_schema_parser(schema_parser)
 
 
@@ -372,27 +387,32 @@ def _configure_column_parser(column_parser):
     column_parser.add_argument(
         "--count",
         "-count",
-        help="Comma separated list of columns for count 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for count 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--sum",
         "-sum",
-        help="Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--avg",
         "-avg",
-        help="Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--min",
         "-min",
-        help="Comma separated list of columns for min 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for min 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--max",
         "-max",
-        help="Comma separated list of columns for max 'col_a,col_b' or * for all columns",
+        help=
+        "Comma separated list of columns for max 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--grouped-columns",
@@ -404,9 +424,9 @@ def _configure_column_parser(column_parser):
         "-pk",
         help="Comma separated list of primary key columns 'col_a,col_b'",
     )
-    column_parser.add_argument(
-        "--labels", "-l", help="Key value pair labels for validation run"
-    )
+    column_parser.add_argument("--labels",
+                               "-l",
+                               help="Key value pair labels for validation run")
     column_parser.add_argument(
         "--threshold",
         "-th",
@@ -431,11 +451,12 @@ def _add_common_arguments(parser):
     parser.add_argument(
         "--tables-list",
         "-tbls",
-        help="Comma separated tables list in the form 'schema.table=target_schema.target_table'",
+        help=
+        "Comma separated tables list in the form 'schema.table=target_schema.target_table'",
     )
-    parser.add_argument(
-        "--bq-result-handler", "-bqrh", help="BigQuery result handler config details"
-    )
+    parser.add_argument("--bq-result-handler",
+                        "-bqrh",
+                        help="BigQuery result handler config details")
     parser.add_argument(
         "--service-account",
         "-sa",
@@ -450,7 +471,8 @@ def _add_common_arguments(parser):
         "--format",
         "-fmt",
         default="table",
-        help="Set the format for printing command output, Supported formats are (text, csv, json, table). Defaults "
+        help=
+        "Set the format for printing command output, Supported formats are (text, csv, json, table). Defaults "
         "to table",
     )
 
@@ -474,14 +496,14 @@ def threshold_float(x):
     try:
         x = float(x)
     except ValueError:
-        raise argparse.ArgumentTypeError("%r not a floating-point literal" % (x,))
+        raise argparse.ArgumentTypeError("%r not a floating-point literal" %
+                                         (x, ))
 
     if x < 0.0 or x > sys.float_info.max:
         raise argparse.ArgumentTypeError(
-            "%r must be positive and below the max float value" % (x,)
-        )
+            "%r must be positive and below the max float value" % (x, ))
     elif x != x:
-        raise argparse.ArgumentTypeError("%r must be a number" % (x,))
+        raise argparse.ArgumentTypeError("%r must be a number" % (x, ))
     return x
 
 
@@ -493,7 +515,6 @@ def threshold_float(x):
 #     if not os.path.exists(dir_path):
 #         os.makedirs(dir_path)
 #     return dir_path
-
 
 # def _get_connection_file(connection_name):
 #     dir_path = _get_data_validation_directory()
@@ -517,7 +538,6 @@ def store_connection(connection_name, conn):
 
 #     with open(file_path, "w") as file:
 #         file.write(json.dumps(conn))
-
 
 # def get_connections():
 #     """ Return dict with connection name and path key pairs."""
@@ -555,6 +575,27 @@ def get_connection(connection_name):
 #     return json.loads(conn_str)
 
 
+def store_validation(validation_file_name, yaml_config):
+    """ Store the validation YAML config under the given name."""
+    mgr = state_manager.StateManager()
+    mgr.create_validation_yaml(validation_file_name, yaml_config)
+
+
+def get_validation(validation_name):
+    """ Return validation YAML for a specific connection."""
+    mgr = state_manager.StateManager()
+    return mgr.get_validation_config(validation_name)
+
+
+def list_validations():
+    """ List all saved validation YAMLs."""
+    mgr = state_manager.StateManager()
+    validations = mgr.list_validations()
+
+    for validation_name in validations:
+        print(f"Validation YAML name: {validation_name}")
+
+
 def get_labels(arg_labels):
     """ Return list of tuples representing key-value label pairs. """
     labels = []
@@ -565,7 +606,8 @@ def get_labels(arg_labels):
             if len(kv) == 2:
                 labels.append((kv[0], kv[1]))
             else:
-                raise ValueError("Labels must be comma-separated key-value pairs.")
+                raise ValueError(
+                    "Labels must be comma-separated key-value pairs.")
     return labels
 
 
@@ -616,7 +658,8 @@ def get_result_handler(rc_value, sa_file=None):
                 "table_id": config[1],
             }
         else:
-            raise ValueError(f"Unable to parse result handler config: `{rc_value}`")
+            raise ValueError(
+                f"Unable to parse result handler config: `{rc_value}`")
 
         if sa_file:
             result_handler["google_service_account_key_path"] = sa_file
@@ -662,25 +705,22 @@ def get_tables_list(arg_tables, default_value=None, is_filesystem=False):
             tables_map = mapping.split("=")
             if len(tables_map) == 1:
                 schema, table = split_table(
-                    tables_map, schema_required=source_schema_required
-                )
+                    tables_map, schema_required=source_schema_required)
                 table_dict = {
                     "schema_name": schema,
                     "table_name": table,
                 }
             elif len(tables_map) == 2:
                 src_schema, src_table = split_table(
-                    [tables_map[0]], schema_required=source_schema_required
-                )
+                    [tables_map[0]], schema_required=source_schema_required)
 
                 table_dict = {
                     "schema_name": src_schema,
                     "table_name": src_table,
                 }
 
-                targ_schema, targ_table = split_table(
-                    [tables_map[1]], schema_required=False
-                )
+                targ_schema, targ_table = split_table([tables_map[1]],
+                                                      schema_required=False)
 
                 if targ_schema:
                     table_dict["target_schema_name"] = targ_schema
@@ -703,7 +743,8 @@ def split_table(table_ref, schema_required=True):
     scehma_required (boolean): Indicates whether schema is required. A source
     table reference requires schema. A target table reference does not.
     """
-    table_ref_list = list(csv.reader(table_ref, delimiter=".", quotechar='"'))[0]
+    table_ref_list = list(csv.reader(table_ref, delimiter=".",
+                                     quotechar='"'))[0]
 
     if len(table_ref_list) == 1 and schema_required:
         raise ValueError("Please provide schema in tables list.")

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -119,10 +119,7 @@ CONNECTION_SOURCE_FIELDS = {
         ["host", "Desired Impala host"],
         ["port", "Desired Imapala port (10000 if not provided)"],
         ["database", "Desired Impala database (default if not provided)"],
-        [
-            "auth_mechanism",
-            "Desired Impala auth mechanism (PLAIN if not provided)"
-        ],
+        ["auth_mechanism", "Desired Impala auth mechanism (PLAIN if not provided)"],
         [
             "kerberos_service_name",
             "Desired Kerberos service name ('impala' if not provided)",
@@ -140,12 +137,10 @@ def get_parsed_args():
 def configure_arg_parser():
     """Extract Args for Run."""
     parser = argparse.ArgumentParser(
-        usage=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+        usage=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
 
-    parser.add_argument("--verbose",
-                        "-v",
-                        action="store_true",
-                        help="Verbose logging")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
     # beta feature only available in run/validate command
     if "beta" in sys.argv:
@@ -173,16 +168,17 @@ def configure_arg_parser():
 def _configure_find_tables(subparsers):
     """Configure arguments for text search table matching."""
     find_tables_parser = subparsers.add_parser(
-        "find-tables", help="Build tables list using approx string matching")
-    find_tables_parser.add_argument("--source-conn",
-                                    "-sc",
-                                    help="Source connection name")
-    find_tables_parser.add_argument("--target-conn",
-                                    "-tc",
-                                    help="Target connection name")
-    find_tables_parser.add_argument("--allowed-schemas",
-                                    "-as",
-                                    help="List of source schemas to match.")
+        "find-tables", help="Build tables list using approx string matching"
+    )
+    find_tables_parser.add_argument(
+        "--source-conn", "-sc", help="Source connection name"
+    )
+    find_tables_parser.add_argument(
+        "--target-conn", "-tc", help="Target connection name"
+    )
+    find_tables_parser.add_argument(
+        "--allowed-schemas", "-as", help="List of source schemas to match."
+    )
     find_tables_parser.add_argument(
         "--score-cutoff",
         "-score",
@@ -194,7 +190,8 @@ def _configure_find_tables(subparsers):
 def _configure_raw_query(subparsers):
     """Configure arguments for text search table matching."""
     query_parser = subparsers.add_parser(
-        "query", help="Run an adhoc query against the supplied connection")
+        "query", help="Run an adhoc query against the supplied connection"
+    )
     query_parser.add_argument("--conn", "-c", help="Connection name to query")
     query_parser.add_argument("--query", "-q", help="Raw query to execute")
 
@@ -202,17 +199,15 @@ def _configure_raw_query(subparsers):
 def _configure_run_config_parser(subparsers):
     """ Configure arguments to run a data validation YAML config."""
     run_config_parser = subparsers.add_parser(
-        "run-config", help="Run validations stored in a YAML config file")
-    run_config_subparsers = run_config_parser.add_subparsers(
-        dest="run_config_cmd")
-    _ = run_config_subparsers.add_parser("list",
-                                         help="List your validation configs")
+        "run-config", help="Run validations stored in a YAML config file"
+    )
+    run_config_subparsers = run_config_parser.add_subparsers(dest="run_config_cmd")
+    _ = run_config_subparsers.add_parser("list", help="List your validation configs")
 
     run_config_parser.add_argument(
         "--config-file",
         "-c",
-        help=
-        "YAML Config File Path to be used for building or running validations.",
+        help="YAML Config File Path to be used for building or running validations.",
     )
 
 
@@ -222,55 +217,45 @@ def _configure_run_parser(subparsers):
     # subparsers = parser.add_subparsers(dest="command")
 
     run_parser = subparsers.add_parser(
-        "run",
-        help="Run a validation and optionally store to config (deprecated)")
+        "run", help="Run a validation and optionally store to config (deprecated)"
+    )
 
     run_parser.add_argument(
         "--type",
         "-t",
         help="Type of Data Validation (Column, GroupedColumn, Row, Schema)",
     )
-    run_parser.add_argument("--source-conn",
-                            "-sc",
-                            help="Source connection name")
-    run_parser.add_argument("--target-conn",
-                            "-tc",
-                            help="Target connection name")
+    run_parser.add_argument("--source-conn", "-sc", help="Source connection name")
+    run_parser.add_argument("--target-conn", "-tc", help="Target connection name")
     run_parser.add_argument(
         "--tables-list",
         "-tbls",
-        help=
-        "Comma separated tables list in the form 'schema.table=target_schema.target_table'",
+        help="Comma separated tables list in the form 'schema.table=target_schema.target_table'",
     )
     run_parser.add_argument(
         "--count",
         "-count",
-        help=
-        "Comma separated list of columns for count 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for count 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--sum",
         "-sum",
-        help=
-        "Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--avg",
         "-avg",
-        help=
-        "Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--min",
         "-min",
-        help=
-        "Comma separated list of columns for min 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for min 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--max",
         "-max",
-        help=
-        "Comma separated list of columns for max 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for max 'col_a,col_b' or * for all columns",
     )
     run_parser.add_argument(
         "--grouped-columns",
@@ -282,21 +267,19 @@ def _configure_run_parser(subparsers):
         "-pk",
         help="Comma separated list of primary key columns 'col_a,col_b'",
     )
-    run_parser.add_argument("--result-handler-config",
-                            "-rc",
-                            help="Result handler config details")
-    run_parser.add_argument("--bq-result-handler",
-                            "-bqrh",
-                            help="BigQuery result handler config details")
+    run_parser.add_argument(
+        "--result-handler-config", "-rc", help="Result handler config details"
+    )
+    run_parser.add_argument(
+        "--bq-result-handler", "-bqrh", help="BigQuery result handler config details"
+    )
     run_parser.add_argument(
         "--config-file",
         "-c",
         help="Store the validation in the YAML Config File Path specified",
     )
     run_parser.add_argument(
-        "--labels",
-        "-l",
-        help="Key value pair labels for validation run",
+        "--labels", "-l", help="Key value pair labels for validation run",
     )
     run_parser.add_argument(
         "--service-account",
@@ -318,8 +301,7 @@ def _configure_run_parser(subparsers):
         "--format",
         "-fmt",
         default="table",
-        help=
-        "Set the format for printing command output, Supported formats are (text, csv, json, table). It defaults "
+        help="Set the format for printing command output, Supported formats are (text, csv, json, table). It defaults "
         "to table",
     )
 
@@ -327,15 +309,15 @@ def _configure_run_parser(subparsers):
 def _configure_connection_parser(subparsers):
     """ Configure the Parser for Connection Management. """
     connection_parser = subparsers.add_parser(
-        "connections", help="Manage & Store connections to your Databases")
+        "connections", help="Manage & Store connections to your Databases"
+    )
     connect_subparsers = connection_parser.add_subparsers(dest="connect_cmd")
     _ = connect_subparsers.add_parser("list", help="List your connections")
 
-    add_parser = connect_subparsers.add_parser("add",
-                                               help="Store a new connection")
-    add_parser.add_argument("--connection-name",
-                            "-c",
-                            help="Name of connection used as reference")
+    add_parser = connect_subparsers.add_parser("add", help="Store a new connection")
+    add_parser.add_argument(
+        "--connection-name", "-c", help="Name of connection used as reference"
+    )
     _configure_database_specific_parsers(add_parser)
 
 
@@ -344,12 +326,14 @@ def _configure_database_specific_parsers(parser):
     subparsers = parser.add_subparsers(dest="connect_type")
 
     raw_parser = subparsers.add_parser(
-        "Raw", help="Supply Raw JSON config for a connection")
+        "Raw", help="Supply Raw JSON config for a connection"
+    )
     raw_parser.add_argument("--json", "-j", help="Json string config")
 
     for database in CONNECTION_SOURCE_FIELDS:
         db_parser = subparsers.add_parser(
-            database, help=f"Store a {database} connection")
+            database, help=f"Store a {database} connection"
+        )
 
         for field_obj in CONNECTION_SOURCE_FIELDS[database]:
             arg_field = "--" + field_obj[0].replace("_", "-")
@@ -360,24 +344,25 @@ def _configure_database_specific_parsers(parser):
 def _configure_validate_parser(subparsers):
     """Configure arguments to run validations."""
     validate_parser = subparsers.add_parser(
-        "validate", help="Run a validation and optionally store to config")
+        "validate", help="Run a validation and optionally store to config"
+    )
 
     # Keep these in order to support data-validation run command for backwards-compatibility
-    validate_parser.add_argument("--type",
-                                 "-t",
-                                 help="Type of Data Validation")
-    validate_parser.add_argument("--result-handler-config",
-                                 "-rc",
-                                 help="Result handler config details")
+    validate_parser.add_argument("--type", "-t", help="Type of Data Validation")
+    validate_parser.add_argument(
+        "--result-handler-config", "-rc", help="Result handler config details"
+    )
 
     validate_subparsers = validate_parser.add_subparsers(dest="validate_cmd")
 
     column_parser = validate_subparsers.add_parser(
-        "column", help="Run a column validation")
+        "column", help="Run a column validation"
+    )
     _configure_column_parser(column_parser)
 
     schema_parser = validate_subparsers.add_parser(
-        "schema", help="Run a schema validation")
+        "schema", help="Run a schema validation"
+    )
     _configure_schema_parser(schema_parser)
 
 
@@ -387,32 +372,27 @@ def _configure_column_parser(column_parser):
     column_parser.add_argument(
         "--count",
         "-count",
-        help=
-        "Comma separated list of columns for count 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for count 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--sum",
         "-sum",
-        help=
-        "Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for sum 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--avg",
         "-avg",
-        help=
-        "Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for avg 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--min",
         "-min",
-        help=
-        "Comma separated list of columns for min 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for min 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--max",
         "-max",
-        help=
-        "Comma separated list of columns for max 'col_a,col_b' or * for all columns",
+        help="Comma separated list of columns for max 'col_a,col_b' or * for all columns",
     )
     column_parser.add_argument(
         "--grouped-columns",
@@ -424,9 +404,9 @@ def _configure_column_parser(column_parser):
         "-pk",
         help="Comma separated list of primary key columns 'col_a,col_b'",
     )
-    column_parser.add_argument("--labels",
-                               "-l",
-                               help="Key value pair labels for validation run")
+    column_parser.add_argument(
+        "--labels", "-l", help="Key value pair labels for validation run"
+    )
     column_parser.add_argument(
         "--threshold",
         "-th",
@@ -451,12 +431,11 @@ def _add_common_arguments(parser):
     parser.add_argument(
         "--tables-list",
         "-tbls",
-        help=
-        "Comma separated tables list in the form 'schema.table=target_schema.target_table'",
+        help="Comma separated tables list in the form 'schema.table=target_schema.target_table'",
     )
-    parser.add_argument("--bq-result-handler",
-                        "-bqrh",
-                        help="BigQuery result handler config details")
+    parser.add_argument(
+        "--bq-result-handler", "-bqrh", help="BigQuery result handler config details"
+    )
     parser.add_argument(
         "--service-account",
         "-sa",
@@ -471,8 +450,7 @@ def _add_common_arguments(parser):
         "--format",
         "-fmt",
         default="table",
-        help=
-        "Set the format for printing command output, Supported formats are (text, csv, json, table). Defaults "
+        help="Set the format for printing command output, Supported formats are (text, csv, json, table). Defaults "
         "to table",
     )
 
@@ -496,14 +474,14 @@ def threshold_float(x):
     try:
         x = float(x)
     except ValueError:
-        raise argparse.ArgumentTypeError("%r not a floating-point literal" %
-                                         (x, ))
+        raise argparse.ArgumentTypeError("%r not a floating-point literal" % (x,))
 
     if x < 0.0 or x > sys.float_info.max:
         raise argparse.ArgumentTypeError(
-            "%r must be positive and below the max float value" % (x, ))
+            "%r must be positive and below the max float value" % (x,)
+        )
     elif x != x:
-        raise argparse.ArgumentTypeError("%r must be a number" % (x, ))
+        raise argparse.ArgumentTypeError("%r must be a number" % (x,))
     return x
 
 
@@ -606,8 +584,7 @@ def get_labels(arg_labels):
             if len(kv) == 2:
                 labels.append((kv[0], kv[1]))
             else:
-                raise ValueError(
-                    "Labels must be comma-separated key-value pairs.")
+                raise ValueError("Labels must be comma-separated key-value pairs.")
     return labels
 
 
@@ -658,8 +635,7 @@ def get_result_handler(rc_value, sa_file=None):
                 "table_id": config[1],
             }
         else:
-            raise ValueError(
-                f"Unable to parse result handler config: `{rc_value}`")
+            raise ValueError(f"Unable to parse result handler config: `{rc_value}`")
 
         if sa_file:
             result_handler["google_service_account_key_path"] = sa_file
@@ -705,22 +681,25 @@ def get_tables_list(arg_tables, default_value=None, is_filesystem=False):
             tables_map = mapping.split("=")
             if len(tables_map) == 1:
                 schema, table = split_table(
-                    tables_map, schema_required=source_schema_required)
+                    tables_map, schema_required=source_schema_required
+                )
                 table_dict = {
                     "schema_name": schema,
                     "table_name": table,
                 }
             elif len(tables_map) == 2:
                 src_schema, src_table = split_table(
-                    [tables_map[0]], schema_required=source_schema_required)
+                    [tables_map[0]], schema_required=source_schema_required
+                )
 
                 table_dict = {
                     "schema_name": src_schema,
                     "table_name": src_table,
                 }
 
-                targ_schema, targ_table = split_table([tables_map[1]],
-                                                      schema_required=False)
+                targ_schema, targ_table = split_table(
+                    [tables_map[1]], schema_required=False
+                )
 
                 if targ_schema:
                     table_dict["target_schema_name"] = targ_schema
@@ -743,8 +722,7 @@ def split_table(table_ref, schema_required=True):
     scehma_required (boolean): Indicates whether schema is required. A source
     table reference requires schema. A target table reference does not.
     """
-    table_ref_list = list(csv.reader(table_ref, delimiter=".",
-                                     quotechar='"'))[0]
+    table_ref_list = list(csv.reader(table_ref, delimiter=".", quotechar='"'))[0]
 
     if len(table_ref_list) == 1 and schema_required:
         raise ValueError("Please provide schema in tables list.")

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -129,7 +129,7 @@ CONNECTION_SOURCE_FIELDS = {
 
 
 def get_parsed_args():
-    """ Return ArgParser with configured CLI arguments."""
+    """Return ArgParser with configured CLI arguments."""
     parser = configure_arg_parser()
     return parser.parse_args()
 
@@ -157,6 +157,7 @@ def configure_arg_parser():
         subparsers = parser.add_subparsers(dest="command")
         _configure_validate_parser(subparsers)
         _configure_run_config_parser(subparsers)
+        _configure_validation_config_parser(subparsers)
         _configure_connection_parser(subparsers)
         _configure_find_tables(subparsers)
         _configure_raw_query(subparsers)
@@ -197,12 +198,11 @@ def _configure_raw_query(subparsers):
 
 
 def _configure_run_config_parser(subparsers):
-    """ Configure arguments to run a data validation YAML config."""
+    """Configure arguments to run a data validation YAML config using the legacy run-config command."""
     run_config_parser = subparsers.add_parser(
-        "run-config", help="Run validations stored in a YAML config file"
+        "run-config",
+        help="Run validations stored in a YAML config file. Note: the 'configs run' command is now the recommended approach",
     )
-    run_config_subparsers = run_config_parser.add_subparsers(dest="run_config_cmd")
-    _ = run_config_subparsers.add_parser("list", help="List your validation configs")
 
     run_config_parser.add_argument(
         "--config-file",
@@ -211,8 +211,36 @@ def _configure_run_config_parser(subparsers):
     )
 
 
+def _configure_validation_config_parser(subparsers):
+    """Configure arguments to run a data validation YAML config."""
+    validation_config_parser = subparsers.add_parser(
+        "configs", help="Run validations stored in a YAML config file"
+    )
+    configs_subparsers = validation_config_parser.add_subparsers(
+        dest="validation_config_cmd"
+    )
+    _ = configs_subparsers.add_parser("list", help="List your validation configs")
+    run_parser = configs_subparsers.add_parser(
+        "run", help="Run your validation configs"
+    )
+    run_parser.add_argument(
+        "--config-file",
+        "-c",
+        help="YAML Config File Path to be used for building or running validations.",
+    )
+
+    get_parser = configs_subparsers.add_parser(
+        "get", help="Get and print a validation config"
+    )
+    get_parser.add_argument(
+        "--config-file",
+        "-c",
+        help="YAML Config File Path to be used for building or running validations.",
+    )
+
+
 def _configure_run_parser(subparsers):
-    """ Configure arguments to run a data validation."""
+    """Configure arguments to run a data validation."""
 
     # subparsers = parser.add_subparsers(dest="command")
 
@@ -307,7 +335,7 @@ def _configure_run_parser(subparsers):
 
 
 def _configure_connection_parser(subparsers):
-    """ Configure the Parser for Connection Management. """
+    """Configure the Parser for Connection Management."""
     connection_parser = subparsers.add_parser(
         "connections", help="Manage & Store connections to your Databases"
     )
@@ -456,7 +484,7 @@ def _add_common_arguments(parser):
 
 
 def get_connection_config_from_args(args):
-    """ Return dict with connection config supplied."""
+    """Return dict with connection config supplied."""
     config = {consts.SOURCE_TYPE: args.connect_type}
 
     if args.connect_type == "Raw":
@@ -506,7 +534,7 @@ def _generate_random_name(conn):
 
 
 def store_connection(connection_name, conn):
-    """ Store the connection config under the given name."""
+    """Store the connection config under the given name."""
     mgr = state_manager.StateManager()
     mgr.create_connection(connection_name, conn)
 
@@ -534,7 +562,7 @@ def store_connection(connection_name, conn):
 
 
 def list_connections():
-    """ List all saved connections."""
+    """List all saved connections."""
     mgr = state_manager.StateManager()
     connections = mgr.list_connections()
 
@@ -543,7 +571,7 @@ def list_connections():
 
 
 def get_connection(connection_name):
-    """ Return dict connection details for a specific connection."""
+    """Return dict connection details for a specific connection."""
     mgr = state_manager.StateManager()
     return mgr.get_connection_config(connection_name)
 
@@ -554,28 +582,29 @@ def get_connection(connection_name):
 
 
 def store_validation(validation_file_name, yaml_config):
-    """ Store the validation YAML config under the given name."""
+    """Store the validation YAML config under the given name."""
     mgr = state_manager.StateManager()
     mgr.create_validation_yaml(validation_file_name, yaml_config)
 
 
 def get_validation(validation_name):
-    """ Return validation YAML for a specific connection."""
+    """Return validation YAML for a specific connection."""
     mgr = state_manager.StateManager()
     return mgr.get_validation_config(validation_name)
 
 
 def list_validations():
-    """ List all saved validation YAMLs."""
+    """List all saved validation YAMLs."""
     mgr = state_manager.StateManager()
     validations = mgr.list_validations()
 
+    print("Validation YAMLs found:")
     for validation_name in validations:
-        print(f"Validation YAML name: {validation_name}")
+        print(f"{validation_name}.yaml")
 
 
 def get_labels(arg_labels):
-    """ Return list of tuples representing key-value label pairs. """
+    """Return list of tuples representing key-value label pairs."""
     labels = []
     if arg_labels:
         pairs = arg_labels.split(",")
@@ -660,7 +689,7 @@ def get_arg_list(arg_value, default_value=None):
 
 
 def get_tables_list(arg_tables, default_value=None, is_filesystem=False):
-    """ Returns dictionary of tables. Backwards compatible for JSON input.
+    """Returns dictionary of tables. Backwards compatible for JSON input.
 
     arg_table (str): tables_list argument specified
     default_value (Any): A default value to supply when arg_value is empty.
@@ -716,7 +745,7 @@ def get_tables_list(arg_tables, default_value=None, is_filesystem=False):
 
 
 def split_table(table_ref, schema_required=True):
-    """ Returns schema and table name given list of input values.
+    """Returns schema and table name given list of input values.
 
     table_ref (List): Table reference i.e ['my.schema.my_table']
     scehma_required (boolean): Indicates whether schema is required. A source

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -34,9 +34,7 @@ class FileSystem(enum.Enum):
 
 
 class StateManager(object):
-    def __init__(self,
-                 file_system_root_path: str = None,
-                 verbose: bool = False):
+    def __init__(self, file_system_root_path: str = None, verbose: bool = False):
         """Initialize a StateManager which handles configuration
         and state management files.
 
@@ -44,9 +42,11 @@ class StateManager(object):
             file_system_root_path (String): A root file system path
                 eg. "gs://bucket/data-validation/" or "/path/to/files/"
         """
-        raw_dir_path = (file_system_root_path
-                        or os.environ.get(consts.ENV_DIRECTORY_VAR)
-                        or consts.DEFAULT_ENV_DIRECTORY)
+        raw_dir_path = (
+            file_system_root_path
+            or os.environ.get(consts.ENV_DIRECTORY_VAR)
+            or consts.DEFAULT_ENV_DIRECTORY
+        )
         self.file_system_root_path = os.path.expanduser(raw_dir_path)
         self.file_system = self._get_file_system()
         self.verbose = verbose
@@ -79,7 +79,8 @@ class StateManager(object):
         """Returns a list of the connection names that exist."""
         file_names = self._list_directory(self._get_connections_directory())
         return [
-            file_name.split(".")[0] for file_name in file_names
+            file_name.split(".")[0]
+            for file_name in file_names
             if file_name.endswith(".connection.json")
         ]
 
@@ -93,11 +94,12 @@ class StateManager(object):
     def _get_connection_path(self, name: str) -> str:
         """Returns the full path to a connection.
 
-      Args:
-          name: The name of the connection.
-      """
-        return os.path.join(self._get_connections_directory(),
-                            f"{name}.connection.json")
+        Args:
+            name: The name of the connection.
+        """
+        return os.path.join(
+            self._get_connections_directory(), f"{name}.connection.json"
+        )
 
     def create_validation_yaml(self, name: str, yaml_config: Dict[str, str]):
         """Create a validation file and store the given config as YAML.
@@ -109,7 +111,6 @@ class StateManager(object):
         validation_path = self._get_validation_path(name)
         yaml_config_str = dump(yaml_config, Dumper=Dumper)
         self._write_file(validation_path, yaml_config_str)
-        print(yaml_config)
 
     def get_validation_config(self, name: str) -> Dict[str, str]:
         """Get a validation configuration from the expected file.
@@ -120,13 +121,14 @@ class StateManager(object):
             A dict of the validation values from the file.
         """
         validation_path = self._get_validation_path(name)
-        validation_str = self._read_file(validation_path)
-        return load(validation_str, Loader=Loader)
+        validation_bytes = self._read_file(validation_path)
+        return load(validation_bytes, Loader=Loader)
 
     def list_validations(self):
         file_names = self._list_directory(self._get_validations_directory())
         return [
-            file_name.split(".")[0] for file_name in file_names
+            file_name.split(".")[0]
+            for file_name in file_names
             if file_name.endswith(".yaml")
         ]
 
@@ -186,8 +188,9 @@ class StateManager(object):
         try:
             self.gcs_bucket = self._get_gcs_bucket()
         except ValueError as e:
-            raise ValueError("GCS Path Failure {} -> {}".format(
-                self.file_system_root_path, e))
+            raise ValueError(
+                "GCS Path Failure {} -> {}".format(self.file_system_root_path, e)
+            )
 
     def _get_gcs_bucket(self):
         bucket_name = self.file_system_root_path[5:].split("/")[0]
@@ -200,7 +203,7 @@ class StateManager(object):
         gcs_file_path = self._get_gcs_file_path(file_path)
         blob = self.gcs_bucket.get_blob(gcs_file_path)
 
-        return blob.download_as_string()
+        return blob.download_as_bytes()
 
     def _write_gcs_file(self, file_path: str, data: str):
         gcs_file_path = self._get_gcs_file_path(file_path)
@@ -211,8 +214,7 @@ class StateManager(object):
         gcs_prefix = self._get_gcs_file_path(directory_path)
         blobs = [
             f.name.replace(gcs_prefix, "")
-            for f in self.gcs_bucket.list_blobs(prefix=gcs_prefix,
-                                                delimiter="/")
+            for f in self.gcs_bucket.list_blobs(prefix=gcs_prefix, delimiter="/")
             if f.name.replace(gcs_prefix, "")
         ]
 

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -99,7 +99,7 @@ class StateManager(object):
         return os.path.join(self._get_connections_directory(),
                             f"{name}.connection.json")
 
-    def create_validation_yaml(self, name: str, yaml_config: dict[str, str]):
+    def create_validation_yaml(self, name: str, yaml_config: Dict[str, str]):
         """Create a validation file and store the given config as YAML.
 
         Args:
@@ -111,7 +111,7 @@ class StateManager(object):
         self._write_file(validation_path, yaml_config_str)
         print(yaml_config)
 
-    def get_validation_config(self, name: str) -> dict[str, str]:
+    def get_validation_config(self, name: str) -> Dict[str, str]:
         """Get a validation configuration from the expected file.
 
         Args:

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -22,6 +22,7 @@ import json
 import os
 from google.cloud import storage
 from typing import Dict, List
+from yaml import dump, load, Dumper, Loader
 
 from data_validation import client_info
 from data_validation import consts
@@ -33,7 +34,9 @@ class FileSystem(enum.Enum):
 
 
 class StateManager(object):
-    def __init__(self, file_system_root_path: str = None, verbose: bool = False):
+    def __init__(self,
+                 file_system_root_path: str = None,
+                 verbose: bool = False):
         """Initialize a StateManager which handles configuration
         and state management files.
 
@@ -41,11 +44,9 @@ class StateManager(object):
             file_system_root_path (String): A root file system path
                 eg. "gs://bucket/data-validation/" or "/path/to/files/"
         """
-        raw_dir_path = (
-            file_system_root_path
-            or os.environ.get(consts.ENV_DIRECTORY_VAR)
-            or consts.DEFAULT_ENV_DIRECTORY
-        )
+        raw_dir_path = (file_system_root_path
+                        or os.environ.get(consts.ENV_DIRECTORY_VAR)
+                        or consts.DEFAULT_ENV_DIRECTORY)
         self.file_system_root_path = os.path.expanduser(raw_dir_path)
         self.file_system = self._get_file_system()
         self.verbose = verbose
@@ -78,8 +79,7 @@ class StateManager(object):
         """Returns a list of the connection names that exist."""
         file_names = self._list_directory(self._get_connections_directory())
         return [
-            file_name.split(".")[0]
-            for file_name in file_names
+            file_name.split(".")[0] for file_name in file_names
             if file_name.endswith(".connection.json")
         ]
 
@@ -96,9 +96,54 @@ class StateManager(object):
       Args:
           name: The name of the connection.
       """
-        return os.path.join(
-            self._get_connections_directory(), f"{name}.connection.json"
-        )
+        return os.path.join(self._get_connections_directory(),
+                            f"{name}.connection.json")
+
+    def create_validation_yaml(self, name: str, yaml_config: dict[str, str]):
+        """Create a validation file and store the given config as YAML.
+
+        Args:
+            name (String): The name of the validation.
+            yaml_config (Dict): A dictionary with the validation details.
+        """
+        validation_path = self._get_validation_path(name)
+        yaml_config_str = dump(yaml_config, Dumper=Dumper)
+        self._write_file(validation_path, yaml_config_str)
+        print(yaml_config)
+
+    def get_validation_config(self, name: str) -> dict[str, str]:
+        """Get a validation configuration from the expected file.
+
+        Args:
+            name: The name of the validation.
+        Returns:
+            A dict of the validation values from the file.
+        """
+        validation_path = self._get_validation_path(name)
+        validation_str = self._read_file(validation_path)
+        return load(validation_str, Loader=Loader)
+
+    def list_validations(self):
+        file_names = self._list_directory(self._get_validations_directory())
+        return [
+            file_name.split(".")[0] for file_name in file_names
+            if file_name.endswith(".yaml")
+        ]
+
+    def _get_validations_directory(self):
+        """Returns the validations directory path."""
+        if self.file_system == FileSystem.LOCAL:
+            # Validation configs should be written to tool root dir, not consts.DEFAULT_ENV_DIRECTORY as connections are
+            return "./"
+        return os.path.join(self.file_system_root_path, "validations/")
+
+    def _get_validation_path(self, name: str) -> str:
+        """Returns the full path to a validation.
+
+        Args:
+            name: The name of the validation.
+        """
+        return os.path.join(self._get_validations_directory(), f"{name}")
 
     def _read_file(self, file_path: str) -> str:
         if self.file_system == FileSystem.GCS:
@@ -112,6 +157,8 @@ class StateManager(object):
         else:
             with open(file_path, "w") as file:
                 file.write(data)
+
+        print("Success! Config output written to {}".format(file_path))
 
     def _list_directory(self, directory_path: str) -> List[str]:
         if self.file_system == FileSystem.GCS:
@@ -139,9 +186,8 @@ class StateManager(object):
         try:
             self.gcs_bucket = self._get_gcs_bucket()
         except ValueError as e:
-            raise ValueError(
-                "GCS Path Failure {} -> {}".format(self.file_system_root_path, e)
-            )
+            raise ValueError("GCS Path Failure {} -> {}".format(
+                self.file_system_root_path, e))
 
     def _get_gcs_bucket(self):
         bucket_name = self.file_system_root_path[5:].split("/")[0]
@@ -165,7 +211,8 @@ class StateManager(object):
         gcs_prefix = self._get_gcs_file_path(directory_path)
         blobs = [
             f.name.replace(gcs_prefix, "")
-            for f in self.gcs_bucket.list_blobs(prefix=gcs_prefix, delimiter="/")
+            for f in self.gcs_bucket.list_blobs(prefix=gcs_prefix,
+                                                delimiter="/")
             if f.name.replace(gcs_prefix, "")
         ]
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -8,7 +8,7 @@ a directory specified by the env variable `PSO_DV_CONFIG_HOME`.
 ## GCS Connection Management (recommended)
 
 The connections can also be stored in GCS using `PSO_DV_CONFIG_HOME`.
-To do so simply add the GCS path to the environment.
+To do so simply add the GCS path to the environment. Note that if this path is set, query validation configs will also be saved here.
 
 eg.
 `export PSO_DV_CONFIG_HOME=gs://my-bucket/my/connections/path/`

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -17,19 +17,23 @@ import os
 from data_validation import cli_tools, consts, data_validation
 from data_validation import __main__ as main
 
-
 PROJECT_ID = os.environ["PROJECT_ID"]
 os.environ[consts.ENV_DIRECTORY_VAR] = f"gs://{PROJECT_ID}/integration_tests/"
 BQ_CONN = {"source_type": "BigQuery", "project_id": PROJECT_ID}
 CONFIG_COUNT_VALID = {
     # BigQuery Specific Connection Name
-    consts.CONFIG_SOURCE_CONN: BQ_CONN,
-    consts.CONFIG_TARGET_CONN: BQ_CONN,
+    consts.CONFIG_SOURCE_CONN:
+    BQ_CONN,
+    consts.CONFIG_TARGET_CONN:
+    BQ_CONN,
     # Validation Type
-    consts.CONFIG_TYPE: "Column",
+    consts.CONFIG_TYPE:
+    "Column",
     # Configuration Required Depending on Validator Type
-    consts.CONFIG_SCHEMA_NAME: "bigquery-public-data.new_york_citibike",
-    consts.CONFIG_TABLE_NAME: "citibike_trips",
+    consts.CONFIG_SCHEMA_NAME:
+    "bigquery-public-data.new_york_citibike",
+    consts.CONFIG_TABLE_NAME:
+    "citibike_trips",
     consts.CONFIG_GROUPED_COLUMNS: [],
     consts.CONFIG_AGGREGATES: [
         {
@@ -63,18 +67,24 @@ CONFIG_COUNT_VALID = {
             consts.CONFIG_FIELD_ALIAS: "min_birth_year",
         },
     ],
-    consts.CONFIG_FORMAT: "table",
+    consts.CONFIG_FORMAT:
+    "table",
 }
 
 CONFIG_GROUPED_COUNT_VALID = {
     # BigQuery Specific Connection Config
-    consts.CONFIG_SOURCE_CONN: BQ_CONN,
-    consts.CONFIG_TARGET_CONN: BQ_CONN,
+    consts.CONFIG_SOURCE_CONN:
+    BQ_CONN,
+    consts.CONFIG_TARGET_CONN:
+    BQ_CONN,
     # Validation Type
-    consts.CONFIG_TYPE: "Column",
+    consts.CONFIG_TYPE:
+    "Column",
     # Configuration Required Depending on Validator Type
-    consts.CONFIG_SCHEMA_NAME: "bigquery-public-data.new_york_citibike",
-    consts.CONFIG_TABLE_NAME: "citibike_trips",
+    consts.CONFIG_SCHEMA_NAME:
+    "bigquery-public-data.new_york_citibike",
+    consts.CONFIG_TABLE_NAME:
+    "citibike_trips",
     consts.CONFIG_AGGREGATES: [
         {
             consts.CONFIG_TYPE: "count",
@@ -97,19 +107,25 @@ CONFIG_GROUPED_COUNT_VALID = {
             consts.CONFIG_CAST: "date",
         },
     ],
-    consts.CONFIG_FORMAT: "table",
+    consts.CONFIG_FORMAT:
+    "table",
 }
 
 # TODO: The definition for this table is stored in: ./tests/resources/
 CONFIG_NUMERIC_AGG_VALID = {
     # BigQuery Specific Connection Config
-    consts.CONFIG_SOURCE_CONN: BQ_CONN,
-    consts.CONFIG_TARGET_CONN: BQ_CONN,
+    consts.CONFIG_SOURCE_CONN:
+    BQ_CONN,
+    consts.CONFIG_TARGET_CONN:
+    BQ_CONN,
     # Validation Type
-    consts.CONFIG_TYPE: "Column",
+    consts.CONFIG_TYPE:
+    "Column",
     # Configuration Required Depending on Validator Type
-    consts.CONFIG_SCHEMA_NAME: "pso_data_validator",
-    consts.CONFIG_TABLE_NAME: "test_data_types",
+    consts.CONFIG_SCHEMA_NAME:
+    "pso_data_validator",
+    consts.CONFIG_TABLE_NAME:
+    "test_data_types",
     consts.CONFIG_AGGREGATES: [
         {
             consts.CONFIG_TYPE: "count",
@@ -131,7 +147,8 @@ CONFIG_NUMERIC_AGG_VALID = {
         },
     ],
     consts.CONFIG_GROUPED_COLUMNS: [],
-    consts.CONFIG_FORMAT: "table",
+    consts.CONFIG_FORMAT:
+    "table",
 }
 
 BQ_CONN_NAME = "bq-integration-test"
@@ -183,36 +200,34 @@ STRING_MATCH_RESULT = '{"schema_name": "pso_data_validator", "table_name": "resu
 
 
 def test_count_validator():
-    validator = data_validation.DataValidation(CONFIG_COUNT_VALID, verbose=True)
+    validator = data_validation.DataValidation(CONFIG_COUNT_VALID,
+                                               verbose=True)
     df = validator.execute()
 
-    count_value = df[df["validation_name"] == "count"]["source_agg_value"].values[0]
-    count_tripduration_value = df[df["validation_name"] == "count_tripduration"][
-        "source_agg_value"
-    ].values[0]
+    count_value = df[df["validation_name"] ==
+                     "count"]["source_agg_value"].values[0]
+    count_tripduration_value = df[
+        df["validation_name"] ==
+        "count_tripduration"]["source_agg_value"].values[0]
     avg_tripduration_value = df[df["validation_name"] == "avg_tripduration"][
-        "source_agg_value"
-    ].values[0]
-    max_birth_year_value = df[df["validation_name"] == "max_birth_year"][
-        "source_agg_value"
-    ].values[0]
-    min_birth_year_value = df[df["validation_name"] == "min_birth_year"][
-        "source_agg_value"
-    ].values[0]
+        "source_agg_value"].values[0]
+    max_birth_year_value = df[df["validation_name"] ==
+                              "max_birth_year"]["source_agg_value"].values[0]
+    min_birth_year_value = df[df["validation_name"] ==
+                              "min_birth_year"]["source_agg_value"].values[0]
 
     assert float(count_value) > 0
     assert float(count_tripduration_value) > 0
     assert float(avg_tripduration_value) > 0
     assert float(max_birth_year_value) > 0
     assert float(min_birth_year_value) > 0
-    assert (
-        df["source_agg_value"].astype(float).sum()
-        == df["target_agg_value"].astype(float).sum()
-    )
+    assert (df["source_agg_value"].astype(float).sum() ==
+            df["target_agg_value"].astype(float).sum())
 
 
 def test_grouped_count_validator():
-    validator = data_validation.DataValidation(CONFIG_GROUPED_COUNT_VALID, verbose=True)
+    validator = data_validation.DataValidation(CONFIG_GROUPED_COUNT_VALID,
+                                               verbose=True)
     df = validator.execute()
     rows = list(df[df["validation_name"] == "count"].iterrows())
 
@@ -228,13 +243,13 @@ def test_grouped_count_validator():
 
 
 def test_numeric_types():
-    validator = data_validation.DataValidation(CONFIG_NUMERIC_AGG_VALID, verbose=True)
+    validator = data_validation.DataValidation(CONFIG_NUMERIC_AGG_VALID,
+                                               verbose=True)
     df = validator.execute()
 
     for validation in df.to_dict(orient="records"):
         assert float(validation["source_agg_value"]) == float(
-            validation["target_agg_value"]
-        )
+            validation["target_agg_value"])
 
 
 def test_cli_store_yaml_then_run():
@@ -246,7 +261,9 @@ def test_cli_store_yaml_then_run():
     mock_args = parser.parse_args(CLI_STORE_COLUMN_ARGS)
     main.run(mock_args)
 
-    yaml_file_path = CLI_CONFIG_FILE
+    # Look for YAML file in GCS env directory, since that has been set
+    yaml_file_path = os.path.join(os.environ[consts.ENV_DIRECTORY_VAR],
+                                  "validations/", CLI_CONFIG_FILE)
     with open(yaml_file_path, "r") as yaml_file:
         # The number of lines is not significant, except that it represents
         # the exact file expected to be created.  Any change to this value

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -265,7 +265,6 @@ def test_cli_store_yaml_then_run_gcs():
     config_managers = main.build_config_managers_from_yaml(run_config_args)
     main.run_validations(run_config_args, config_managers)
 
-    os.remove(yaml_file_path)
     # _remove_bq_conn()
 
 

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -168,6 +168,7 @@ CLI_STORE_COLUMN_ARGS = [
 ]
 EXPECTED_NUM_YAML_LINES = 33  # Expected number of lines for validation config geenrated by CLI_STORE_COLUMN_ARGS
 CLI_RUN_CONFIG_ARGS = ["run-config", "--config-file", CLI_CONFIG_FILE]
+CLI_CONFIGS_RUN_ARGS = ["configs", "run", "--config-file", CLI_CONFIG_FILE]
 
 CLI_FIND_TABLES_ARGS = [
     "find-tables",
@@ -260,8 +261,13 @@ def test_cli_store_yaml_then_run_gcs():
     yaml_file_str = validation_bytes.decode("utf-8")
     assert len(yaml_file_str.splitlines()) == EXPECTED_NUM_YAML_LINES
 
-    # Run generated config
+    # Run generated config using 'run-config' command
     run_config_args = parser.parse_args(CLI_RUN_CONFIG_ARGS)
+    config_managers = main.build_config_managers_from_yaml(run_config_args)
+    main.run_validations(run_config_args, config_managers)
+
+    # Run generated config using 'configs run' command
+    run_config_args = parser.parse_args(CLI_CONFIGS_RUN_ARGS)
     config_managers = main.build_config_managers_from_yaml(run_config_args)
     main.run_validations(run_config_args, config_managers)
 
@@ -289,8 +295,13 @@ def test_cli_store_yaml_then_run_local():
         # is likely to be a breaking change and must be assessed.
         assert len(yaml_file.readlines()) == EXPECTED_NUM_YAML_LINES
 
-    # Run generated config
+    # Run generated config using 'run-config' command
     run_config_args = parser.parse_args(CLI_RUN_CONFIG_ARGS)
+    config_managers = main.build_config_managers_from_yaml(run_config_args)
+    main.run_validations(run_config_args, config_managers)
+
+    # Run generated config using 'configs run' command
+    run_config_args = parser.parse_args(CLI_CONFIGS_RUN_ARGS)
     config_managers = main.build_config_managers_from_yaml(run_config_args)
     main.run_validations(run_config_args, config_managers)
 

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -99,8 +99,7 @@ CLI_FIND_TABLES_ARGS = [
 
 
 @mock.patch(
-    "argparse.ArgumentParser.parse_args",
-    return_value=argparse.Namespace(**CLI_ARGS),
+    "argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**CLI_ARGS),
 )
 def test_get_parsed_args(mock_args):
     """Test arg parser values with validate command."""
@@ -234,8 +233,7 @@ def test_get_labels_err(test_input):
 
 
 @pytest.mark.parametrize(
-    "test_input,expected",
-    [(0, 0.0), (50, 50.0), (100, 100.0)],
+    "test_input,expected", [(0, 0.0), (50, 50.0), (100, 100.0)],
 )
 def test_threshold_float(test_input, expected):
     """Test threshold float function."""
@@ -244,8 +242,7 @@ def test_threshold_float(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input",
-    [(-4), (float("nan")), (float("inf")), ("string")],
+    "test_input", [(-4), (float("nan")), (float("inf")), ("string")],
 )
 def test_threshold_float_err(test_input):
     """Test that threshold float only accepts positive floats."""
@@ -398,8 +395,7 @@ def test_get_filters(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input",
-    [("source:"), ("invalid:filter:count")],
+    "test_input", [("source:"), ("invalid:filter:count")],
 )
 def test_get_filters_err(test_input):
     """Test get filters function returns error."""
@@ -429,12 +425,9 @@ def test_split_table_no_schema():
 
 
 @pytest.mark.parametrize(
-    "test_input",
-    [(["table"])],
+    "test_input", [(["table"])],
 )
-def test_split_table_err(
-    test_input,
-):
+def test_split_table_err(test_input,):
     """Test split table throws the right errors."""
     with pytest.raises(ValueError):
         cli_tools.split_table(test_input)

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -99,7 +99,8 @@ CLI_FIND_TABLES_ARGS = [
 
 
 @mock.patch(
-    "argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**CLI_ARGS),
+    "argparse.ArgumentParser.parse_args",
+    return_value=argparse.Namespace(**CLI_ARGS),
 )
 def test_get_parsed_args(mock_args):
     """Test arg parser values with validate command."""
@@ -159,13 +160,17 @@ def test_create_and_list_connections(capsys, fs):
     assert captured.out == "Connection Name: test\n"
 
 
-def test_configure_arg_parser_list_validation_configs():
+def test_configure_arg_parser_list_and_run_validation_configs():
     """Test configuring arg parse in different ways."""
     parser = cli_tools.configure_arg_parser()
-    args = parser.parse_args(["run-config", "list"])
 
-    assert args.command == "run-config"
-    assert args.run_config_cmd == "list"
+    args = parser.parse_args(["configs", "list"])
+    assert args.command == "configs"
+    assert args.validation_config_cmd == "list"
+
+    args = parser.parse_args(["configs", "run"])
+    assert args.command == "configs"
+    assert args.validation_config_cmd == "run"
 
 
 def test_create_and_list_and_get_validations(capsys, fs):
@@ -178,7 +183,7 @@ def test_create_and_list_and_get_validations(capsys, fs):
     cli_tools.list_validations()
     captured = capsys.readouterr()
 
-    assert captured.out == "Validation YAML name: example_validation\n"
+    assert captured.out == "Validation YAMLs found:\nexample_validation.yaml\n"
 
     # Retrive the stored vaildation config
     yaml_config = cli_tools.get_validation("example_validation.yaml")
@@ -223,13 +228,14 @@ def test_get_labels(test_input, expected):
     ],
 )
 def test_get_labels_err(test_input):
-    """Ensure that Value Error is raised when incorrect label argument is provided. """
+    """Ensure that Value Error is raised when incorrect label argument is provided."""
     with pytest.raises(ValueError):
         cli_tools.get_labels(test_input)
 
 
 @pytest.mark.parametrize(
-    "test_input,expected", [(0, 0.0), (50, 50.0), (100, 100.0)],
+    "test_input,expected",
+    [(0, 0.0), (50, 50.0), (100, 100.0)],
 )
 def test_threshold_float(test_input, expected):
     """Test threshold float function."""
@@ -238,7 +244,8 @@ def test_threshold_float(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input", [(-4), (float("nan")), (float("inf")), ("string")],
+    "test_input",
+    [(-4), (float("nan")), (float("inf")), ("string")],
 )
 def test_threshold_float_err(test_input):
     """Test that threshold float only accepts positive floats."""
@@ -385,16 +392,17 @@ def test_get_result_handler(test_input, expected):
     ],
 )
 def test_get_filters(test_input, expected):
-    """ Test get filters from file function. """
+    """Test get filters from file function."""
     res = cli_tools.get_filters(test_input)
     assert res == expected
 
 
 @pytest.mark.parametrize(
-    "test_input", [("source:"), ("invalid:filter:count")],
+    "test_input",
+    [("source:"), ("invalid:filter:count")],
 )
 def test_get_filters_err(test_input):
-    """ Test get filters function returns error. """
+    """Test get filters function returns error."""
     with pytest.raises(ValueError):
         cli_tools.get_filters(test_input)
 
@@ -421,9 +429,12 @@ def test_split_table_no_schema():
 
 
 @pytest.mark.parametrize(
-    "test_input", [(["table"])],
+    "test_input",
+    [(["table"])],
 )
-def test_split_table_err(test_input,):
+def test_split_table_err(
+    test_input,
+):
     """Test split table throws the right errors."""
     with pytest.raises(ValueError):
         cli_tools.split_table(test_input)

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -59,35 +59,30 @@ CLI_ADD_CONNECTION_ARGS = [
 ]
 
 TEST_VALIDATION_CONFIG = {
-    'source':
-    'example',
-    'target':
-    'example',
-    'result_handler': {},
-    'validations': [{
-        'type':
-        'Column',
-        'table_name':
-        'citibike_trips',
-        'schema_name':
-        'bigquery-public-data.new_york_citibike',
-        'target_schema_name':
-        'bigquery-public-data.new_york_citibike',
-        'target_table_name':
-        'citibike_trips',
-        'labels': [],
-        'threshold':
-        0.0,
-        'format':
-        'table',
-        'filters': [],
-        'aggregates': [{
-            'source_column': None,
-            'target_column': None,
-            'field_alias': 'count',
-            'type': 'count'
-        }]
-    }]
+    "source": "example",
+    "target": "example",
+    "result_handler": {},
+    "validations": [
+        {
+            "type": "Column",
+            "table_name": "citibike_trips",
+            "schema_name": "bigquery-public-data.new_york_citibike",
+            "target_schema_name": "bigquery-public-data.new_york_citibike",
+            "target_table_name": "citibike_trips",
+            "labels": [],
+            "threshold": 0.0,
+            "format": "table",
+            "filters": [],
+            "aggregates": [
+                {
+                    "source_column": None,
+                    "target_column": None,
+                    "field_alias": "count",
+                    "type": "count",
+                }
+            ],
+        }
+    ],
 }
 
 WRITE_SUCCESS_STRING = "Success! Config output written to"
@@ -104,8 +99,7 @@ CLI_FIND_TABLES_ARGS = [
 
 
 @mock.patch(
-    "argparse.ArgumentParser.parse_args",
-    return_value=argparse.Namespace(**CLI_ARGS),
+    "argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**CLI_ARGS),
 )
 def test_get_parsed_args(mock_args):
     """Test arg parser values with validate command."""
@@ -176,8 +170,7 @@ def test_configure_arg_parser_list_validation_configs():
 
 def test_create_and_list_and_get_validations(capsys, fs):
     # Create validation config file
-    cli_tools.store_validation("example_validation.yaml",
-                               TEST_VALIDATION_CONFIG)
+    cli_tools.store_validation("example_validation.yaml", TEST_VALIDATION_CONFIG)
     captured = capsys.readouterr()
     assert WRITE_SUCCESS_STRING in captured.out
 
@@ -236,8 +229,7 @@ def test_get_labels_err(test_input):
 
 
 @pytest.mark.parametrize(
-    "test_input,expected",
-    [(0, 0.0), (50, 50.0), (100, 100.0)],
+    "test_input,expected", [(0, 0.0), (50, 50.0), (100, 100.0)],
 )
 def test_threshold_float(test_input, expected):
     """Test threshold float function."""
@@ -246,8 +238,7 @@ def test_threshold_float(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input",
-    [(-4), (float("nan")), (float("inf")), ("string")],
+    "test_input", [(-4), (float("nan")), (float("inf")), ("string")],
 )
 def test_threshold_float_err(test_input):
     """Test that threshold float only accepts positive floats."""
@@ -260,68 +251,69 @@ def test_threshold_float_err(test_input):
     [
         (
             "src.schema.src_table=targ.schema.targ_table",
-            [{
-                "schema_name": "src.schema",
-                "table_name": "src_table",
-                "target_schema_name": "targ.schema",
-                "target_table_name": "targ_table",
-            }],
+            [
+                {
+                    "schema_name": "src.schema",
+                    "table_name": "src_table",
+                    "target_schema_name": "targ.schema",
+                    "target_table_name": "targ_table",
+                }
+            ],
         ),
         (
             'src_schema."odd.table"=targ_schema.targ_table',
-            [{
-                "schema_name": "src_schema",
-                "table_name": "odd.table",
-                "target_schema_name": "targ_schema",
-                "target_table_name": "targ_table",
-            }],
+            [
+                {
+                    "schema_name": "src_schema",
+                    "table_name": "odd.table",
+                    "target_schema_name": "targ_schema",
+                    "target_table_name": "targ_table",
+                }
+            ],
         ),
         (
             "src_schema.src_table = targ_schema. targ_table",
-            [{
-                "schema_name": "src_schema",
-                "table_name": "src_table",
-                "target_schema_name": "targ_schema",
-                "target_table_name": "targ_table",
-            }],
+            [
+                {
+                    "schema_name": "src_schema",
+                    "table_name": "src_table",
+                    "target_schema_name": "targ_schema",
+                    "target_table_name": "targ_table",
+                }
+            ],
         ),
         (
             "src_schema.src_table",
-            [{
-                "schema_name": "src_schema",
-                "table_name": "src_table"
-            }],
+            [{"schema_name": "src_schema", "table_name": "src_table"}],
         ),
         (
             "src_schema.src_table = targ_table",
-            [{
-                "schema_name": "src_schema",
-                "table_name": "src_table",
-                "target_table_name": "targ_table",
-            }],
+            [
+                {
+                    "schema_name": "src_schema",
+                    "table_name": "src_table",
+                    "target_table_name": "targ_table",
+                }
+            ],
         ),
         (
             "src.schema.src_table = targ.schema.targ_table",
-            [{
-                "schema_name": "src.schema",
-                "table_name": "src_table",
-                "target_schema_name": "targ.schema",
-                "target_table_name": "targ_table",
-            }],
+            [
+                {
+                    "schema_name": "src.schema",
+                    "table_name": "src_table",
+                    "target_schema_name": "targ.schema",
+                    "target_table_name": "targ_table",
+                }
+            ],
         ),
         (
             'src.schema."src.table"',
-            [{
-                "schema_name": "src.schema",
-                "table_name": "src.table"
-            }],
+            [{"schema_name": "src.schema", "table_name": "src.table"}],
         ),
         (
             '[{"schema_name":"schema", "table_name": "table"}]',
-            [{
-                "schema_name": "schema",
-                "table_name": "table"
-            }],
+            [{"schema_name": "schema", "table_name": "table"}],
         ),
     ],
 )
@@ -364,11 +356,7 @@ def test_get_arg_list(test_input, expected):
     [
         (
             "project.dataset.table",
-            {
-                "type": "BigQuery",
-                "project_id": "project",
-                "table_id": "dataset.table"
-            },
+            {"type": "BigQuery", "project_id": "project", "table_id": "dataset.table"},
         ),
         (
             "project.data.data.table",
@@ -391,17 +379,9 @@ def test_get_result_handler(test_input, expected):
     [
         (
             "source:target",
-            [{
-                "type": "custom",
-                "source": "source",
-                "target": "target"
-            }],
+            [{"type": "custom", "source": "source", "target": "target"}],
         ),
-        ("source", [{
-            "type": "custom",
-            "source": "source",
-            "target": "source"
-        }]),
+        ("source", [{"type": "custom", "source": "source", "target": "source"}]),
     ],
 )
 def test_get_filters(test_input, expected):
@@ -411,8 +391,7 @@ def test_get_filters(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input",
-    [("source:"), ("invalid:filter:count")],
+    "test_input", [("source:"), ("invalid:filter:count")],
 )
 def test_get_filters_err(test_input):
     """ Test get filters function returns error. """
@@ -442,10 +421,9 @@ def test_split_table_no_schema():
 
 
 @pytest.mark.parametrize(
-    "test_input",
-    [(["table"])],
+    "test_input", [(["table"])],
 )
-def test_split_table_err(test_input, ):
+def test_split_table_err(test_input,):
     """Test split table throws the right errors."""
     with pytest.raises(ValueError):
         cli_tools.split_table(test_input)

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -14,11 +14,42 @@
 
 from data_validation import state_manager
 
-
 TEST_CONN_NAME = "example"
 TEST_CONN = {
     "source_type": "BigQuery",
     "project_id": "my-project",
+}
+TEST_VALIDATION_NAME = "citibike.yaml"
+TEST_VALIDATION_CONFIG = {
+    'source':
+    'example',
+    'target':
+    'example',
+    'result_handler': {},
+    'validations': [{
+        'type':
+        'Column',
+        'table_name':
+        'citibike_trips',
+        'schema_name':
+        'bigquery-public-data.new_york_citibike',
+        'target_schema_name':
+        'bigquery-public-data.new_york_citibike',
+        'target_table_name':
+        'citibike_trips',
+        'labels': [],
+        'threshold':
+        0.0,
+        'format':
+        'table',
+        'filters': [],
+        'aggregates': [{
+            'source_column': None,
+            'target_column': None,
+            'field_alias': 'count',
+            'type': 'count'
+        }]
+    }]
 }
 
 
@@ -50,3 +81,21 @@ def test_create_unknown_filepath(capsys, fs):
     file_path = manager._get_connection_path(TEST_CONN_NAME)
     expected_file_path = files_directory + f"{TEST_CONN_NAME}.connection.json"
     assert file_path == expected_file_path
+
+
+def test_create_and_get_validation_config(capsys, fs):
+    manager = state_manager.StateManager()
+    manager.create_validation_yaml(TEST_VALIDATION_NAME,
+                                   TEST_VALIDATION_CONFIG)
+
+    config = manager.get_validation_config(TEST_VALIDATION_NAME)
+    assert config == TEST_VALIDATION_CONFIG
+
+
+def test_create_and_list_validation(capsys, fs):
+    manager = state_manager.StateManager()
+    manager.create_validation_yaml(TEST_VALIDATION_NAME,
+                                   TEST_VALIDATION_CONFIG)
+
+    validations = manager.list_validations()
+    assert validations == [TEST_VALIDATION_NAME.split(".")[0]]

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -21,35 +21,30 @@ TEST_CONN = {
 }
 TEST_VALIDATION_NAME = "citibike.yaml"
 TEST_VALIDATION_CONFIG = {
-    'source':
-    'example',
-    'target':
-    'example',
-    'result_handler': {},
-    'validations': [{
-        'type':
-        'Column',
-        'table_name':
-        'citibike_trips',
-        'schema_name':
-        'bigquery-public-data.new_york_citibike',
-        'target_schema_name':
-        'bigquery-public-data.new_york_citibike',
-        'target_table_name':
-        'citibike_trips',
-        'labels': [],
-        'threshold':
-        0.0,
-        'format':
-        'table',
-        'filters': [],
-        'aggregates': [{
-            'source_column': None,
-            'target_column': None,
-            'field_alias': 'count',
-            'type': 'count'
-        }]
-    }]
+    "source": "example",
+    "target": "example",
+    "result_handler": {},
+    "validations": [
+        {
+            "type": "Column",
+            "table_name": "citibike_trips",
+            "schema_name": "bigquery-public-data.new_york_citibike",
+            "target_schema_name": "bigquery-public-data.new_york_citibike",
+            "target_table_name": "citibike_trips",
+            "labels": [],
+            "threshold": 0.0,
+            "format": "table",
+            "filters": [],
+            "aggregates": [
+                {
+                    "source_column": None,
+                    "target_column": None,
+                    "field_alias": "count",
+                    "type": "count",
+                }
+            ],
+        }
+    ],
 }
 
 
@@ -85,8 +80,7 @@ def test_create_unknown_filepath(capsys, fs):
 
 def test_create_and_get_validation_config(capsys, fs):
     manager = state_manager.StateManager()
-    manager.create_validation_yaml(TEST_VALIDATION_NAME,
-                                   TEST_VALIDATION_CONFIG)
+    manager.create_validation_yaml(TEST_VALIDATION_NAME, TEST_VALIDATION_CONFIG)
 
     config = manager.get_validation_config(TEST_VALIDATION_NAME)
     assert config == TEST_VALIDATION_CONFIG
@@ -94,8 +88,7 @@ def test_create_and_get_validation_config(capsys, fs):
 
 def test_create_and_list_validation(capsys, fs):
     manager = state_manager.StateManager()
-    manager.create_validation_yaml(TEST_VALIDATION_NAME,
-                                   TEST_VALIDATION_CONFIG)
+    manager.create_validation_yaml(TEST_VALIDATION_NAME, TEST_VALIDATION_CONFIG)
 
     validations = manager.list_validations()
     assert validations == [TEST_VALIDATION_NAME.split(".")[0]]


### PR DESCRIPTION
Resolves #288. Allows validation configs to be saved to GCS when the `PSO_DV_CONFIG_HOME` env var is set. Also adds 'list' functionality and corresponding docs updates. 