### PR TITLE
fix: supports NULL datetime/timestamps in Hive to BQ

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -116,6 +116,18 @@ def _calculate_difference(field_differences, datatype, validation, is_value_comp
             .else_(consts.VALIDATION_STATUS_FAIL)
             .end()
         )
+    # String data types i.e "None" can be returned for NULL timestamp/datetime aggs
+    elif isinstance(datatype, ibis.expr.datatypes.String):
+        difference = pct_difference = ibis.null().cast("float64")
+        validation_status = (
+            ibis.case()
+            .when(
+                target_value.isnull() & source_value.isnull(),
+                consts.VALIDATION_STATUS_SUCCESS,
+            )
+            .else_(consts.VALIDATION_STATUS_FAIL)
+            .end()
+        )
     else:
         difference = (target_value - source_value).cast("float64")
 

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -81,7 +81,7 @@ def test_schema_validation():
         df = data_validator.execute()
 
         for validation in df.to_dict(orient="records"):
-            assert validation["status"] == consts.VALIDATION_STATUS_SUCCESS
+            assert validation["validation_status"] == consts.VALIDATION_STATUS_SUCCESS
     except exceptions.DataClientConnectionFailure:
         # Local Testing will not work for MySQL
         pass

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -124,4 +124,4 @@ def test_schema_validation(cloud_sql):
     df = data_validator.execute()
 
     for validation in df.to_dict(orient="records"):
-        assert validation["status"] == consts.VALIDATION_STATUS_SUCCESS
+        assert validation["validation_status"] == consts.VALIDATION_STATUS_SUCCESS


### PR DESCRIPTION
Closes Issue #452 

- Allows NULL Hive datetime/timestamp to be compared in validations. Previously DVT would throw a `ibis.common.exceptions.IbisTypeError: Value <class 'ibis.expr.datatypes.Interval'> is not a valid datatype` error
- Fixes bug with "status" in system tests in PR #455 