### PR TITLE
feat: :sparkles: Add support for source/target inline sql queries for `validate custom-query` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,14 @@ data-validation (--verbose or -v) (--log-level or -ll) validate custom-query col
   --target-conn or -tc TARGET_CONN
                         Target connection details
                         See: *Connections* section for each data source
+  --source-query SOURCE_QUERY, -sq SOURCE_QUERY
+                        Source sql query
+                        Either --source-query or --source-query-file must be provided
   --source-query-file  SOURCE_QUERY_FILE, -sqf SOURCE_QUERY_FILE
                         File containing the source sql commands
+  --target-query TARGET_QUERY, -tq TARGET_QUERY
+                        Target sql query
+                        Either --target-query or --target-query-file must be provided
   --target-query-file TARGET_QUERY_FILE, -tqf TARGET_QUERY_FILE
                         File containing the target sql commands
   [--count COLUMNS]     Comma separated list of columns for count or * for all columns
@@ -336,8 +342,14 @@ data-validation (--verbose or -v) (--log-level or -ll) validate custom-query row
   --target-conn or -tc TARGET_CONN
                         Target connection details
                         See: *Connections* section for each data source
+  --source-query SOURCE_QUERY, -sq SOURCE_QUERY
+                        Source sql query
+                        Either --source-query or --source-query-file must be provided
   --source-query-file SOURCE_QUERY_FILE, -sqf SOURCE_QUERY_FILE
                         File containing the source sql commands
+  --target-query TARGET_QUERY, -tq TARGET_QUERY
+                        Target sql query
+                        Either --target-query or --target-query-file must be provided
   --target-query-file TARGET_QUERY_FILE, -tqf TARGET_QUERY_FILE
                         File containing the target sql commands
   --comparison-fields or -comp-fields FIELDS

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -181,10 +181,22 @@ def build_config_from_args(args: Namespace, config_manager: ConfigManager):
     if config_manager.validation_type == consts.CUSTOM_QUERY:
         config_manager.append_custom_query_type(args.custom_query_type)
 
-        source_query_str = config_manager.get_query_from_file(args.source_query_file)
+        # Get source sql query from source sql file or inline query
+        if args.source_query:
+            source_query_str = config_manager.get_query_from_inline(args.source_query)
+        else:
+            source_query_str = config_manager.get_query_from_file(
+                args.source_query_file
+            )
         config_manager.append_source_query(source_query_str)
 
-        target_query_str = config_manager.get_query_from_file(args.target_query_file)
+        # Get target sql query from target sql file or inline query
+        if args.target_query:
+            target_query_str = config_manager.get_query_from_inline(args.target_query)
+        else:
+            target_query_str = config_manager.get_query_from_file(
+                args.target_query_file
+            )
         config_manager.append_target_query(target_query_str)
 
         # For custom-query column command

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -624,22 +624,40 @@ def _configure_custom_query_row_parser(custom_query_row_parser):
         "required arguments"
     )
     required_arguments.add_argument(
-        "--source-query-file",
-        "-sqf",
-        required=True,
-        help="File containing the source sql query",
-    )
-    required_arguments.add_argument(
-        "--target-query-file",
-        "-tqf",
-        required=True,
-        help="File containing the target sql query",
-    )
-    required_arguments.add_argument(
         "--primary-keys",
         "-pk",
         required=True,
         help="Comma separated list of primary key columns 'col_a,col_b'",
+    )
+
+    # Group for mutually exclusive source query arguments. Either must be supplied
+    source_mutually_exclusive = required_arguments.add_mutually_exclusive_group(
+        required=True
+    )
+    source_mutually_exclusive.add_argument(
+        "--source-query-file",
+        "-sqf",
+        help="File containing the source sql query",
+    )
+    source_mutually_exclusive.add_argument(
+        "--source-query",
+        "-sq",
+        help="Source sql query",
+    )
+
+    # Group for mutually exclusive target query arguments. Either must be supplied
+    target_mutually_exclusive = required_arguments.add_mutually_exclusive_group(
+        required=True
+    )
+    target_mutually_exclusive.add_argument(
+        "--target-query-file",
+        "-tqf",
+        help="File containing the target sql query",
+    )
+    target_mutually_exclusive.add_argument(
+        "--target-query",
+        "-tq",
+        help="Target sql query",
     )
 
     # Group for mutually exclusive required arguments. Either must be supplied
