### PR TITLE
Revert "fix: Teradata limit on column name, bug when casting to VARCHAR"

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -23,13 +23,6 @@ from data_validation.result_handlers.bigquery import BigQueryResultHandler
 from data_validation.result_handlers.text import TextResultHandler
 from data_validation.validation_builder import ValidationBuilder
 
-# If you have a Teradata License there is an optional teradatasql import
-try:
-    from third_party.ibis.ibis_teradata.client import TeradataClient
-except Exception:
-    msg = "pip install teradatasql (requires Teradata licensing)"
-    TeradataClient = clients._raise_missing_client_error(msg)
-
 
 class ConfigManager(object):
     _config: dict = None
@@ -692,17 +685,7 @@ class ConfigManager(object):
                 ):  # this needs to be the previous manifest of columns
                     col = {}
                     col["reference"] = [column]
-
-                    prefix = f"{calc[:3]}_"
-                    offset = len(prefix)
-                    # Teradata max column name length is 30 chars
-                    if type(self.source_client) == TeradataClient and len(column) >= (
-                        30 - offset
-                    ):
-                        col["name"] = prefix + column[:-offset]
-                    else:
-                        col["name"] = prefix + column
-
+                    col["name"] = f"{calc}__" + column
                     col["calc_type"] = calc
                     col["depth"] = i
                     name = col["name"]

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -133,11 +133,9 @@ def trans_string(t, context):
 def trans_float64(t, context):
     return "FLOAT64"
 
-
 @ibis_type_to_teradata_type.register(dt.Integer, TypeTranslationContext)
 def trans_integer(t, context):
     return "INT64"
-
 
 @ibis_type_to_teradata_type.register(dt.UInt64, (TypeTranslationContext, UDFContext))
 def trans_lossy_integer(t, context):

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -125,17 +125,21 @@ def trans_default(t):
 def trans_string_context(datatype, context):
     return "VARCHAR(255)"
 
+
 @ibis_type_to_teradata_type.register(dt.String, TypeTranslationContext)
 def trans_string(t, context):
     return "VARCHAR(255)"
+
 
 @ibis_type_to_teradata_type.register(dt.Floating, TypeTranslationContext)
 def trans_float64(t, context):
     return "FLOAT64"
 
+
 @ibis_type_to_teradata_type.register(dt.Integer, TypeTranslationContext)
 def trans_integer(t, context):
     return "INT64"
+
 
 @ibis_type_to_teradata_type.register(dt.UInt64, (TypeTranslationContext, UDFContext))
 def trans_lossy_integer(t, context):

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -126,11 +126,6 @@ def trans_string_context(datatype, context):
     return "VARCHAR(255)"
 
 
-@ibis_type_to_teradata_type.register(dt.String, TypeTranslationContext)
-def trans_string(t, context):
-    return "VARCHAR(255)"
-
-
 @ibis_type_to_teradata_type.register(dt.Floating, TypeTranslationContext)
 def trans_float64(t, context):
     return "FLOAT64"

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -125,6 +125,9 @@ def trans_default(t):
 def trans_string_context(datatype, context):
     return "VARCHAR(255)"
 
+@ibis_type_to_teradata_type.register(dt.String, TypeTranslationContext)
+def trans_string(t, context):
+    return "VARCHAR(255)"
 
 @ibis_type_to_teradata_type.register(dt.Floating, TypeTranslationContext)
 def trans_float64(t, context):


### PR DESCRIPTION
Reverts GoogleCloudPlatform/professional-services-data-validator#580.
As this will introduce new error of duplicate columns, we need to revert this merge.