### PR TITLE
fix: Updates BigQuery hashbytes to use to_hex for row validations 

### DIFF
--- a/data_validation/result_handlers/text.py
+++ b/data_validation/result_handlers/text.py
@@ -23,7 +23,6 @@ Output validation report to text-based log
 """
 
 from data_validation import consts
-import pandas as pd
 
 
 class TextResultHandler(object):
@@ -36,16 +35,6 @@ class TextResultHandler(object):
         Utility for printing formatted results
         :param result_df
         """
-        # the text transformer chokes on bytestring results (e.g. SHA256) this
-        # dataframe slice is to remove the source and target values
-        mask = result_df["validation_type"] == consts.ROW_VALIDATION
-        row_result_df = result_df[mask]
-        other_result_df = result_df[~mask]
-        row_result_df["source_agg_value"] = None
-        row_result_df["target_agg_value"] = None
-        frames = [row_result_df, other_result_df]
-        result_df = pd.concat(frames)
-
         if self.format == "text":
             print(result_df.to_string(index=False))
         elif self.format == "csv":

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -104,7 +104,7 @@ def format_hashbytes_bigquery(translator, expr):
     arg, how = expr.op().args
     compiled_arg = translator.translate(arg)
     if how == "sha256":
-        return f"SHA256({compiled_arg})"
+        return f"TO_HEX(SHA256({compiled_arg}))"
     elif how == "farm_fingerprint":
         return f"FARM_FINGERPRINT({compiled_arg})"
     else:


### PR DESCRIPTION
Closes #399 

This resolves the issue of printing bytestring results (e.g. SHA256) with the text result handler as well.