@@ -741,17 +759,35 @@ def _configure_custom_query_column_parser(custom_query_column_parser):
     required_arguments = custom_query_column_parser.add_argument_group(
         "required arguments"
     )
-    required_arguments.add_argument(
+
+    # Group for mutually exclusive source query arguments. Either must be supplied
+    source_mutually_exclusive = required_arguments.add_mutually_exclusive_group(
+        required=True
+    )
+    source_mutually_exclusive.add_argument(
         "--source-query-file",
         "-sqf",
-        required=True,
         help="File containing the source sql query",
     )
-    required_arguments.add_argument(
+    source_mutually_exclusive.add_argument(
+        "--source-query",
+        "-sq",
+        help="Source sql query",
+    )
+
+    # Group for mutually exclusive target query arguments. Either must be supplied
+    target_mutually_exclusive = required_arguments.add_mutually_exclusive_group(
+        required=True
+    )
+    target_mutually_exclusive.add_argument(
         "--target-query-file",
         "-tqf",
-        required=True,
         help="File containing the target sql query",
+    )
+    target_mutually_exclusive.add_argument(
+        "--target-query",
+        "-tq",
+        help="Target sql query",
     )
 
     _add_common_arguments(optional_arguments, required_arguments)

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -843,3 +843,15 @@ class ConfigManager(object):
             )
         file.close()
         return query
+
+    def get_query_from_inline(self, inline_query):
+        """Return query from inline query arg"""
+
+        query = inline_query.rstrip(";\n")
+
+        if not query or query.isspace():
+            raise ValueError(
+                "Expected arg with sql query, got empty arg or arg with white spaces. "
+                f"input query: {query}"
+            )
+        return query

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -864,11 +864,12 @@ class ConfigManager(object):
     def get_query_from_inline(self, inline_query):
         """Return query from inline query arg"""
 
-        query = inline_query.rstrip(";\n")
+        query = inline_query.strip()
+        query = query.rstrip(";\n")
 
         if not query or query.isspace():
             raise ValueError(
-                "Expected arg with sql query, got empty arg or arg with white spaces. "
-                f"input query: {query}"
+                "Expected arg with sql query, got empty arg or arg with white "
+                f"spaces. input query: '{inline_query}'"
             )
         return query

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -426,9 +426,14 @@ data-validation validate custom-query column \
   --max num_bikes_available
 ````
 
-#### Run a custom query column validation with inline source/target query
+#### Run a custom query column validation using inline source/target query
 ````shell script
-data-validation validate custom-query column -sc my_bq_conn -tc my_bq_conn --source-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' --target-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' --count bikeid,gender
+data-validation validate custom-query column \
+  -sc my_bq_conn \
+  -tc my_bq_conn \
+  --source-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' \
+  --target-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' \
+  --count bikeid,gender
 ````
 
 #### Run a custom query row validation

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -309,6 +309,11 @@ data-validation validate custom-query column --source-query-file source_query.sq
 data-validation validate custom-query column --source-query-file source_query.sql --target-query-file target_query.sql -sc my_bq_conn -tc my_bq_conn --max num_bikes_available
 ````
 
+#### Run a custom query column validation with inline source/target query
+````shell script
+data-validation validate custom-query column -sc my_bq_conn -tc my_bq_conn --source-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' --target-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' --count bikeid,gender
+````
+
 #### Run a custom query row validation
 ````shell script
 data-validation validate custom-query row --source-query-file source_query.sql --target-query-file target_query.sql -sc my_bq_conn -tc my_bq_conn --hash '*' --primary-keys station_id


### PR DESCRIPTION
Add support for source/target inline sql queries for `validate custom-query` command
### Example:
```
data-validation validate custom-query column \
-sc my_bq_conn \
-tc my_bq_conn \
--source-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' \
--target-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' \
--count bikeid,gender
```

### User can also use combination of both `sql file` and `inline query`

### Example
```
data-validation validate custom-query column \
-sc my_bq_conn \
-tc my_bq_conn \
--source-query 'select bikeid, gender from bigquery-public-data.new_york_citibike.citibike_trips' \
--target-query-file target_query.sql \
--count bikeid,gender
```

### User can validate using these 4 combinations:
1. Supply `--source-query` and `--target-query`
2. Supply `--source-query` and `--target-query-file`
3. Supply `--source-query-file` and `--target-query`
4. Supply `--source-query-file` and `--target-query-file`