### PR TITLE
test: Support local integration tests for Teradata, Postgres and SQL Server

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -23,6 +23,10 @@ import pytest
 ALPHABET = "abcdefghijklmnopqrstuvwxyz"
 
 
+def pytest_addoption(parser):
+    parser.addoption("--no-cloud-sql", action="store_const", const=True)
+
+
 @pytest.fixture(scope="module")
 def bigquery_client():
     project_id = os.environ["PROJECT_ID"]

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -16,6 +16,7 @@ import os
 
 from data_validation import data_validation, consts
 
+TERADATA_USER = os.getenv("TERADATA_USER", "udf")
 TERADATA_PASSWORD = os.getenv("TERADATA_PASSWORD")
 TERADATA_HOST = os.getenv("TERADATA_HOST")
 PROJECT_ID = os.getenv("PROJECT_ID")
@@ -23,7 +24,7 @@ PROJECT_ID = os.getenv("PROJECT_ID")
 conn = {
     "source_type": "Teradata",
     "host": TERADATA_HOST,
-    "user_name": "udf",
+    "user_name": TERADATA_USER,
     "password": TERADATA_PASSWORD,
     "port": 1025,
 }


### PR DESCRIPTION
Ideally, I'd like to run the integration tests before submitting a PR.

After some brief searching around, I concluded the best way to do that for TD is with the [TD Vantage Express VM](https://downloads.teradata.com/download/database/teradata-express-for-vmware-player)
which uses `dbc` not `udf` as its user name.

Also, since [Cloud SQL cannot re-use the same instance name until 1 week after deletion](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/b1dc82adf92adf19702f5ef41590c62c7c128c74/tests/system/data_sources/deploy_cloudsql/cloudsql_resource_manager.py#L133-L135) and the tests [currently hard code the instance name](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/b1dc82adf92adf19702f5ef41590c62c7c128c74/tests/system/data_sources/test_postgres.py#L35), it's easier/cheaper to run the PG and MSSQL integration tests against local docker containers.

Changes made:

* test: optionally get Teradata user name from `TERADATA_USER` env var

* test: add `--no-cloud-sql` flag to `pytest` options

* test: instantiate `CloudSQLResourceManager` in a fixture when `--no-cloud-sql` is not passed

* test: optionally get Postgres host from `POSTGRES_HOST` env var

* test: optionally get SQL Server host from `SQL_SERVER_HOST` env var

* test: optionally get SQL server user from `SQL_SERVER_USER` env var