### PR TITLE
fix: schema validation fixes for Oracle/SQL Server float64 and SQL Server datetimeoffset

### DIFF
--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -211,8 +211,6 @@ def test_schema_validation_core_types(mock_conn):
     assert len(config_managers) == 1
     config_manager = config_managers[0]
     validator = data_validation.DataValidation(config_manager.config, verbose=False)
-    # TODO When issue-764 is complete remove the return statement below.
-    return
     df = validator.execute()
     # With filter on failures the data frame should be empty
     assert len(df) == 0

--- a/third_party/ibis/ibis_oracle/client.py
+++ b/third_party/ibis/ibis_oracle/client.py
@@ -50,6 +50,11 @@ def sa_oracle_NUMBER(_, satype, nullable=True):
     return dt.Decimal(satype.precision, satype.scale, nullable=nullable)
 
 
+@dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.BINARY_DOUBLE)
+def sa_oracle_BINARY_DOUBLE(_, satype, nullable=True):
+    return dt.Float64(nullable=nullable)
+
+
 @dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.BFILE)
 def sa_oracle_BFILE(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
@@ -69,13 +74,16 @@ def sa_oracle_DATE(_, satype, nullable=True):
 def sa_oracle_VARCHAR(_, satype, nullable=True):
     return dt.String(nullable=nullable)
 
+
 @dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.VARCHAR2)
 def sa_oracle_VARCHAR2(_, satype, nullable=True):
     return dt.String(nullable=nullable)
 
+
 @dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.TIMESTAMP)
 def sa_oracle_TIMESTAMP(_, satype, nullable=True):
     return dt.Timestamp(nullable=nullable)
+
 
 class OracleTable(alch.AlchemyTable):
     pass
@@ -244,7 +252,7 @@ class OracleClient(alch.AlchemyClient):
 
     def get_schema(self, name, schema=None):
         return self.table(name, schema=schema).schema()
-    
+
     def sql(self, query):
         """
         Convert a Oracle query to an Ibis table expression
@@ -267,7 +275,7 @@ class OracleClient(alch.AlchemyClient):
             "DB_TYPE_NVARCHAR": "string",
             "DB_TYPE_VARCHAR": "string",
             "DB_TYPE_TIMESTAMP": "timestamp",
-            "DB_TYPE_DATE": "timestamp"
+            "DB_TYPE_DATE": "timestamp",
         }
 
         with self._execute(limited_query, results=True) as cur:
@@ -283,5 +291,5 @@ class OracleClient(alch.AlchemyClient):
                 else:
                     ibis_datatype = type_map[row[1].name]
                 ibis_types.append(ibis_datatype)
-                
+
         return sch.Schema(names, ibis_types)


### PR DESCRIPTION
This PR fixes two issues:

- https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/783
- https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/764

I included issue 764 in the same changes because it was preventing me from enabling unit tests for the issue 783 changes.

The fixes are:

- Oracle BINARY_FLOAT is identified as Float64 (not Float32)
- SQL Server FLOAT is identified as Float64 (not Float32)
- SQL Server DATETIMEOFFSET is identified as Timestamp(UTC) (previously threw an exception)

I couldn't think of a way to add unit tests for these changes because it seemed to me like it needs a SQL engine connection to test. Therefore I've relied upon integration tests.