### PR TITLE
feat: Add Impala flags for http_transport and http_path

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -144,6 +144,8 @@ CONNECTION_SOURCE_FIELDS = {
             "Size of the connection pool. Typically this is not necessary to configure. (default is 8)",
         ],
         ["hdfs_client", "An existing HDFS client"],
+        ["use_http_transport", "Boolean if HTTP proxy is provided (default is False)"],
+        ["http_path", "URL path of HTTP proxy"],
     ],
     "DB2": [
         ["host", "Desired DB2 host"],

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -333,7 +333,7 @@ Please note AlloyDB supports same connection config as Postgres.
     "port": 10000,
     "database": "default",
     "auth-mechanism": "PLAIN",
-    
+
     # (Optional)
     "use-ssl": False,
     "timeout": 45,
@@ -343,7 +343,7 @@ Please note AlloyDB supports same connection config as Postgres.
     "pool-size": 10,
     "hdfs-client": "hdfs-client",
     "use-http-transport": False,
-    "http_path": None,
+    "http-path": "",
 }
 ```
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -333,6 +333,7 @@ Please note AlloyDB supports same connection config as Postgres.
     "port": 10000,
     "database": "default",
     "auth-mechanism": "PLAIN",
+    
     # (Optional)
     "use-ssl": False,
     "timeout": 45,
@@ -340,7 +341,9 @@ Please note AlloyDB supports same connection config as Postgres.
     "user": "user",
     "password": "password",
     "pool-size": 10,
-    "hdfs-client": "hdfs-client"
+    "hdfs-client": "hdfs-client",
+    "use-http-transport": False,
+    "http_path": None,
 }
 ```
 


### PR DESCRIPTION
- Adds support for optional flags `use_http_transport` and `http_path` for Impala/Hive connections
- Documents flags