### PR TITLE
fix: SQL Server and BigQuery hash function matching

### DIFF
--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -429,7 +429,7 @@ _operation_registry.update(
         ops.MinRank: unary(lambda arg: sa.func.rank()),
         ops.PercentRank: unary(lambda arg: sa.func.percent_rank()),
         ops.NullIf: fixed_arity(sa.func.nullif, 2),
-        ops.IfNull: fixed_arity(sa.func.coalesce, 2),
+        ops.IfNull: fixed_arity(sa.func.isnull, 2),
         ms_ops.Between: _between,
         ops.Translate: fixed_arity('translate', 3),
         ms_ops.NotAny: _not_any1,


### PR DESCRIPTION
Closes #613 

Fixes bug that generated a different hash when comparing MSSQL and BigQuery. The coalesce() function was returning a unicode value and it has been updated to use isnull() instead.