### PR TITLE
feat: Postgres row hash validation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ perform this task.
 
 DVT supports the following validations:
 * Column validation (count, sum, avg, min, max, group by)
-* Row validation (BQ, Hive, Teradata, Oracle, SQL Server only)
+* Row validation (BQ, Hive, Teradata, Oracle, SQL Server, Postgres only)
 * Schema validation 
 * Custom Query validation
 * Ad hoc SQL exploration
@@ -133,7 +133,7 @@ The [Examples](https://github.com/GoogleCloudPlatform/professional-services-data
 
 #### Row Validations
 
-(Note: Row hash validation is currently supported for BigQuery, Teradata, Impala/Hive, Oracle, and SQL Server.
+(Note: Row hash validation is currently supported for BigQuery, Teradata, Impala/Hive, Oracle, SQL Server, and Postgres.
 Struct and array data types are not currently supported and random row is not yet supported for Oracle or SQL Server.
 In addition, please note that SHA256 is not a supported function on Teradata systems. 
 If you wish to perform this comparison on Teradata you will need to 

--- a/data_validation/query_builder/random_row_builder.py
+++ b/data_validation/query_builder/random_row_builder.py
@@ -25,6 +25,7 @@ import ibis.backends.pandas.execution.util as pandas_util
 from ibis_bigquery import BigQueryClient
 from ibis.backends.impala.client import ImpalaClient
 from ibis.backends.pandas.client import PandasClient
+from ibis.backends.postgres.client import PostgreSQLClient
 from ibis.expr.signature import Argument as Arg
 from data_validation import clients
 from data_validation.query_builder.query_builder import QueryBuilder
@@ -50,6 +51,7 @@ RANDOM_SORT_SUPPORTS = {
     PandasClient: "NA",
     BigQueryClient: "RAND()",
     ImpalaClient: "RAND()",
+    PostgreSQLClient: "RANDOM()",
 }
 
 

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -94,7 +94,6 @@ def test_sql_server_count(cloud_sql):
 def test_sql_server_row(cloud_sql):
     """Test row validation on SQL Server instance"""
     config_row_valid = {
-        # BigQuery Specific Connection Config
         consts.CONFIG_SOURCE_CONN: CONN,
         consts.CONFIG_TARGET_CONN: CONN,
         # Validation Type


### PR DESCRIPTION
Closes #586 

Supports row hash validation for Postgres.
Support for random row is dependent on PR #588 being merged which sets the framework for SQLAlchemy random row.