### PR TITLE
fix: ensure all statuses are success or fail, particularly after _join_pivots (#329)

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -90,6 +90,7 @@ def generate_report(
         print(documented.compile())
 
     result_df = client.execute(documented)
+    result_df.status.fillna("fail", inplace=True)
 
     return result_df
 

--- a/tests/unit/test_combiner.py
+++ b/tests/unit/test_combiner.py
@@ -538,7 +538,7 @@ def test_generate_report_without_group_by(
                     "difference": [-1.0, -1.0, _NAN, _NAN, _NAN, _NAN],
                     "pct_difference": [-50.0, -25.0, _NAN, _NAN, _NAN, _NAN],
                     "pct_threshold": [25.0, 25.0, _NAN, _NAN, _NAN, _NAN],
-                    "status": ["fail", "success", _NAN, _NAN, _NAN, _NAN],
+                    "status": ["fail", "success", "fail", "fail", "fail", "fail"],
                     "labels": [[("name", "group_label")]] * 6,
                 }
             ),


### PR DESCRIPTION
I'm not sure if this is intended behavior or not but I would imagine we want a proper `success` or `fail` validation status for each row. In particular, if one result set contains a row that the other result set does not contain, we probably want to know about it. Currently in this case, `_join_pivots` will return a status of `nan` as described in #329. This PR sets all `nan` statuses to `fail`.

- fix: ensure all statuses are success or fail, particularly after `_join_pivots` (#329)