### PR TITLE
feat: support float and decimal types in Hive

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -55,6 +55,7 @@ def get_aggregate_config(args, config_manager):
     aggregate_configs = [config_manager.build_config_count_aggregate()]
     supported_data_types = [
         "float64",
+        "float32",
         "int8",
         "int16",
         "int32",

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -512,13 +512,13 @@ class ConfigManager(object):
             if column not in allowlist_columns:
                 continue
             elif column not in casefold_target_columns:
-                logging.info(
+                print(
                     f"Skipping {agg_type} on {column} as column is not present in target table"
                 )
                 continue
             elif supported_types and column_type not in supported_types:
                 if self.verbose:
-                    logging.info(
+                    print(
                         f"Skipping {agg_type} on {column} due to data type: {column_type}"
                     )
                 continue

--- a/samples/run/Dockerfile
+++ b/samples/run/Dockerfile
@@ -15,6 +15,10 @@ RUN apt-get update \
 RUN pip install --upgrade pip
 RUN pip install Flask gunicorn google_pso_data_validator
 
+# Hive/Impala Dependencies 
+# RUN pip install hdfs
+# RUN pip install thrift-sasl
+
 # Oracle Dependencies
 # if you are using Oracle you should add .rpm files
 # under your license to a directory called oracle/

--- a/third_party/ibis/ibis_addon/datatypes.py
+++ b/third_party/ibis/ibis_addon/datatypes.py
@@ -28,8 +28,8 @@ from ibis.backends.pandas.execution.constants import IBIS_TYPE_TO_PANDAS_TYPE
 
 # BigQuery BIGNUMERIC support needs to be pushed to Ibis
 bigquery._pandas_helpers.BQ_TO_ARROW_SCALARS["BIGNUMERIC"] = pyarrow.decimal256
-_DTYPE_TO_IBIS_TYPE["BIGNUMERIC"] = dt.float64
-_DTYPE_TO_IBIS_TYPE["NUMERIC"] = dt.float64
+_DTYPE_TO_IBIS_TYPE["BIGNUMERIC"] = dt.Decimal(38,9)
+_DTYPE_TO_IBIS_TYPE["NUMERIC"] = dt.Decimal(38,9)
 
 
 # Ibis Pandas Client Inference

--- a/third_party/ibis/ibis_addon/datatypes.py
+++ b/third_party/ibis/ibis_addon/datatypes.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import decimal
+import ibis.expr.datatypes as dt
+import ibis.expr.schema as sch
+import numpy as np
+import pandas as pd
+import pyarrow
 
 from google.cloud import bigquery
 from ibis_bigquery.client import _DTYPE_TO_IBIS_TYPE
 from ibis_bigquery.datatypes import ibis_type_to_bigquery_type, TypeTranslationContext, trans_numeric_udf
-import ibis.expr.datatypes as dt
-from ibis.backends.pandas.client import _inferable_pandas_dtypes
-import pyarrow
+from ibis.backends.pandas.client import _inferable_pandas_dtypes, infer_pandas_schema, infer_pandas_dtype
+from ibis.backends.pandas.execution.constants import IBIS_TYPE_TO_PANDAS_TYPE
 
 
 # BigQuery BIGNUMERIC support needs to be pushed to Ibis
@@ -27,9 +32,12 @@ _DTYPE_TO_IBIS_TYPE["BIGNUMERIC"] = dt.float64
 _DTYPE_TO_IBIS_TYPE["NUMERIC"] = dt.float64
 
 
-# Ibis Pandas Clent Inference
+# Ibis Pandas Client Inference
 # Still Open: floating, integer, mixed-integer,
 # mixed-integer-float, complex, categorical, timedelta64, timedelta, period
+IBIS_TYPE_TO_PANDAS_TYPE[dt.Decimal(10,0)] = np.dtype(decimal.Decimal)
+_inferable_pandas_dtypes['decimal'] = dt.Decimal(10,0)
+
 _inferable_pandas_dtypes['date'] = dt.date
 _inferable_pandas_dtypes['datetime64'] = dt.timestamp
 _inferable_pandas_dtypes['datetime'] = dt.timestamp
@@ -46,3 +54,36 @@ def trans_numeric(t, context):
     return 'NUMERIC'
 
 trans_numeric_udf = trans_numeric
+
+@sch.infer.register(pd.DataFrame)
+def infer_pandas_schema_incl_decimals(df, schema=None):
+    schema = schema if schema is not None else {}
+
+    pairs = []
+    for column_name, pandas_dtype in df.dtypes.iteritems():
+        if not isinstance(column_name, str):
+            raise TypeError(
+                'Column names must be strings to use the pandas backend'
+            )
+
+        if column_name in schema:
+            ibis_dtype = dt.dtype(schema[column_name])
+        elif pandas_dtype == np.object_:
+            inferred_dtype = infer_pandas_dtype(df[column_name], skipna=True)
+            if inferred_dtype == 'mixed':
+                raise TypeError(
+                    'Unable to infer type of column {0!r}. Try instantiating '
+                    'your table from the client with client.table('
+                    "'my_table', schema={{{0!r}: <explicit type>}})".format(
+                        column_name
+                    )
+                )
+            ibis_dtype = _inferable_pandas_dtypes[inferred_dtype]
+        else:
+            ibis_dtype = dt.dtype(pandas_dtype)
+
+        pairs.append((column_name, ibis_dtype))
+
+    return sch.schema(pairs)
+
+infer_pandas_schema = infer_pandas_schema_incl_decimals


### PR DESCRIPTION
- Added support for DECIMAL types in Hive for column and row level aggregation. Treats them as Decimal(10,0) which is the default
- Added support for FLOAT type in Hive (float32)
- Updated BigQuery NUMERIC to correlate to Decimal(38,9) in Ibis
- Added dependencies to Cloud Run Hive example