### PR TITLE
feat: added run_id to output 

### DIFF
--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -144,7 +144,6 @@ COLUMN_FILTER_LIST = [
     "end_time",
     "labels",
     "pct_threshold",
-    "run_id",
     "start_time",
     "target_table_name",
     "target_column_name",

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -153,7 +153,6 @@ COLUMN_FILTER_LIST = [
     "num_random_rows",
 ]
 SCHEMA_VALIDATION_COLUMN_FILTER_LIST = [
-    "run_id",
     "start_time",
     "end_time",
     "aggregation_type",


### PR DESCRIPTION
Closes issues #686

- Added run_id to final result so that user doesn't need to go into BQ and search the execution results to find the appropriate run_id