### PR TITLE
docs: fix typo on ibis_snowflake

### DIFF
--- a/third_party/ibis/ibis_snowflake/README.md
+++ b/third_party/ibis/ibis_snowflake/README.md
@@ -22,7 +22,7 @@ The Snowflake client is accessible through the ibis.ibis_snowflake namespace. Th
     snowflake://{user}:{password}@{account}/{database}
 
 #
-# **2.Code snippet for connecting to oracle Exadata using ibis:-**
+# **2.Code snippet for connecting to Snowflake using ibis:-**
 
     import ibis
     import os


### PR DESCRIPTION
I'm assuming the Snowflake file shouldn't be referencing Oracle Exadata