### PR TITLE
fix: Teradata limit on column name, bug when casting to VARCHAR

### DIFF
--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -126,6 +126,11 @@ def trans_string_context(datatype, context):
     return "VARCHAR(255)"
 
 
+@ibis_type_to_teradata_type.register(dt.String, TypeTranslationContext)
+def trans_string(t, context):
+    return "VARCHAR(255)"
+
+
 @ibis_type_to_teradata_type.register(dt.Floating, TypeTranslationContext)
 def trans_float64(t, context):
     return "FLOAT64"


### PR DESCRIPTION
Closes #579 
- Fixes bug in Teradata which cast to "STRING" instead of to "VARCHAR(255)"
- Sets limit on Teradata column names to 30 characters
- Shortens prefix appended to calc column aliases