### PR TITLE
feat: Oracle row level validation support

### DIFF
--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -175,6 +175,12 @@ def sa_format_hashbytes(translator, expr):
     hash_to_string = sa.func.convert(sa.sql.literal_column('CHAR(64)'), hash_func, sa.sql.literal_column('2'))
     return sa.func.lower(hash_to_string)
 
+def sa_format_hashbytes_oracle(translator, expr):
+    arg, how = expr.op().args
+    compiled_arg = translator.translate(arg)
+    hash_func = sa.func.standard_hash(compiled_arg, sa.sql.literal_column("'SHA2_256'"))
+    return sa.func.lower(hash_func)
+
 
 _pandas_client._inferable_pandas_dtypes["floating"] = _pandas_client.dt.float64
 IntegerColumn.bit_xor = ibis.expr.api._agg_function("bit_xor", BitXor, True)
@@ -194,5 +200,6 @@ BigQueryExprTranslator._registry[RawSQL] = format_raw_sql
 ImpalaExprTranslator._registry[RawSQL] = format_raw_sql
 ImpalaExprTranslator._registry[HashBytes] = format_hashbytes_hive
 OracleExprTranslator._registry[RawSQL] = sa_format_raw_sql
+OracleExprTranslator._registry[HashBytes] = sa_format_hashbytes_oracle
 TeradataExprTranslator._registry[RawSQL] = format_raw_sql
 TeradataExprTranslator._registry[HashBytes] = format_hashbytes_teradata

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -178,7 +178,7 @@ def sa_format_hashbytes(translator, expr):
 def sa_format_hashbytes_oracle(translator, expr):
     arg, how = expr.op().args
     compiled_arg = translator.translate(arg)
-    hash_func = sa.func.standard_hash(compiled_arg, sa.sql.literal_column("'SHA2_256'"))
+    hash_func = sa.func.standard_hash(compiled_arg, sa.sql.literal_column("'SHA256'"))
     return sa.func.lower(hash_func)
 
 

--- a/third_party/ibis/ibis_oracle/alchemy.py
+++ b/third_party/ibis/ibis_oracle/alchemy.py
@@ -28,7 +28,7 @@ _ibis_type_to_sqla = {
     dt11.LONGRAW: sa.Binary,
 }
 _ibis_type_to_sqla.update(s_al._ibis_type_to_sqla)
-_ibis_type_to_sqla[dt.String] = sa.sql.sqltypes.String(length=65533)
+_ibis_type_to_sqla[dt.String] = sa.sql.sqltypes.String(length=4000)
 
 def _to_sqla_type(itype, type_map=None):
     if type_map is None:

--- a/third_party/ibis/ibis_oracle/alchemy.py
+++ b/third_party/ibis/ibis_oracle/alchemy.py
@@ -28,7 +28,7 @@ _ibis_type_to_sqla = {
     dt11.LONGRAW: sa.Binary,
 }
 _ibis_type_to_sqla.update(s_al._ibis_type_to_sqla)
-
+_ibis_type_to_sqla[dt.String] = sa.sql.sqltypes.String(length=65533)
 
 def _to_sqla_type(itype, type_map=None):
     if type_map is None:

--- a/third_party/ibis/ibis_oracle/client.py
+++ b/third_party/ibis/ibis_oracle/client.py
@@ -43,6 +43,8 @@ def sa_oracle_LONG(_, satype, nullable=True):
 
 @dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.NUMBER)
 def sa_oracle_NUMBER(_, satype, nullable=True):
+    if not satype.precision and not satype.scale:
+        return dt.Decimal(38, 0, nullable=nullable)
     return dt.Decimal(satype.precision, satype.scale, nullable=nullable)
 
 

--- a/third_party/ibis/ibis_oracle/compiler.py
+++ b/third_party/ibis/ibis_oracle/compiler.py
@@ -439,7 +439,8 @@ def _mod(t, expr):
 
 def _string_join(t, expr):
     sep, elements = expr.op().args
-    return sa.func.concat(t.translate(sep), *map(t.translate, elements))
+    columns = [col.name for col in map(t.translate, elements)]
+    return sa.sql.literal_column(" || ".join(columns))
 
 
 def _literal(t, expr):

--- a/third_party/ibis/ibis_oracle/compiler.py
+++ b/third_party/ibis/ibis_oracle/compiler.py
@@ -439,7 +439,7 @@ def _mod(t, expr):
 
 def _string_join(t, expr):
     sep, elements = expr.op().args
-    return sa.func.concat_ws(t.translate(sep), *map(t.translate, elements))
+    return sa.func.concat(t.translate(sep), *map(t.translate, elements))
 
 
 def _literal(t, expr):


### PR DESCRIPTION
Closes #556 

Supports row level validation for Oracle.

- Does NOT support random row yet. As a workaround, filters are supported.