### PR TITLE
fix: bare data-validation command throws exception

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -141,7 +141,8 @@ CONNECTION_SOURCE_FIELDS = {
 def get_parsed_args():
     """Return ArgParser with configured CLI arguments."""
     parser = configure_arg_parser()
-    return parser.parse_args()
+    args = None if sys.argv[1:] else ["--help"]
+    return parser.parse_args(args)
 
 
 def configure_arg_parser():

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -141,7 +141,7 @@ CONNECTION_SOURCE_FIELDS = {
 def get_parsed_args():
     """Return ArgParser with configured CLI arguments."""
     parser = configure_arg_parser()
-    args = None if sys.argv[1:] else ["--help"]
+    args = ["--help"] if len(sys.argv) == 1 else None
     return parser.parse_args(args)
 
 


### PR DESCRIPTION
Closes issue #596 
* Prints data-validation --help output when bare data-validation command is executed. 