### PR TITLE
bug: primary keys were all lowercased

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -157,7 +157,7 @@ def build_config_from_args(args, config_manager):
         if args.grouped_columns is not None:
             grouped_columns = cli_tools.get_arg_list(args.grouped_columns)
             config_manager.append_query_groups(
-                config_manager.build_config_grouped_columns(grouped_columns)
+                config_manager.build_column_configs(grouped_columns)
             )
     elif config_manager.validation_type == consts.ROW_VALIDATION:
         if args.comparison_fields is not None:
@@ -173,7 +173,7 @@ def build_config_from_args(args, config_manager):
     if args.primary_keys is not None:
         primary_keys = cli_tools.get_arg_list(args.primary_keys)
         config_manager.append_primary_keys(
-            config_manager.build_config_comparison_fields(primary_keys)
+            config_manager.build_column_configs(primary_keys)
         )
         if args.hash != "*":
             config_manager.append_dependent_aliases(primary_keys)

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -427,15 +427,15 @@ class ConfigManager(object):
             field_configs.append(column_config)
         return field_configs
 
-    def build_config_grouped_columns(self, grouped_columns):
+    def build_column_configs(self, columns):
         """Return list of grouped column config objects."""
-        grouped_column_configs = []
+        column_configs = []
         source_table = self.get_source_ibis_calculated_table()
         target_table = self.get_target_ibis_calculated_table()
         casefold_source_columns = {x.casefold(): str(x) for x in source_table.columns}
         casefold_target_columns = {x.casefold(): str(x) for x in target_table.columns}
 
-        for column in grouped_columns:
+        for column in columns:
 
             if column.casefold() not in casefold_source_columns:
                 raise ValueError(f"Grouped Column DNE in source: {column}")
@@ -447,9 +447,9 @@ class ConfigManager(object):
                 consts.CONFIG_FIELD_ALIAS: column,
                 consts.CONFIG_CAST: None,
             }
-            grouped_column_configs.append(column_config)
+            column_configs.append(column_config)
 
-        return grouped_column_configs
+        return column_configs
 
     def build_config_count_aggregate(self):
         """Return dict aggregate for COUNT(*)."""

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -222,13 +222,13 @@ def test_get_table_info(module_under_test):
     assert target_table_spec == expected_table_spec
 
 
-def test_build_config_grouped_columns(module_under_test):
+def test_build_column_configs(module_under_test):
     config_manager = module_under_test.ConfigManager(
         SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
     )
 
-    column_configs = config_manager.build_config_grouped_columns(["a"])
-    lazy_column_configs = config_manager.build_config_grouped_columns(["A"])
+    column_configs = config_manager.build_column_configs(["a"])
+    lazy_column_configs = config_manager.build_column_configs(["A"])
     assert column_configs[0] == GROUPED_COLUMN_CONFIG_A
     assert (
         lazy_column_configs[0][consts.CONFIG_SOURCE_COLUMN]


### PR DESCRIPTION
This PR resolves the issue seen which caused uppercase primary keys (and generally any non-matching primary keys) to fail.

Resolves:
https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/504