### PR TITLE
fix: Protect non-date columns from astype(str) date workaround

### DIFF
--- a/data_validation/data_validation.py
+++ b/data_validation/data_validation.py
@@ -18,6 +18,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import ibis.backends.pandas
+import ibis.expr.datatypes as dt
 import numpy
 import pandas
 
@@ -254,16 +255,22 @@ class DataValidation(object):
             }
             validation_builder.add_filter(filter_field)
 
-    @classmethod
-    def _get_pandas_schema(self, source_df, target_df, join_on_fields, verbose=False):
-        """Return a pandas schema which aligns source and targe for joins."""
-        # TODO(dhercher): We are experiencing issues around datetime coming as sring and not matching
-        # currently the hack to cast it to string works, but is not ideal.
-        # We should look at both types, and if 1 is
-        # date-like than use pandas.to_datetime on the other.
-        for join_on_field in join_on_fields:
-            source_df[join_on_field] = source_df[join_on_field].astype(str)
-            target_df[join_on_field] = target_df[join_on_field].astype(str)
+    def _get_pandas_schema(
+        self,
+        source_df: pandas.core.frame.DataFrame,
+        target_df: pandas.core.frame.DataFrame,
+        join_on_schema: dict,
+        verbose=False,
+    ):
+        """Return a pandas schema which aligns source and target for joins."""
+        for join_on_field in join_on_schema:
+            if isinstance(join_on_schema[join_on_field], (dt.Date, dt.Timestamp)):
+                # TODO(dhercher): We are experiencing issues around datetime coming as string
+                # and not matching. Currently the hack to cast it to string works, but is not ideal.
+                # We should look at both types, and if one is
+                # date-like than use pandas.to_datetime on the other.
+                source_df[join_on_field] = source_df[join_on_field].astype(str)
+                target_df[join_on_field] = target_df[join_on_field].astype(str)
 
         # Loop over index keys() instead of iteritems() because pandas is
         # failing with datetime64[ns, UTC] data type on Python 3.9.
@@ -327,8 +334,9 @@ class DataValidation(object):
                 source_df = futures[0].result()
                 target_df = futures[1].result()
 
+            join_on_schema = {_: source_query.schema()[_] for _ in join_on_fields}
             pd_schema = self._get_pandas_schema(
-                source_df, target_df, join_on_fields, verbose=self.verbose
+                source_df, target_df, join_on_schema, verbose=self.verbose
             )
 
             pandas_client = ibis.backends.pandas.connect(

--- a/data_validation/data_validation.py
+++ b/data_validation/data_validation.py
@@ -255,8 +255,9 @@ class DataValidation(object):
             }
             validation_builder.add_filter(filter_field)
 
+    @classmethod
     def _get_pandas_schema(
-        self,
+        cls,
         source_df: pandas.core.frame.DataFrame,
         target_df: pandas.core.frame.DataFrame,
         join_on_schema: dict,

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -508,8 +508,9 @@ def test_data_validation_client(module_under_test, fs):
 
 def test_get_pandas_schema(module_under_test):
     """Test extracting pandas schema from dataframes for Ibis Pandas."""
-    client = module_under_test.DataValidation(SAMPLE_CONFIG)
-    pandas_schema = client._get_pandas_schema(SOURCE_DF, SOURCE_DF, JOIN_ON_DATE_FIELDS)
+    pandas_schema = module_under_test.DataValidation._get_pandas_schema(
+        SOURCE_DF, SOURCE_DF, JOIN_ON_DATE_FIELDS
+    )
 
     assert (pandas_schema.index == NON_OBJECT_FIELDS).all()
 

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -18,6 +18,8 @@ import pytest
 import random
 from datetime import datetime, timedelta
 
+import ibis.expr.datatypes as dt
+
 from data_validation import consts
 
 
@@ -425,7 +427,7 @@ SOURCE_QUERY_DATA = [
     }
 ]
 SOURCE_DF = pandas.DataFrame(SOURCE_QUERY_DATA)
-JOIN_ON_FIELDS = ["date"]
+JOIN_ON_DATE_FIELDS = {"date": dt.Date()}
 NON_OBJECT_FIELDS = pandas.Index(["int_val", "double_val"])
 
 RANDOM_STRINGS = ["a", "b", "c", "d"]
@@ -506,9 +508,8 @@ def test_data_validation_client(module_under_test, fs):
 
 def test_get_pandas_schema(module_under_test):
     """Test extracting pandas schema from dataframes for Ibis Pandas."""
-    pandas_schema = module_under_test.DataValidation._get_pandas_schema(
-        SOURCE_DF, SOURCE_DF, JOIN_ON_FIELDS
-    )
+    client = module_under_test.DataValidation(SAMPLE_CONFIG)
+    pandas_schema = client._get_pandas_schema(SOURCE_DF, SOURCE_DF, JOIN_ON_DATE_FIELDS)
 
     assert (pandas_schema.index == NON_OBJECT_FIELDS).all()
 


### PR DESCRIPTION
There is a workaround related to joining source and target data frames on date based columns. The workaround turns join columns in both source and target data frames to strings before combining them to create a final report.

Unfortunately this workaround was also converting numeric columns to string which was causing problems with trailing zeros after the decimal place. A join on the numeric would ignore these, a join on strings of `1` and `1.0` was a mismatch.

This change modifies the existing workaround to only be active when the join column in the source schema is date based.