### PR TITLE
fix: support NUMBER with no precision/scale

### DIFF
--- a/third_party/ibis/ibis_oracle/client.py
+++ b/third_party/ibis/ibis_oracle/client.py
@@ -43,6 +43,8 @@ def sa_oracle_LONG(_, satype, nullable=True):
 
 @dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.NUMBER)
 def sa_oracle_NUMBER(_, satype, nullable=True):
+    if not satype.precision and not satype.scale:
+        return dt.Decimal(38, 0, nullable=nullable)
     return dt.Decimal(satype.precision, satype.scale, nullable=nullable)
 
 


### PR DESCRIPTION
Currently, NUMBER in Oracle is only supported when a precision and scale are present in the schema i.e NUMBER (2,2). This adds support for NUMBER without precision/scale.