### PR TITLE
feat: Divert cast of PostgreSQL decimal with scale>0 to to_char

### DIFF
--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -220,11 +220,12 @@ def sa_cast_postgres(t, expr):
         #     100.00
         # This doesn't match most engines which would return "100".
         # Using to_char() function instead of cast to return a more typical value.
+        # We've wrapped to_char in rtrim(".") due to whole numbers having a trailing ".".
         # Would have liked to use trim_scale but this is only available in PostgreSQL 13+
         #     return (sa.cast(sa.func.trim_scale(sa_arg), sa_type))
         precision = arg.type().precision or 38
         fmt = "FM" + ("9" * (precision - arg.type().scale)) + "." + ("9" * arg.type().scale)
-        return sa.func.to_char(sa_arg, fmt)
+        return sa.func.rtrim(sa.func.to_char(sa_arg, fmt), ".")
 
     if arg.type().equals(dt.binary) and typ.equals(dt.string):
         return sa.func.encode(sa_arg, 'escape')


### PR DESCRIPTION
Example of PostgreSQL default CAST behaviour (note the unnecessary `.00`):

```
# SELECT CAST(CAST(100 AS DECIMAL(5,2)) AS VARCHAR(10));
 varchar
---------
 100.00
```

Most other engines would return a string of `'100'` from the above operation.

This change overrides the PostgreSQL `cast()` function in `third_party/ibis/ibis_addon/operations.py`. The new code diverts the operation to `rtrim(to_char(),'.')` for `Decimal` columns with a scale > 0. The example about then looks like this:

```
# SELECT RTRIM(TO_CHAR(CAST(100 AS DECIMAL(5,2)),'FM999.99'),'.');
 rtrim
-------
 100
```