### PR TITLE
feat: extend TO_CHAR to cover date, time and timestamp types

### DIFF
--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -33,7 +33,7 @@ import ibis.expr.rules as rlz
 from data_validation.clients import _raise_missing_client_error
 from ibis_bigquery.compiler import reduction as bq_reduction, BigQueryExprTranslator
 from ibis.expr.operations import Arg, Comparison, Reduction, ValueOp
-from ibis.expr.types import BinaryValue, IntegerColumn, StringValue, NumericValue
+from ibis.expr.types import BinaryValue, IntegerColumn, StringValue, NumericValue, TemporalValue
 from ibis.backends.impala.compiler import ImpalaExprTranslator
 from ibis.backends.pandas import client as _pandas_client
 from ibis.backends.base_sqlalchemy.alchemy import AlchemyExprTranslator
@@ -67,7 +67,7 @@ class HashBytes(ValueOp):
     output_type = rlz.shape_like("arg", "binary")
 
 class ToChar(ValueOp):
-    arg = Arg(rlz.one_of([rlz.value(dt.Decimal), rlz.value(dt.float64)]))
+    arg = Arg(rlz.one_of([rlz.value(dt.Decimal), rlz.value(dt.float64), rlz.value(dt.Date), rlz.value(dt.Time), rlz.value(dt.Timestamp)]))
     fmt = Arg(rlz.string)
     output_type = rlz.shape_like("arg", dt.string)
 

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -209,6 +209,7 @@ StringValue.hash = compile_hash
 BinaryValue.hashbytes = compile_hashbytes
 StringValue.hashbytes = compile_hashbytes
 NumericValue.to_char = compile_to_char
+TemporalValue.to_char = compile_to_char
 BigQueryExprTranslator._registry[BitXor] = bq_reduction("BIT_XOR")
 BigQueryExprTranslator._registry[Hash] = format_hash_bigquery
 BigQueryExprTranslator._registry[HashBytes] = format_hashbytes_bigquery


### PR DESCRIPTION
feat: extend TO_CHAR to cover date, time and timestamp field types

The change made for https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/623 only applies to Decimal and float values (see code changes below). Extending this to date, time and timestamp.

Sundar Mudupalli