### PR TITLE
fix: Making primary key compulsory for Custom Query Row Validation

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -585,6 +585,7 @@ def _configure_custom_query_parser(custom_query_parser):
         "--primary-keys",
         "-pk",
         help="Comma separated list of primary key columns 'col_a,col_b'",
+        required=True,
     )
     custom_query_parser.add_argument(
         "--wildcard-include-string-len",

--- a/third_party/ibis/ibis_oracle/client.py
+++ b/third_party/ibis/ibis_oracle/client.py
@@ -264,10 +264,15 @@ class OracleClient(alch.AlchemyClient):
 
     def _get_schema_using_query(self, limited_query):
         type_map = {
+            "DB_TYPE_CHAR": "string",
+            "DB_TYPE_LONG": "string",
             "DB_TYPE_NVARCHAR": "string",
             "DB_TYPE_VARCHAR": "string",
             "DB_TYPE_TIMESTAMP": "timestamp",
-            "DB_TYPE_DATE": "timestamp"
+            "DB_TYPE_DATE": "timestamp",
+            "DB_TYPE_BOOLEAN": "boolean",
+            "DB_TYPE_BINARY_DOUBLE": "float64",
+            "DB_TYPE_BINARY_FLOAT": "float64",
         }
 
         with self._execute(limited_query, results=True) as cur:


### PR DESCRIPTION
* fix: Making primary key compulsory for Custom Query Row Validation (#670) 

* Adding more datatype support for oracle custom query row validation. 