### PR TITLE
Feat: Random Sort for Pandas Queries

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -465,7 +465,7 @@ def run_validation_configs(args):
 
 
 def validate(args):
-    """ Run commands related to data validation."""
+    """Run commands related to data validation."""
     if args.validate_cmd in ["column", "row", "schema", "custom-query"]:
         run(args)
     else:

--- a/data_validation/app.py
+++ b/data_validation/app.py
@@ -44,9 +44,9 @@ def validate(config):
 
 
 def main(request):
-    """ Handle incoming Data Validation requests.
+    """Handle incoming Data Validation requests.
 
-        request (flask.Request): HTTP request object.
+    request (flask.Request): HTTP request object.
     """
     try:
         config = _get_request_content(request)["config"]

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -279,7 +279,9 @@ def _configure_run_parser(subparsers):
         help="Store the validation in the YAML Config File Path specified",
     )
     run_parser.add_argument(
-        "--labels", "-l", help="Key value pair labels for validation run",
+        "--labels",
+        "-l",
+        help="Key value pair labels for validation run",
     )
     run_parser.add_argument(
         "--hash",
@@ -536,10 +538,14 @@ def _configure_custom_query_parser(custom_query_parser):
     """Configure arguments to run custom-query validations."""
     _add_common_arguments(custom_query_parser)
     custom_query_parser.add_argument(
-        "--source-query-file", "-sqf", help="File containing the source sql query",
+        "--source-query-file",
+        "-sqf",
+        help="File containing the source sql query",
     )
     custom_query_parser.add_argument(
-        "--target-query-file", "-tqf", help="File containing the target sql query",
+        "--target-query-file",
+        "-tqf",
+        help="File containing the target sql query",
     )
     custom_query_parser.add_argument(
         "--count",

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -193,7 +193,7 @@ def get_all_tables(client, allowed_schemas=None):
 
 
 def get_data_client(connection_config):
-    """ Return DataClient client from given configuration """
+    """Return DataClient client from given configuration"""
     connection_config = copy.deepcopy(connection_config)
     source_type = connection_config.pop(consts.SOURCE_TYPE)
 

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -91,11 +91,11 @@ class ConfigManager(object):
         return self._config[consts.CONFIG_TYPE]
 
     def use_random_rows(self):
-        """ Return if the validation should use a random row filter. """
+        """Return if the validation should use a random row filter."""
         return self._config.get(consts.CONFIG_USE_RANDOM_ROWS) or False
 
     def random_row_batch_size(self):
-        """ Return if the validation should use a random row filter. """
+        """Return if the validation should use a random row filter."""
         return (
             self._config.get(consts.CONFIG_RANDOM_ROW_BATCH_SIZE)
             or consts.DEFAULT_NUM_RANDOM_ROWS
@@ -107,12 +107,12 @@ class ConfigManager(object):
 
     @property
     def max_recursive_query_size(self):
-        """Return Aggregates from Config """
+        """Return Aggregates from Config"""
         return self._config.get(consts.CONFIG_MAX_RECURSIVE_QUERY_SIZE, 50000)
 
     @property
     def aggregates(self):
-        """Return Aggregates from Config """
+        """Return Aggregates from Config"""
         return self._config.get(consts.CONFIG_AGGREGATES, [])
 
     def append_aggregates(self, aggregate_configs):
@@ -130,18 +130,18 @@ class ConfigManager(object):
 
     @property
     def dependent_aliases(self):
-        """ Return all columns that are needed in final dataframe for row validations. """
+        """Return all columns that are needed in final dataframe for row validations."""
         return self._config.get(consts.CONFIG_DEPENDENT_ALIASES, [])
 
     def append_dependent_aliases(self, dependent_aliases):
-        """ Appends columns that are needed in final dataframe for row validations. """
+        """Appends columns that are needed in final dataframe for row validations."""
         self._config[consts.CONFIG_DEPENDENT_ALIASES] = (
             self.dependent_aliases + dependent_aliases
         )
 
     @property
     def query_groups(self):
-        """ Return Query Groups from Config """
+        """Return Query Groups from Config"""
         return self._config.get(consts.CONFIG_GROUPED_COLUMNS, [])
 
     def append_query_groups(self, grouped_column_configs):
@@ -152,7 +152,7 @@ class ConfigManager(object):
 
     @property
     def source_query_file(self):
-        """ Return SQL Query File from Config """
+        """Return SQL Query File from Config"""
         return self._config.get(consts.CONFIG_SOURCE_QUERY_FILE, [])
 
     def append_source_query_file(self, query_file_configs):
@@ -163,7 +163,7 @@ class ConfigManager(object):
 
     @property
     def target_query_file(self):
-        """ Return SQL Query File from Config """
+        """Return SQL Query File from Config"""
         return self._config.get(consts.CONFIG_TARGET_QUERY_FILE, [])
 
     def append_target_query_file(self, query_file_configs):
@@ -174,7 +174,7 @@ class ConfigManager(object):
 
     @property
     def primary_keys(self):
-        """ Return Primary keys from Config """
+        """Return Primary keys from Config"""
         return self._config.get(consts.CONFIG_PRIMARY_KEYS, [])
 
     def append_primary_keys(self, primary_key_configs):
@@ -185,7 +185,7 @@ class ConfigManager(object):
 
     @property
     def comparison_fields(self):
-        """ Return fields from Config """
+        """Return fields from Config"""
         return self._config.get(consts.CONFIG_COMPARISON_FIELDS, [])
 
     def append_comparison_fields(self, field_configs):
@@ -196,7 +196,7 @@ class ConfigManager(object):
 
     @property
     def filters(self):
-        """Return Filters from Config """
+        """Return Filters from Config"""
         return self._config.get(consts.CONFIG_FILTERS, [])
 
     @property
@@ -258,7 +258,7 @@ class ConfigManager(object):
 
     @property
     def threshold(self):
-        """Return threshold from Config """
+        """Return threshold from Config"""
         return self._config.get(consts.CONFIG_THRESHOLD, 0.0)
 
     def get_source_ibis_table(self):
@@ -271,7 +271,7 @@ class ConfigManager(object):
 
     def get_source_ibis_calculated_table(self, depth=None):
         """Return mutated IbisTable from source
