### PR TITLE
fix: support for cast to timestamp in TD, support for random row

### DIFF
--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -25,11 +25,15 @@ from ibis.backends.pandas.client import PandasClient
 import ibis.backends.pandas.execution.util as pandas_util
 
 from ibis.expr.signature import Argument as Arg
-from third_party.ibis.ibis_teradata.client import TeradataClient
 from typing import List
 from data_validation import clients
 from io import StringIO
 
+try:
+    from third_party.ibis.ibis_teradata.client import TeradataClient
+except Exception:
+    msg = "pip install teradatasql (requires Teradata licensing)"
+    TeradataClient = clients._raise_missing_client_error(msg)
 
 """ The QueryBuilder for retreiving random row values to filter against."""
 

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -25,6 +25,7 @@ from ibis.backends.pandas.client import PandasClient
 import ibis.backends.pandas.execution.util as pandas_util
 
 from ibis.expr.signature import Argument as Arg
+from third_party.ibis.ibis_teradata.client import TeradataClient
 from typing import List
 from data_validation import clients
 from io import StringIO
@@ -109,10 +110,12 @@ class RandomRowBuilder(object):
                 RandomSortKey(RANDOM_SORT_SUPPORTS[type(data_client)]).to_expr()
             )
 
-        logging.warning(
-            "Data Client %s Does Not Enforce Random Sort on Sample",
-            str(type(data_client)),
-        )
+        if type(data_client) != TeradataClient:
+        # Teradata 'SAMPLE' is random by nature and does not require a sort by
+            logging.warning(
+                "Data Client %s Does Not Enforce Random Sort on Sample",
+                str(type(data_client)),
+            )
         return table
 
 

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -111,7 +111,7 @@ class RandomRowBuilder(object):
             )
 
         if type(data_client) != TeradataClient:
-        # Teradata 'SAMPLE' is random by nature and does not require a sort by
+            # Teradata 'SAMPLE' is random by nature and does not require a sort by
             logging.warning(
                 "Data Client %s Does Not Enforce Random Sort on Sample",
                 str(type(data_client)),

--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -121,15 +121,16 @@ def schema_validation_matching(source_fields, target_fields, exclusion_fields):
 
     if exclusion_fields is not None:
         for field in exclusion_fields:
-            del source_fields_casefold[field]
-            del target_fields_casefold[field]
+            source_fields_casefold.pop(field, None) 
+            target_fields_casefold.pop(field, None)
 
     # Go through each source and check if target exists and matches
     for source_field_name, source_field_type in source_fields_casefold.items():
         # target field exists
         if source_field_name in target_fields_casefold:
             # target data type matches
-            if source_field_type == target_fields_casefold[source_field_name]:
+            target_field_type = target_fields_casefold[source_field_name]
+            if source_field_type == target_field_type:
                 results.append(
                     [
                         source_field_name,

--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -121,7 +121,7 @@ def schema_validation_matching(source_fields, target_fields, exclusion_fields):
 
     if exclusion_fields is not None:
         for field in exclusion_fields:
-            source_fields_casefold.pop(field, None) 
+            source_fields_casefold.pop(field, None)
             target_fields_casefold.pop(field, None)
 
     # Go through each source and check if target exists and matches

--- a/third_party/ibis/ibis_teradata/client.py
+++ b/third_party/ibis/ibis_teradata/client.py
@@ -94,7 +94,7 @@ class TeradataClient(SQLClient):
         self.use_no_lock_tables = use_no_lock_tables
 
     def __del__ (self):
-        teradatasql.close()
+        self.client.close()
         
     def _execute(self, dml, results=False, **kwargs):
         query = TeradataQuery(self, dml)

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -116,22 +116,14 @@ class TeradataTypeTranslator(object):
 
 ibis_type_to_teradata_type = Dispatcher("ibis_type_to_teradata_type")
 
-
-@ibis_type_to_teradata_type.register(str)
-def trans_string_default(datatype):
-    return ibis_type_to_teradata_type(dt.dtype(datatype))
-    
-
-
 @ibis_type_to_teradata_type.register(dt.DataType)
 def trans_default(t):
-    # return ibis_type_to_teradata_type(t, TypeTranslationContext())
-    return "VARCHAR(255)"
+    return ibis_type_to_teradata_type(t, TypeTranslationContext())
 
 
 @ibis_type_to_teradata_type.register(str, TypeTranslationContext)
 def trans_string_context(datatype, context):
-    return "VARCHAR"
+    return "VARCHAR(255)"
 
 
 @ibis_type_to_teradata_type.register(dt.Floating, TypeTranslationContext)
@@ -157,7 +149,7 @@ def trans_date(t, context):
 @ibis_type_to_teradata_type.register(dt.Timestamp, TypeTranslationContext)
 def trans_timestamp(t, context):
     if t.timezone is not None:
-        raise TypeError("BigQuery does not support timestamps with timezones")
+        return f"TIMESTAMP AT TIME ZONE '{t.timezone}'"
     return "TIMESTAMP"
 
 


### PR DESCRIPTION
Closes #536 

- Removes warning for Teradata random row validation as it is supported with SAMPLE 
- Adds support for casting to Teradata TIMESTAMP and including timezone cast
- Fixes bug for schema validation that throws error if column is not included in both source and target tables