### PR TITLE
fix: Better detection of Oracle client

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -715,9 +715,16 @@ class ConfigManager(object):
     def _strftime_format(
         self, column_type: Union[dt.Date, dt.Timestamp], client
     ) -> str:
+        def is_oracle_client(client):
+            # When no Oracle client installed clients.OracleClient is not a class
+            try:
+                return isinstance(client, clients.OracleClient)
+            except TypeError:
+                return False
+
         if isinstance(column_type, dt.Timestamp):
             return "%Y-%m-%d %H:%M:%S"
-        if isinstance(client, clients.OracleClient):
+        if is_oracle_client(client):
             # Oracle DATE is a DateTime
             return "%Y-%m-%d %H:%M:%S"
         return "%Y-%m-%d"


### PR DESCRIPTION
Better detection of OracleClient when `cx-Oracle` is not installed, protecting from:
```
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```