### PR TITLE
fix: Protect column and row validation calculated column names from Oracle 30 character identifier limit

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -126,6 +126,14 @@ def get_pandas_client(table_name, file_path, file_type):
     return pandas_client
 
 
+def is_oracle_client(client):
+    try:
+        return isinstance(client, OracleClient)
+    except TypeError:
+        # When no Oracle client has been installed OracleClient is not a class
+        return False
+
+
 def get_ibis_table(client, schema_name, table_name, database_name=None):
     """Return Ibis Table for Supplied Client.
 
@@ -251,6 +259,21 @@ def get_data_client(connection_config):
         raise exceptions.DataClientConnectionFailure(msg)
 
     return data_client
+
+
+def get_max_column_length(client):
+    """Return the max column length supported by client.
+
+    client (IbisClient): Client to use for tables
+    """
+    if is_oracle_client(client):
+        # We can't reliably know which Version class client.version is stored in
+        # because it is out of our control. Therefore using string identification
+        # of Oracle <= 12.1 to avoid exceptions of this nature:
+        #  TypeError: '<' not supported between instances of 'Version' and 'Version'
+        if str(client.version)[:2] in ["10", "11"] or str(client.version)[:4] == "12.1":
+            return 30
+    return 128
 
 
 CLIENT_LOOKUP = {

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -64,6 +64,7 @@ class ConfigManager(object):
         self.verbose = verbose
         if self.validation_type not in consts.CONFIG_TYPES:
             raise ValueError(f"Unknown Configuration Type: {self.validation_type}")
+        self._comparison_max_col_length = None
 
     @property
     def config(self):
@@ -712,19 +713,35 @@ class ConfigManager(object):
 
         return calculated_config
 
+    @staticmethod
+    def _is_oracle_client(client):
+        try:
+            return isinstance(client, clients.OracleClient)
+        except TypeError:
+            # When no Oracle client installed clients.OracleClient is not a class
+            return False
+
+    def _get_comparison_max_col_length(self):
+        def max_length(client):
+            if self._is_oracle_client(client):
+                # We can't reliably know which Version class client.version is stored in
+                # because it is out of our control. Therefore using string identification
+                # of Oracle <= 12.1 to avoid exceptions of this nature:
+                #  TypeError: '<' not supported between instances of 'Version' and 'Version'
+                if str(client.version)[:2] in ["10", "11"] or str(client.version)[:4] == "12.1":
+                    return 30
+            return 128
+
+        if not self._comparison_max_col_length:
+            self._comparison_max_col_length = min([max_length(self.source_client), max_length(self.target_client)])
+        return self._comparison_max_col_length
+
     def _strftime_format(
         self, column_type: Union[dt.Date, dt.Timestamp], client
     ) -> str:
-        def is_oracle_client(client):
-            # When no Oracle client installed clients.OracleClient is not a class
-            try:
-                return isinstance(client, clients.OracleClient)
-            except TypeError:
-                return False
-
         if isinstance(column_type, dt.Timestamp):
             return "%Y-%m-%d %H:%M:%S"
-        if is_oracle_client(client):
+        if self._is_oracle_client(client):
             # Oracle DATE is a DateTime
             return "%Y-%m-%d %H:%M:%S"
         return "%Y-%m-%d"
@@ -820,14 +837,15 @@ class ConfigManager(object):
                 column_aliases[name] = i
                 col_names.append(col)
             else:
-                for (
-                    column
-                ) in (
-                    previous_level
-                ):  # this needs to be the previous manifest of columns
+                # This needs to be the previous manifest of columns
+                for j, column in enumerate(previous_level):
+                    calc_col_name = f"{calc}__{column}"
+                    if len(calc_col_name) > self._get_comparison_max_col_length():
+                        # Use an abstract name for the calculated column to avoid composing invalid SQL
+                        calc_col_name = f"{calc}__dvt_calc_col_{j}"
                     col = {}
                     col["reference"] = [column]
-                    col["name"] = f"{calc}__" + column
+                    col["name"] = calc_col_name
                     col["calc_type"] = calc
                     col["depth"] = i
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -380,3 +380,46 @@ def test_custom_query_get_query_from_inline(module_under_test):
             "Expected arg with sql query, got empty arg or arg "
             "with white spaces. input query: ' '"
         )
+
+
+def test__get_comparison_max_col_length(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+    max_identifier_length = config_manager._get_comparison_max_col_length()
+    assert isinstance(max_identifier_length, int)
+    short_itentifier = "id"
+    too_long_itentifier = "a_long_column_name".ljust(max_identifier_length + 1, "_")
+    nearly_too_long_itentifier = "another_long_column_name".ljust(
+        max_identifier_length - 1, "_"
+    )
+    assert len(short_itentifier) < max_identifier_length
+    assert len(too_long_itentifier) > max_identifier_length
+    assert len(nearly_too_long_itentifier) < max_identifier_length
+    new_identifier = config_manager._prefix_calc_col_name(
+        short_itentifier, "prefix", 900
+    )
+    assert (
+        len(short_itentifier) <= max_identifier_length
+    ), f"Column name is too long: {new_identifier}"
+    assert (
+        "900" not in new_identifier
+    ), f"Column name should NOT contain ID 900: {new_identifier}"
+    new_identifier = config_manager._prefix_calc_col_name(
+        too_long_itentifier, "prefix", 901
+    )
+    assert (
+        len(new_identifier) <= max_identifier_length
+    ), f"Column name is too long: {new_identifier}"
+    assert (
+        "901" in new_identifier
+    ), f"Column name should contain ID 901: {new_identifier}"
+    new_identifier = config_manager._prefix_calc_col_name(
+        nearly_too_long_itentifier, "prefix", 902
+    )
+    assert (
+        len(new_identifier) <= max_identifier_length
+    ), f"Column name is too long: {new_identifier}"
+    assert (
+        "902" in new_identifier
+    ), f"Column name should contain ID 902: {new_identifier}"


### PR DESCRIPTION
This protects all engines not just Oracle 12.1 and below. It's just that Oracle 12.1 and below have a 30 character limit which we almost always cross for row validation. Other engines have a 128 character identifier limit and therefore are less likely to be breached.

This PR introduces the following change:

1. Identify the maximum identifier length for both source and target engines and take the lowest one as the ceiling for the validation.
2. When prefixing a column alias with an operation, such as sum__, ifnull__ etc, we compare the length of the resulting name with the maximum length.
3. If the new name breaches the maximum then a simplified alias is used. The simplified alias uses the column position in place of its name.
4. This has been done for both concat/hash row validation and aggregate column validation.
5. I've added unit tests for the name shortening logic.
6. Ideally we could do with adding integration tests for Oracle 11g, I think this can happen outside of this issue.

Example of column validation SQL from new logic:
```
SELECT count(:count_1) AS count
, max(t0.id) AS max__id
, max(t0.col_dec_long_123456789012345) AS max__dvt_calc_col_1
, max(t0.length__dvt_calc_col_4) AS max__length__dvt_calc_col_4
FROM (
  SELECT t1.id AS id
  , t1.col_dec_long_123456789012345 AS col_dec_long_123456789012345
  , t1.col_dec2_long_123456789012345 AS col_dec2_long_123456789012345
  , t1.col_date_long_1234567890 AS col_date_long_1234567890
  , t1.col_string_long_1234567890 AS col_string_long_1234567890
  , length(t1.col_string_long_1234567890) AS length__dvt_calc_col_4
  FROM dvt_test.tab_long_cols t1
) t0
```

Note that:

- `length__dvt_calc_col_4` is introduced at depth 1 because the length of `length__col_string_long_1234567890` would cross 30 characters
- The `max__` alias is then applied to the length column at depth 0: `max__length__dvt_calc_col_4`
- The `max__` alias is applied to the decimal column at depth 0 because the length of `max__col_dec_long_123456789012345` would cross 30 characters
- `max__id` is unaffected because it remains below 30 characters

The same logic would be seen in a row validation too but more functions are applied so we're more likely to see `dvt_calc_col` columns. It's worth pointing out that this is only visible in the SQL statement, the end report still uses proper column names.