### PR TITLE
fix: only replaces datatypes and not column names

### DIFF
--- a/third_party/ibis/ibis_impala/api.py
+++ b/third_party/ibis/ibis_impala/api.py
@@ -62,18 +62,18 @@ def parse_type(t):
                 return ValueError(t)
         elif "struct" in t or "array" in t or "map" in t:
             if "bigint" in t:
-                t = t.replace("bigint", "int64")
+                t = t.replace(":bigint", ":int64")
             elif "tinyint" in t:
-                t = t.replace("tinyint", "int8")
+                t = t.replace(":tinyint", ":int8")
             elif "smallint" in t:
-                t = t.replace("smallint", "int16")
+                t = t.replace(":smallint", ":int16")
             else:
-                t = t.replace("int", "int32")
+                t = t.replace(":int", ":int32")
 
             if "varchar" in t:
-                t = t.replace("varchar", "string")
+                t = t.replace(":varchar", ":string")
             else:
-                t = t.replace("char","string")
+                t = t.replace(":char",":string")
             return t
         else:
             raise Exception(t)


### PR DESCRIPTION
Fixes issue in PR #444 so that only data types with the select text will be replaces, not column names as well. A customer ran into an issue where 'internal_name' was being replaced by 'int32ernal_name'.