### PR TITLE
fix: use an appropriate column filter list for schema validation (#350)

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -153,6 +153,13 @@ def build_config_managers_from_args(args):
 
     format = args.format if args.format else "table"
 
+    use_random_rows = (
+        None if config_type == consts.SCHEMA_VALIDATION else args.use_random_row
+    )
+    random_row_batch_size = (
+        None if config_type == consts.SCHEMA_VALIDATION else args.random_row_batch_size
+    )
+
     is_filesystem = source_client._source_type == "FileSystem"
     tables_list = cli_tools.get_tables_list(
         args.tables_list, default_value=[], is_filesystem=is_filesystem
@@ -167,8 +174,8 @@ def build_config_managers_from_args(args):
             labels,
             threshold,
             format,
-            use_random_rows=args.use_random_row,
-            random_row_batch_size=args.random_row_batch_size,
+            use_random_rows=use_random_rows,
+            random_row_batch_size=random_row_batch_size,
             source_client=source_client,
             target_client=target_client,
             result_handler_config=result_handler_config,

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -277,7 +277,13 @@ class ConfigManager(object):
     def get_result_handler(self):
         """Return ResultHandler instance from supplied config."""
         if not self.result_handler_config:
-            return TextResultHandler(self._config.get(consts.CONFIG_FORMAT, "table"))
+            if self.config[consts.CONFIG_TYPE] == consts.SCHEMA_VALIDATION:
+                cols_filter_list = consts.SCHEMA_VALIDATION_COLUMN_FILTER_LIST
+            else:
+                cols_filter_list = consts.COLUMN_FILTER_LIST
+            return TextResultHandler(
+                self._config.get(consts.CONFIG_FORMAT, "table"), cols_filter_list
+            )
 
         result_type = self.result_handler_config[consts.CONFIG_TYPE]
         if result_type == "BigQuery":

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -129,3 +129,11 @@ COLUMN_FILTER_LIST = [
     "run_id",
     "start_time",
 ]
+SCHEMA_VALIDATION_COLUMN_FILTER_LIST = [
+    "run_id",
+    "start_time",
+    "end_time",
+    "aggregation_type",
+    "source_agg_value",
+    "target_agg_value",
+]

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -134,6 +134,18 @@ CONFIG_NUMERIC_AGG_VALID = {
     consts.CONFIG_FORMAT: "table",
 }
 
+CONFIG_SCHEMA_VALIDATION = {
+    # BigQuery Specific Connection Config
+    consts.CONFIG_SOURCE_CONN: BQ_CONN,
+    consts.CONFIG_TARGET_CONN: BQ_CONN,
+    # Validation Type
+    consts.CONFIG_TYPE: "Schema",
+    # Configuration Required Depending on Validator Type
+    consts.CONFIG_SCHEMA_NAME: "bigquery-public-data.new_york_citibike",
+    consts.CONFIG_TABLE_NAME: "citibike_trips",
+    consts.CONFIG_FORMAT: "table",
+}
+
 BQ_CONN_NAME = "bq-integration-test"
 CLI_CONFIG_FILE = "example_test.yaml"
 
@@ -235,6 +247,14 @@ def test_numeric_types():
         assert float(validation["source_agg_value"]) == float(
             validation["target_agg_value"]
         )
+
+
+def test_schema_validation():
+    validator = data_validation.DataValidation(CONFIG_SCHEMA_VALIDATION, verbose=True)
+    df = validator.execute()
+
+    for validation in df.to_dict(orient="records"):
+        assert validation["status"] == "Pass"
 
 
 def test_cli_store_yaml_then_run():


### PR DESCRIPTION
- fix: use an appropriate column filter list for schema validation (#350)
  - Here is the full traceback I was a able to reproduce:
    ```
    Traceback (most recent call last):
      File "/home/ajwelch/professional-services-data-validator/env/bin/data-validation", line 33, in <module>
        sys.exit(load_entry_point('google-pso-data-validator', 'console_scripts', 'data-validation')())
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 397, in main
        validate(args)
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 376, in validate
        run(args)
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 357, in run
        run_validations(args, config_managers)
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 333, in run_validations
        run_validation(config_manager, verbose=args.verbose)
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 322, in run_validation
        validator.execute()
      File "/home/ajwelch/professional-services-data-validator/data_validation/data_validation.py", line 101, in execute
        return self.result_handler.execute(self.config, result_df)
      File "/home/ajwelch/professional-services-data-validator/data_validation/result_handlers/text.py", line 61, in execute
        self.print_formatted_(result_df)
      File "/home/ajwelch/professional-services-data-validator/data_validation/result_handlers/text.py", line 46, in print_formatted_
        result_df.drop(self.cols_filter_list, axis=1).to_markdown(
      File "/home/ajwelch/professional-services-data-validator/env/lib/python3.9/site-packages/pandas/core/frame.py", line 4308, in drop
        return super().drop(
      File "/home/ajwelch/professional-services-data-validator/env/lib/python3.9/site-packages/pandas/core/generic.py", line 4153, in drop
        obj = obj._drop_axis(labels, axis, level=level, errors=errors)
      File "/home/ajwelch/professional-services-data-validator/env/lib/python3.9/site-packages/pandas/core/generic.py", line 4188, in _drop_axis
        new_axis = axis.drop(labels, errors=errors)
      File "/home/ajwelch/professional-services-data-validator/env/lib/python3.9/site-packages/pandas/core/indexes/base.py", line 5591, in drop
        raise KeyError(f"{labels[mask]} not found in axis")
    KeyError: "['labels' 'pct_threshold'] not found in axis"
    ``
- fix: only reference `use_random_row` and `random_row_batch_size` args if we are not doing a schema validation
  - fixes the following traceback:
    ```
    Traceback (most recent call last):
      File "/home/ajwelch/professional-services-data-validator/env/bin/data-validation", line 33, in <module>
        sys.exit(load_entry_point('google-pso-data-validator', 'console_scripts', 'data-validation')())
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 394, in main
        validate(args)
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 373, in validate
        run(args)
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 349, in run
        config_managers = build_config_managers_from_args(args)
      File "/home/ajwelch/professional-services-data-validator/data_validation/__main__.py", line 170, in build_config_managers_from_args
        use_random_rows=args.use_random_row,
    AttributeError: 'Namespace' object has no attribute 'use_random_row'
    ```