-           n: Int the depth of subquery requested"""
+        n: Int the depth of subquery requested"""
         table = self.get_source_ibis_table()
         vb = ValidationBuilder(self)
         calculated_table = table.mutate(
@@ -290,7 +290,7 @@ class ConfigManager(object):
 
     def get_target_ibis_calculated_table(self, depth=None):
         """Return mutated IbisTable from target
-           n: Int the depth of subquery requested"""
+        n: Int the depth of subquery requested"""
         table = self.get_target_ibis_table()
         vb = ValidationBuilder(self)
         calculated_table = table.mutate(
@@ -332,8 +332,10 @@ class ConfigManager(object):
                 consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH
             )
             if key_path:
-                credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-                    key_path
+                credentials = (
+                    google.oauth2.service_account.Credentials.from_service_account_file(
+                        key_path
+                    )
                 )
             else:
                 credentials = None
@@ -445,7 +447,7 @@ class ConfigManager(object):
         return aggregate_config
 
     def append_stringlen_calc_field(self, column, agg_type):
-        """ Append calculated field for length(string) for column validation"""
+        """Append calculated field for length(string) for column validation"""
         calculated_config = {
             consts.CONFIG_CALCULATED_SOURCE_COLUMNS: [column],
             consts.CONFIG_CALCULATED_TARGET_COLUMNS: [column],

--- a/data_validation/data_validation.py
+++ b/data_validation/data_validation.py
@@ -78,7 +78,7 @@ class DataValidation(object):
     # TODO(dhercher) we planned on shifting this to use an Execution Handler.
     # Leaving to to swast on the design of how this should look.
     def execute(self):
-        """ Execute Queries and Store Results """
+        """Execute Queries and Store Results"""
         # Apply random row filter before validations run
         if self.config_manager.use_random_rows():
             self._add_random_row_filter()
@@ -90,7 +90,7 @@ class DataValidation(object):
                 self.validation_builder, grouped_fields
             )
         elif self.config_manager.validation_type == consts.SCHEMA_VALIDATION:
-            """ Perform only schema validation """
+            """Perform only schema validation"""
             result_df = self.schema_validator.execute()
         else:
             result_df = self._execute_validation(
@@ -101,7 +101,7 @@ class DataValidation(object):
         return self.result_handler.execute(self.config, result_df)
 
     def _add_random_row_filter(self):
-        """ Add random row filters to the validation builder. """
+        """Add random row filters to the validation builder."""
         if not self.config_manager.primary_keys:
             raise ValueError("Primary Keys are required for Random Row Filters")
 
@@ -135,15 +135,15 @@ class DataValidation(object):
         self.validation_builder.add_filter(filter_field)
 
     def query_too_large(self, rows_df, grouped_fields):
-        """ Return bool to dictate if another level of recursion
-            would create a too large result set.
+        """Return bool to dictate if another level of recursion
+        would create a too large result set.
 
-            Rules to define too large are:
-                - If any grouped fields remain, return False.
-                    (assumes user added logical sized groups)
-                - Else, if next group size is larger
-                    than the limit, return True.
-                - Finally return False if no covered case occured.
+        Rules to define too large are:
+            - If any grouped fields remain, return False.
+                (assumes user added logical sized groups)
+            - Else, if next group size is larger
+                than the limit, return True.
+            - Finally return False if no covered case occured.
         """
         if len(grouped_fields) > 1:
             return False
@@ -233,7 +233,7 @@ class DataValidation(object):
         return pandas.concat(past_results)
 
     def _add_recursive_validation_filter(self, validation_builder, row):
-        """ Return ValidationBuilder Configured for Next Recursive Search """
+        """Return ValidationBuilder Configured for Next Recursive Search"""
         group_by_columns = json.loads(row[consts.GROUP_BY_COLUMNS])
         for alias, value in group_by_columns.items():
             filter_field = {
@@ -280,7 +280,7 @@ class DataValidation(object):
         return pd_schema
 
     def _execute_validation(self, validation_builder, process_in_memory=True):
-        """ Execute Against a Supplied Validation Builder """
+        """Execute Against a Supplied Validation Builder"""
         self.run_metadata.validations = validation_builder.get_metadata()
 
         source_query = validation_builder.get_source_query()
@@ -358,7 +358,7 @@ class DataValidation(object):
         return result_df
 
     def combine_data(self, source_df, target_df, join_on_fields):
-        """ TODO: Return List of Dictionaries """
+        """TODO: Return List of Dictionaries"""
         # Clean Data to Standardize
         if join_on_fields:
             df = source_df.merge(

--- a/data_validation/query_builder/query_builder.py
+++ b/data_validation/query_builder/query_builder.py
@@ -250,7 +250,7 @@ class GroupedField(object):
 
 class ColumnReference(object):
     def __init__(self, column_name):
-        """ A representation of an calculated field to build a query.
+        """A representation of an calculated field to build a query.
 
         Args:
             column_name (String): The column name used in a complex expr
@@ -258,7 +258,7 @@ class ColumnReference(object):
         self.column_name = column_name
 
     def compile(self, ibis_table):
-        """ Return an ibis object referencing the column.
+        """Return an ibis object referencing the column.
 
         Args:
             ibis_table (IbisTable): The table obj reference
@@ -269,7 +269,7 @@ class ColumnReference(object):
 class CalculatedField(object):
     def __init__(self, ibis_expr, config, fields, cast=None, **kwargs):
 
-        """ A representation of an calculated field to build a query.
+        """A representation of an calculated field to build a query.
 
         Args:
             config dict: Configurations object explaining calc field details
@@ -288,7 +288,10 @@ class CalculatedField(object):
         fields = [config["default_concat_separator"], fields]
         cast = "string"
         return CalculatedField(
-            ibis.expr.api.StringValue.join, config, fields, cast=cast,
+            ibis.expr.api.StringValue.join,
+            config,
+            fields,
+            cast=cast,
         )
 
     @staticmethod
@@ -296,12 +299,18 @@ class CalculatedField(object):
         if config.get("default_hash_function") is None:
             how = "sha256"
             return CalculatedField(
-                ibis.expr.api.StringValue.hashbytes, config, fields, how=how,
+                ibis.expr.api.StringValue.hashbytes,
+                config,
+                fields,
+                how=how,
             )
         else:
             how = "farm_fingerprint"
             return CalculatedField(
-                ibis.expr.api.ValueExpr.hash, config, fields, how=how,
+                ibis.expr.api.ValueExpr.hash,
+                config,
+                fields,
+                how=how,
             )
 
     @staticmethod
@@ -312,31 +321,50 @@ class CalculatedField(object):
             else config.get("default_null_string")
         )
         fields = [fields[0], config["default_string"]]
-        return CalculatedField(ibis.expr.api.ValueExpr.fillna, config, fields,)
+        return CalculatedField(
+            ibis.expr.api.ValueExpr.fillna,
+            config,
+            fields,
+        )
 
     @staticmethod
     def length(config, fields):
-        return CalculatedField(ibis.expr.api.StringValue.length, config, fields,)
+        return CalculatedField(
+            ibis.expr.api.StringValue.length,
+            config,
+            fields,
+        )
 
     @staticmethod
     def rstrip(config, fields):
-        return CalculatedField(ibis.expr.api.StringValue.rstrip, config, fields,)
+        return CalculatedField(
+            ibis.expr.api.StringValue.rstrip,
+            config,
+            fields,
+        )
 
     @staticmethod
     def upper(config, fields):
-        return CalculatedField(ibis.expr.api.StringValue.upper, config, fields,)
+        return CalculatedField(
+            ibis.expr.api.StringValue.upper,
+            config,
+            fields,
+        )
 
     @staticmethod
     def cast(config, fields):
         if config.get("default_cast") is None:
             target_type = "string"
         return CalculatedField(
-            ibis.expr.api.ValueExpr.cast, config, fields, target_type=target_type,
+            ibis.expr.api.ValueExpr.cast,
+            config,
+            fields,
+            target_type=target_type,
         )
 
     @staticmethod
     def custom(expr):
-        """ Returns a CalculatedField instance built for any custom SQL using a supported operator.
+        """Returns a CalculatedField instance built for any custom SQL using a supported operator.
         Args:
             expr (Str): A custom SQL expression used to filter a query
         """
@@ -376,7 +404,7 @@ class QueryBuilder(object):
         comparison_fields,
         limit=None,
     ):
-        """ Build a QueryBuilder object which can be used to build queries easily
+        """Build a QueryBuilder object which can be used to build queries easily
 
         Args:
             aggregate_fields (list[AggregateField]): AggregateField instances with Ibis expressions
@@ -394,7 +422,7 @@ class QueryBuilder(object):
 
     @staticmethod
     def build_count_validator(limit=None):
-        """ Return a basic template builder for most validations """
+        """Return a basic template builder for most validations"""
         aggregate_fields = []
         filters = []
         grouped_fields = []
@@ -520,7 +548,7 @@ class QueryBuilder(object):
         self.filters.append(filter_obj)
 
     def add_calculated_field(self, calculated_field):
-        """ Add a CalculatedField instance to your query which
+        """Add a CalculatedField instance to your query which
             will add the desired scalar function to your compiled
             query (ie. CONCAT(field_a, field_b))
         Args:

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -101,13 +101,16 @@ class RandomRowBuilder(object):
     def maybe_add_random_sort(
         self, data_client: ibis.client, table: ibis.Expr
     ) -> ibis.Expr:
-        """ Return a randomly sorted query if it is supported for the client."""
+        """Return a randomly sorted query if it is supported for the client."""
         if type(data_client) in RANDOM_SORT_SUPPORTS:
             return table.sort_by(
                 RandomSortKey(RANDOM_SORT_SUPPORTS[type(data_client)]).to_expr()
             )
 
-        logging.warning("Data Client %s Does Not Enforce Random Sort on Sample", str(type(data_client)))
+        logging.warning(
+            "Data Client %s Does Not Enforce Random Sort on Sample",
+            str(type(data_client)),
+        )
         return table
 
 

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -148,12 +148,13 @@ pandas_util.compute_sorted_frame = compute_sorted_frame
 ##### Override Order By for SQL #####
 #####################################
 
+
 def format_order_by(self):
     if not self.order_by:
         return None
 
     buf = StringIO()
-    buf.write('ORDER BY ')
+    buf.write("ORDER BY ")
 
     formatted = []
     for expr in self.order_by:
@@ -167,10 +168,11 @@ def format_order_by(self):
         key = expr.op()
         translated = self._translate(key.expr)
         if not key.ascending:
-            translated += ' DESC'
+            translated += " DESC"
         formatted.append(translated)
 
-    buf.write(', '.join(formatted))
+    buf.write(", ".join(formatted))
     return buf.getvalue()
+
 
 sql_compiler.Select.format_order_by = format_order_by

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -23,12 +23,12 @@ from data_validation import clients
 
 class RandomRowBuilder(object):
     def __init__(self, primary_keys: List[str], batch_size: int):
-        """ Build a RandomRowBuilder objct which is ready to build a random row filter query.
+        """Build a RandomRowBuilder objct which is ready to build a random row filter query.
 
-    Args:
-        primary_keys: A list of primary key field strings used to find random rows.
-        batch_size: A max size for the number of random row values to find.
-    """
+        Args:
+            primary_keys: A list of primary key field strings used to find random rows.
+            batch_size: A max size for the number of random row values to find.
+        """
         self.primary_keys = primary_keys
         self.batch_size = batch_size
 
@@ -37,11 +37,11 @@ class RandomRowBuilder(object):
     ) -> ibis.Expr:
         """Return an Ibis query object
 
-    Args:
-        data_client (IbisClient): The client used to query random rows.
-        schema_name (String): The name of the schema for the given table.
-        table_name (String): The name of the table to query.
-    """
+        Args:
+            data_client (IbisClient): The client used to query random rows.
+            schema_name (String): The name of the schema for the given table.
+            table_name (String): The name of the table to query.
+        """
         table = clients.get_ibis_table(data_client, schema_name, table_name)
         query = table[self.primary_keys].limit(self.batch_size)
 

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import random
+import logging
 import ibis
 import ibis.expr.operations as ops
 import ibis.expr.types as tz
@@ -106,6 +107,7 @@ class RandomRowBuilder(object):
                 RandomSortKey(RANDOM_SORT_SUPPORTS[type(data_client)]).to_expr()
             )
 
+        logging.warning("Data Client %s Does Not Enforce Random Sort on Sample", str(type(data_client)))
         return table
 
 

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -31,6 +31,14 @@ from io import StringIO
 """ The QueryBuilder for retreiving random row values to filter against."""
 
 
+######################################
+### Adding new datasources should be
+### done by adding the Client and
+### syntax for random sorts in the
+### dict below. If upstream injection
+### is required, feel free to reach
+### out to dhercher
+######################################
 RANDOM_SORT_SUPPORTS = {
     PandasClient: "NA",
     BigQueryClient: "RAND()",

--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -32,7 +32,7 @@ class SchemaValidation(object):
         self.run_metadata = run_metadata or metadata.RunMetadata()
 
     def execute(self):
-        """ Performs a validation between source and a target schema"""
+        """Performs a validation between source and a target schema"""
         ibis_source_schema = self.config_manager.source_client.get_schema(
             self.config_manager.source_table, self.config_manager.source_schema
         )
@@ -91,7 +91,7 @@ class SchemaValidation(object):
 
 
 def schema_validation_matching(source_fields, target_fields):
-    """ Compare schemas between two dictionary objects """
+    """Compare schemas between two dictionary objects"""
     results = []
     # Go through each source and check if target exists and matches
     for source_field_name, source_field_type in source_fields.items():

--- a/data_validation/validation_builder.py
+++ b/data_validation/validation_builder.py
@@ -72,7 +72,7 @@ class ValidationBuilder(object):
 
     @staticmethod
     def get_query_builder(validation_type):
-        """ Return Query Builder object given validation type """
+        """Return Query Builder object given validation type"""
         if validation_type in [
             "Column",
             "GroupedColumn",
@@ -100,20 +100,20 @@ class ValidationBuilder(object):
         return self._metadata
 
     def get_group_aliases(self):
-        """ Return List of String Aliases """
+        """Return List of String Aliases"""
         return list(self.group_aliases.keys())
 
     def get_primary_keys(self):
-        """ Return List of String Aliases """
+        """Return List of String Aliases"""
         # do we need this?
         return list(self.primary_keys.keys())
 
     def get_calculated_aliases(self):
-        """ Return List of String Aliases """
+        """Return List of String Aliases"""
         return self.calculated_aliases.keys()
 
     def get_comparison_fields(self):
-        """ Return List of String Aliases """
+        """Return List of String Aliases"""
         return self.comparison_fields.keys()
 
     def get_grouped_alias_source_column(self, alias):
@@ -123,13 +123,13 @@ class ValidationBuilder(object):
         return self.group_aliases[alias][consts.CONFIG_TARGET_COLUMN]
 
     def add_config_aggregates(self):
-        """ Add Aggregations to Query """
+        """Add Aggregations to Query"""
         aggregate_fields = self.config_manager.aggregates
         for aggregate_field in aggregate_fields:
             self.add_aggregate(aggregate_field)
 
     def add_config_calculated_fields(self):
-        """ Add calculated fields to Query """
+        """Add calculated fields to Query"""
         calc_fields = self.config_manager.calculated_fields
         if calc_fields is not None:
             for calc_field in calc_fields:
@@ -146,13 +146,13 @@ class ValidationBuilder(object):
             self.add_comparison_field(field)
 
     def add_config_query_groups(self, query_groups=None):
-        """ Add Grouped Columns to Query """
+        """Add Grouped Columns to Query"""
         grouped_fields = query_groups or self.config_manager.query_groups
         for grouped_field in grouped_fields:
             self.add_query_group(grouped_field)
 
     def add_config_filters(self):
-        """ Add Filters to Query """
+        """Add Filters to Query"""
         filter_fields = self.config_manager.filters
         for filter_field in filter_fields:
             self.add_filter(filter_field)
@@ -193,7 +193,7 @@ class ValidationBuilder(object):
         )
 
     def pop_grouped_fields(self):
-        """ Return grouped fields and reset configs."""
+        """Return grouped fields and reset configs."""
         self.source_builder.grouped_fields = []
         self.target_builder.grouped_fields = []
         self.group_aliases = {}
@@ -223,7 +223,7 @@ class ValidationBuilder(object):
         self.group_aliases[alias] = grouped_field
 
     def add_primary_key(self, primary_key):
-        """ Add ComparionField to Queries
+        """Add ComparionField to Queries
 
         Args:
             primary_key (Dict): An object with source, target, and cast info
@@ -274,7 +274,7 @@ class ValidationBuilder(object):
         self.target_builder.add_filter_field(target_filter)
 
     def add_comparison_field(self, comparison_field):
-        """ Add ComparionField to Queries
+        """Add ComparionField to Queries
 
         Args:
             comparison_field (Dict): An object with source, target, and cast info
@@ -299,7 +299,7 @@ class ValidationBuilder(object):
         )
 
     def add_calc(self, calc_field):
-        """ Add CalculatedField to Queries
+        """Add CalculatedField to Queries
 
         Args:
             calc_field (Dict): An object with source, target, and cast info
@@ -327,7 +327,7 @@ class ValidationBuilder(object):
         self.calculated_aliases[alias] = calc_field
 
     def get_source_query(self):
-        """ Return query for source validation """
+        """Return query for source validation"""
         source_config = {
             "data_client": self.source_client,
             "schema_name": self.config_manager.source_schema,
@@ -356,7 +356,7 @@ class ValidationBuilder(object):
         return query
 
     def get_target_query(self):
-        """ Return query for source validation """
+        """Return query for source validation"""
         target_config = {
             "data_client": self.target_client,
             "schema_name": self.config_manager.target_schema,
@@ -395,7 +395,7 @@ class ValidationBuilder(object):
         self.target_builder.limit = limit
 
     def get_query_from_file(self, filename):
-        """ Return query from input file """
+        """Return query from input file"""
         query = ""
         try:
             file = open(filename, "r")
@@ -412,7 +412,7 @@ class ValidationBuilder(object):
         return query
 
     def get_aggregation_query(self, agg_type, column_name):
-        """ Return aggregation query """
+        """Return aggregation query"""
         aggregation_query = ""
         if column_name is None:
             aggregation_query = agg_type + "(*) as " + agg_type + ","
@@ -430,7 +430,7 @@ class ValidationBuilder(object):
         return aggregation_query
 
     def get_wrapper_aggregation_query(self, aggregate_query, base_query):
-        """ Return wrapper aggregation query """
+        """Return wrapper aggregation query"""
 
         return (
             aggregate_query[: len(aggregate_query) - 1]

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,6 +34,7 @@ DEFAULT_PYTHON_VERSION = "3.9"
 PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
 
 BLACK_PATHS = ("data_validation", "samples", "tests", "noxfile.py", "setup.py")
+LINT_PACKAGES = ["flake8", "black==22.3.0"]
 
 
 def _setup_session_requirements(session, extra_packages=[]):
@@ -93,9 +94,8 @@ def lint(session):
     serious code quality issues.
     """
 
-    _setup_session_requirements(
-        session, extra_packages=["flake8", "black==19.10b0", "click==8.0.4"]
-    )
+    _setup_session_requirements(session, extra_packages=LINT_PACKAGES)
+
     session.install("--upgrade", "pip", "wheel")
     session.run("flake8", "data_validation")
     session.run("flake8", "tests")
@@ -110,7 +110,7 @@ def blacken(session):
     """
     # Pin a specific version of black, so that the linter doesn't conflict with
     # contributors.
-    session.install("black==19.10b0")
+    _setup_session_requirements(session, extra_packages=LINT_PACKAGES)
     session.run("black", *BLACK_PATHS)
 
 

--- a/samples/functions/main.py
+++ b/samples/functions/main.py
@@ -31,9 +31,9 @@ def _clean_dataframe(df):
 
 
 def main(request):
-    """ Handle incoming Data Validation requests.
+    """Handle incoming Data Validation requests.
 
-        request (flask.Request): HTTP request object.
+    request (flask.Request): HTTP request object.
     """
     try:
         config = request.json["config"]

--- a/samples/run/main.py
+++ b/samples/run/main.py
@@ -44,9 +44,9 @@ def validate(config):
 
 
 def main(request):
-    """ Handle incoming Data Validation requests.
+    """Handle incoming Data Validation requests.
 
-        request (flask.Request): HTTP request object.
+    request (flask.Request): HTTP request object.
     """
     try:
         config = _get_request_content(request)["config"]

--- a/samples/run/test.py
+++ b/samples/run/test.py
@@ -41,8 +41,14 @@ def get_cloud_run_url(service_name, project_id):
 
 
 data = {
-    "source_conn": {"source_type": "BigQuery", "project_id": PROJECT_ID,},
-    "target_conn": {"source_type": "BigQuery", "project_id": PROJECT_ID,},
+    "source_conn": {
+        "source_type": "BigQuery",
+        "project_id": PROJECT_ID,
+    },
+    "target_conn": {
+        "source_type": "BigQuery",
+        "project_id": PROJECT_ID,
+    },
     "type": "Column",
     "schema_name": "bigquery-public-data.new_york_citibike",
     "table_name": "citibike_stations",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dependencies = [
     "google-api-python-client==1.12.8",
     "ibis-framework==1.4.0",
     "ibis-bigquery==0.1.1",
-    "impyla==0.16.3",
+    "impyla==0.17.0",
     "SQLAlchemy==1.3.22",
     "PyMySQL==1.0.2",
     "psycopg2-binary==2.8.6",

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,8 @@ setuptools.setup(
     install_requires=dependencies,
     extras_require=extras_require,
     entry_points={
-        "console_scripts": ["data-validation=data_validation.__main__:main",]
+        "console_scripts": [
+            "data-validation=data_validation.__main__:main",
+        ]
     },
 )

--- a/tests/system/data_sources/deploy_cloudsql/cloudsql_resource_manager.py
+++ b/tests/system/data_sources/deploy_cloudsql/cloudsql_resource_manager.py
@@ -36,7 +36,7 @@ class CloudSQLResourceManager:
         enable_bin_logs=True,
         already_exists=False,
     ):
-        """Initialize a CloudSQLResourceManager """
+        """Initialize a CloudSQLResourceManager"""
         if database_type not in DATABASE_TYPES:
             raise ValueError(
                 f"Invalid database type. Must be of the form {str(DATABASE_TYPES)}"
@@ -55,14 +55,14 @@ class CloudSQLResourceManager:
         self.db = {}
 
     def describe(self):
-        """ Returns description of resource manager instance """
+        """Returns description of resource manager instance"""
         print(
             f"Creates a {self._database_type} instance in project {self._project_id} with "
             f"database_id: {self._database_id}, instance_id: {self._instance_id}."
         )
 
     def setup(self):
-        """ Creates Cloud SQL instance and database """
+        """Creates Cloud SQL instance and database"""
         with GCloudContext(self._project_id) as gcloud:
             if self._already_exists:
                 json_describe = gcloud.Run(
@@ -114,7 +114,7 @@ class CloudSQLResourceManager:
                 return self.db["PRIMARY_ADDRESS"]
 
     def add_data(self, gcs_data_path):
-        """ Adds data to Cloud SQL database """
+        """Adds data to Cloud SQL database"""
         if self._already_exists:
             return
         with GCloudContext(self._project_id) as gcloud:
@@ -129,7 +129,7 @@ class CloudSQLResourceManager:
             )
 
     def teardown(self):
-        """ Deletes Cloud SQL instance """
+        """Deletes Cloud SQL instance"""
         # If instance is deleted per integration test, instance_id will need a random
         # suffix appended since Cloud SQL cannot re-use the same instance name until
         # 1 week after deletion.
@@ -137,7 +137,7 @@ class CloudSQLResourceManager:
             gcloud.Run("--quiet", "sql", "instances", "delete", self._instance_id)
 
     def _get_random_string(self, length=5):
-        """ Returns random string
+        """Returns random string
         Args:
             length (int): Desired length of random string"""
         return "".join(random.choice(string.ascii_lowercase) for i in range(length))

--- a/tests/system/data_sources/deploy_cloudsql/gcloud_context.py
+++ b/tests/system/data_sources/deploy_cloudsql/gcloud_context.py
@@ -33,7 +33,7 @@ class GCloudContext(object):
         pass
 
     def Run(self, *args, **kwargs):
-        """ Runs gcloud command and returns output"""
+        """Runs gcloud command and returns output"""
         env = kwargs.pop("env", None)
         if not env:
             env = os.environ.copy()

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -361,7 +361,9 @@ def _store_bq_conn():
 def test_random_row_query_builder():
     bq_client = clients.get_data_client(BQ_CONN)
     row_query_builder = random_row_builder.RandomRowBuilder(["station_id"], 10)
-    query = row_query_builder.compile(bq_client, "bigquery-public-data.new_york_citibike", "citibike_stations")
+    query = row_query_builder.compile(
+        bq_client, "bigquery-public-data.new_york_citibike", "citibike_stations"
+    )
 
     random_rows = bq_client.execute(query)
     print(random_rows)
@@ -370,4 +372,15 @@ def test_random_row_query_builder():
 
     assert query.compile() == EXPECTED_RANDOM_ROW_QUERY
     assert len(random_rows["station_id"]) == 10
-    assert list(random_rows["station_id"]) != [4683, 4676, 4675, 4674, 4673, 4671, 4670, 4666, 4665, 4664]
+    assert list(random_rows["station_id"]) != [
+        4683,
+        4676,
+        4675,
+        4674,
+        4673,
+        4671,
+        4670,
+        4666,
+        4665,
+        4664,
+    ]

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -366,9 +366,6 @@ def test_random_row_query_builder():
     )
 
     random_rows = bq_client.execute(query)
-    print(random_rows)
-    print(random_rows["station_id"].values)
-    print(query.compile())
 
     assert query.compile() == EXPECTED_RANDOM_ROW_QUERY
     assert len(random_rows["station_id"]) == 10

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -53,7 +53,8 @@ CONFIG_COUNT_VALID = {
 def test_mysql_count_invalid_host():
     try:
         data_validator = data_validation.DataValidation(
-            CONFIG_COUNT_VALID, verbose=False,
+            CONFIG_COUNT_VALID,
+            verbose=False,
         )
         df = data_validator.execute()
         assert df["source_agg_value"][0] == df["target_agg_value"][0]

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -53,7 +53,7 @@ def cloud_sql(request):
 
 
 def test_postgres_count(cloud_sql):
-    """ Test count validation on Postgres instance """
+    """Test count validation on Postgres instance"""
     conn = {
         "source_type": "Postgres",
         "host": POSTGRES_HOST,
@@ -83,6 +83,9 @@ def test_postgres_count(cloud_sql):
         consts.CONFIG_FORMAT: "table",
     }
 
-    data_validator = data_validation.DataValidation(config_count_valid, verbose=False,)
+    data_validator = data_validation.DataValidation(
+        config_count_valid,
+        verbose=False,
+    )
     df = data_validator.execute()
     assert df["source_agg_value"][0] == df["target_agg_value"][0]

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -183,7 +183,8 @@ def test_count_validator(count_config):
     assert float(count_string_value) > 0
     assert float(avg_float_value) > 0
     assert datetime.datetime.strptime(
-        max_timestamp_value, "%Y-%m-%d %H:%M:%S%z",
+        max_timestamp_value,
+        "%Y-%m-%d %H:%M:%S%z",
     ) > datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
     assert float(min_int_value) > 0
 

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -54,7 +54,7 @@ def cloud_sql(request):
 
 
 def test_sql_server_count(cloud_sql):
-    """ Test count validation on SQL Server instance """
+    """Test count validation on SQL Server instance"""
     conn = {
         "source_type": "MSSQL",
         "host": SQL_SERVER_HOST,
@@ -84,7 +84,10 @@ def test_sql_server_count(cloud_sql):
         consts.CONFIG_FORMAT: "table",
     }
 
-    data_validator = data_validation.DataValidation(config_count_valid, verbose=False,)
+    data_validator = data_validation.DataValidation(
+        config_count_valid,
+        verbose=False,
+    )
     df = data_validator.execute()
     assert df["source_agg_value"][0] == df["target_agg_value"][0]
 

--- a/tests/unit/query_builder/test_random_row_builder.py
+++ b/tests/unit/query_builder/test_random_row_builder.py
@@ -38,7 +38,7 @@ def module_under_test():
 
 
 def _create_table_file(table_path, data):
-    """ Create JSON File """
+    """Create JSON File"""
     with open(table_path, "w") as f:
         f.write(data)
 

--- a/tests/unit/query_builder/test_random_row_builder.py
+++ b/tests/unit/query_builder/test_random_row_builder.py
@@ -25,8 +25,7 @@ CONN_CONFIG = {
     "file_type": "json",
 }
 
-JSON_DATA = (
-    """
+JSON_DATA = """
 [
 {"col_a":0,"col_b":"a"},{"col_a":1,"col_b":"b"},{"col_a":2,"col_b":"c"},
 {"col_a":3,"col_b":"a"},{"col_a":4,"col_b":"b"},{"col_a":5,"col_b":"c"},
@@ -37,7 +36,6 @@ JSON_DATA = (
 {"col_a":18,"col_b":"a"},{"col_a":19,"col_b":"b"},{"col_a":20,"col_b":"c"},
 {"col_a":21,"col_b":"a"},{"col_a":22,"col_b":"b"},{"col_a":23,"col_b":"c"}
 ]"""
-)
 
 
 @pytest.fixture

--- a/tests/unit/query_builder/test_random_row_builder.py
+++ b/tests/unit/query_builder/test_random_row_builder.py
@@ -26,7 +26,17 @@ CONN_CONFIG = {
 }
 
 JSON_DATA = (
-    """[{"col_a":0,"col_b":"a"},{"col_a":1,"col_b":"b"},{"col_a":2,"col_b":"c"}]"""
+    """
+[
+{"col_a":0,"col_b":"a"},{"col_a":1,"col_b":"b"},{"col_a":2,"col_b":"c"},
+{"col_a":3,"col_b":"a"},{"col_a":4,"col_b":"b"},{"col_a":5,"col_b":"c"},
+{"col_a":6,"col_b":"a"},{"col_a":7,"col_b":"b"},{"col_a":8,"col_b":"c"},
+{"col_a":9,"col_b":"a"},{"col_a":10,"col_b":"b"},{"col_a":11,"col_b":"c"},
+{"col_a":12,"col_b":"a"},{"col_a":13,"col_b":"b"},{"col_a":14,"col_b":"c"},
+{"col_a":15,"col_b":"a"},{"col_a":16,"col_b":"b"},{"col_a":17,"col_b":"c"},
+{"col_a":18,"col_b":"a"},{"col_a":19,"col_b":"b"},{"col_a":20,"col_b":"c"},
+{"col_a":21,"col_b":"a"},{"col_a":22,"col_b":"b"},{"col_a":23,"col_b":"c"}
+]"""
 )
 
 
@@ -58,10 +68,10 @@ def test_compile(module_under_test, fs):
     _create_table_file(TABLE_FILE_PATH, JSON_DATA)
     client = clients.get_data_client(CONN_CONFIG)
     primary_keys = ["col_a"]
-    builder = module_under_test.RandomRowBuilder(primary_keys, 1)
+    builder = module_under_test.RandomRowBuilder(primary_keys, 10)
 
     query = builder.compile(client, None, CONN_CONFIG["table_name"])
     df = client.execute(query)
 
     assert list(df.columns) == primary_keys
-    assert len(df) == 1
+    assert len(df) == 10

--- a/tests/unit/result_handlers/test_text.py
+++ b/tests/unit/result_handlers/test_text.py
@@ -48,12 +48,12 @@ def module_under_test():
 
 
 def test_import(module_under_test):
-    """Test import cleanly """
+    """Test import cleanly"""
     assert module_under_test is not None
 
 
 def test_basic_result_handler(module_under_test):
-    """Test basic handler executes """
+    """Test basic handler executes"""
     result_df = DataFrame(SAMPLE_RESULT_DATA, columns=SAMPLE_RESULT_COLUMNS)
     format = "csv"
     result_handler = module_under_test.TextResultHandler(

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -57,7 +57,8 @@ RESULT_TABLE_CONFIGS = [
 
 
 @mock.patch(
-    "argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**CLI_ARGS),
+    "argparse.ArgumentParser.parse_args",
+    return_value=argparse.Namespace(**CLI_ARGS),
 )
 def test_configure_arg_parser(mock_args):
     """Test arg parser values."""

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -99,7 +99,8 @@ CLI_FIND_TABLES_ARGS = [
 
 
 @mock.patch(
-    "argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(**CLI_ARGS),
+    "argparse.ArgumentParser.parse_args",
+    return_value=argparse.Namespace(**CLI_ARGS),
 )
 def test_get_parsed_args(mock_args):
     """Test arg parser values with validate command."""
@@ -233,7 +234,8 @@ def test_get_labels_err(test_input):
 
 
 @pytest.mark.parametrize(
-    "test_input,expected", [(0, 0.0), (50, 50.0), (100, 100.0)],
+    "test_input,expected",
+    [(0, 0.0), (50, 50.0), (100, 100.0)],
 )
 def test_threshold_float(test_input, expected):
     """Test threshold float function."""
@@ -242,7 +244,8 @@ def test_threshold_float(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input", [(-4), (float("nan")), (float("inf")), ("string")],
+    "test_input",
+    [(-4), (float("nan")), (float("inf")), ("string")],
 )
 def test_threshold_float_err(test_input):
     """Test that threshold float only accepts positive floats."""
@@ -395,7 +398,8 @@ def test_get_filters(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input", [("source:"), ("invalid:filter:count")],
+    "test_input",
+    [("source:"), ("invalid:filter:count")],
 )
 def test_get_filters_err(test_input):
     """Test get filters function returns error."""
@@ -425,9 +429,12 @@ def test_split_table_no_schema():
 
 
 @pytest.mark.parametrize(
-    "test_input", [(["table"])],
+    "test_input",
+    [(["table"])],
 )
-def test_split_table_err(test_input,):
+def test_split_table_err(
+    test_input,
+):
     """Test split table throws the right errors."""
     with pytest.raises(ValueError):
         cli_tools.split_table(test_input)

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -104,7 +104,7 @@ def module_under_test():
 
 
 def test_import(module_under_test):
-    """Test import cleanly """
+    """Test import cleanly"""
     assert module_under_test is not None
 
 
@@ -202,7 +202,7 @@ def test_process_in_memory(module_under_test):
 
 
 def test_get_table_info(module_under_test):
-    """Test basic handler executes """
+    """Test basic handler executes"""
     config_manager = module_under_test.ConfigManager(
         SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
     )

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import json
 import pandas
 import pytest

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -390,7 +390,7 @@ def module_under_test():
 
 
 def _create_table_file(table_path, data):
-    """ Create JSON File """
+    """Create JSON File"""
     with open(table_path, "w") as f:
         f.write(data)
 
@@ -446,7 +446,7 @@ def test_import(module_under_test):
 
 
 def test_data_validation_client(module_under_test, fs):
-    """ Test getting a Data Validation Client """
+    """Test getting a Data Validation Client"""
     _create_table_file(SOURCE_TABLE_FILE_PATH, JSON_DATA)
     _create_table_file(TARGET_TABLE_FILE_PATH, JSON_DATA)
 
@@ -456,7 +456,7 @@ def test_data_validation_client(module_under_test, fs):
 
 
 def test_get_pandas_schema(module_under_test):
-    """ Test extracting pandas schema from dataframes for Ibis Pandas."""
+    """Test extracting pandas schema from dataframes for Ibis Pandas."""
     pandas_schema = module_under_test.DataValidation._get_pandas_schema(
         SOURCE_DF, SOURCE_DF, JOIN_ON_FIELDS
     )

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -43,7 +43,15 @@ def test_get_column_name(
 
 def test_get_column_name_with_unexpected_result_type(module_under_test):
     validation = module_under_test.ValidationMetadata(
-        "", "", "", "", "", "", "", "", "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
     )
     with pytest.raises(ValueError, match="Unexpected result_type"):
         validation.get_column_name("oops_i_goofed")

--- a/tests/unit/test_schema_validation.py
+++ b/tests/unit/test_schema_validation.py
@@ -82,7 +82,7 @@ def module_under_test():
 
 
 def _create_table_file(table_path, data):
-    """ Create JSON File """
+    """Create JSON File"""
     with open(table_path, "w") as f:
         f.write(data)
 


### PR DESCRIPTION
The branch adds a new operation for RandomSort logic.  It also implements this logic by injecting a wrapper around the pandas implementation (which should hold up relatively cleanly to Ibis upgrades).

The logic implements BigQuery by overriding the `format_order_by` logic in the SELECT object itself, and is likely to need scrutiny on Ibis upgrade (find me at that time)

Adding new alchemy sources likely just takes adding the correct SQL (eg `RAND()`) which is required for random sorting on the given DB.