### PR TITLE
Fix: close Teradata connection via object delete

### DIFF
--- a/third_party/ibis/ibis_teradata/client.py
+++ b/third_party/ibis/ibis_teradata/client.py
@@ -93,6 +93,9 @@ class TeradataClient(SQLClient):
         self.client = teradatasql.connect(**self.teradata_config)
         self.use_no_lock_tables = use_no_lock_tables
 
+    def __del__ (self):
+        teradatasql.close()
+        
     def _execute(self, dml, results=False, **kwargs):
         query = TeradataQuery(self, dml)
         df = self._execute_query(query, **kwargs)


### PR DESCRIPTION
This is to add a way to close a Teradata connection to mitigate the issue identified in https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/445 

Per the user's suggestion, once the connection object is deleted, the connection will be closed via teradatasql.close()