### PR TITLE
test: Add cross engine tests using BigQuery target

### DIFF
--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -166,7 +166,7 @@ def test_column_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # Hive tests are really slow so I've excluded --min below assuming that --max is effectively the same test.
     # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
-    # TODO Change --sum and --max options to include col_char_2 when issue-XXX is complete.
+    # TODO Change --sum and --max options to include col_char_2 when issue-842 is complete.
     args = parser.parse_args(
         [
             "validate",

--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -113,7 +113,7 @@ def test_schema_validation_core_types_to_bigquery():
                 # Hive decimals that map to BigQuery NUMERIC.
                 "decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
                 # Hive decimals that map to BigQuery BIGNUMERIC.
-                # This is incorrect and needs an issue raising.
+                # When issue-839 is resolved we need to edit the line below as appropriate.
                 "decimal(38,0):decimal(38,9),"
                 # BigQuery does not have a float32 type.
                 "float32:float64"

--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -72,7 +72,12 @@ def mock_get_connection_config(*args):
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_schema_validation_core_types():
+def disabled_test_schema_validation_core_types():
+    """
+    Disabled this test in favour of test_schema_validation_core_types_to_bigquery().
+    The Hive integration tests are too slow and timing out but I believe
+    test_column_validation_core_types_to_bigquery() will cover off most of what this test does.
+    """
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [
@@ -133,7 +138,12 @@ def test_schema_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_column_validation_core_types():
+def disabled_test_column_validation_core_types():
+    """
+    Disabled this test in favour of test_column_validation_core_types_to_bigquery().
+    The Hive integration tests are too slow and timing out but I believe
+    test_column_validation_core_types_to_bigquery() will cover off most of what this test does.
+    """
     parser = cli_tools.configure_arg_parser()
     # Hive tests are really slow so I've excluded --min below assuming that --max is
     # effectively the same test when comparing an engine back to itself.
@@ -192,7 +202,12 @@ def test_column_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_row_validation_core_types():
+def disabled_test_row_validation_core_types():
+    """
+    Disabled this test in favour of test_row_validation_core_types_to_bigquery().
+    The Hive integration tests are too slow and timing out but I believe
+    test_column_validation_core_types_to_bigquery() will cover off most of what this test does.
+    """
     parser = cli_tools.configure_arg_parser()
     # TODO Change --hash option to * below when issue-765 is complete.
     args = parser.parse_args(

--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 from data_validation import __main__ as main
 from data_validation import cli_tools, data_validation, consts
+from tests.system.data_sources.test_bigquery import BQ_CONN
 
 
 HIVE_HOST = os.getenv("HIVE_HOST", "localhost")
@@ -60,11 +61,18 @@ def test_count_validator():
     assert df["source_agg_value"][0] == df["target_agg_value"][0]
 
 
+def mock_get_connection_config(*args):
+    if args[1] in ("hive-conn", "mock-conn"):
+        return CONN
+    elif args[1] == "bq-conn":
+        return BQ_CONN
+
+
 @mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
-    return_value=CONN,
+    new=mock_get_connection_config,
 )
-def test_schema_validation_core_types(mock_conn):
+def test_schema_validation_core_types():
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [
@@ -87,9 +95,45 @@ def test_schema_validation_core_types(mock_conn):
 
 @mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
-    return_value=CONN,
+    new=mock_get_connection_config,
 )
-def test_column_validation_core_types(mock_conn):
+def test_schema_validation_core_types_to_bigquery():
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "schema",
+            "-sc=hive-conn",
+            "-tc=bq-conn",
+            "-tbls=pso_data_validator.dvt_core_types",
+            "--filter-status=fail",
+            (
+                # All Hive integrals go to BigQuery INT64.
+                "--allow-list=int8:int64,int16:int64,int32:int64,"
+                # Hive decimals that map to BigQuery NUMERIC.
+                "decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
+                # Hive decimals that map to BigQuery BIGNUMERIC.
+                # This is incorrect and needs an issue raising.
+                "decimal(38,0):decimal(38,9),"
+                # BigQuery does not have a float32 type.
+                "float32:float64"
+            ),
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_core_types():
     parser = cli_tools.configure_arg_parser()
     # Hive tests are really slow so I've excluded --min below assuming that --max is
     # effectively the same test when comparing an engine back to itself.
@@ -116,9 +160,39 @@ def test_column_validation_core_types(mock_conn):
 
 @mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
-    return_value=CONN,
+    new=mock_get_connection_config,
 )
-def test_row_validation_core_types(mock_conn):
+def test_column_validation_core_types_to_bigquery():
+    parser = cli_tools.configure_arg_parser()
+    # Hive tests are really slow so I've excluded --min below assuming that --max is effectively the same test.
+    # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
+    # TODO Change --sum and --max options to include col_char_2 when issue-XXX is complete.
+    args = parser.parse_args(
+        [
+            "validate",
+            "column",
+            "-sc=hive-conn",
+            "-tc=bq-conn",
+            "-tbls=pso_data_validator.dvt_core_types",
+            "--filter-status=fail",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_string,col_date,col_datetime,col_tstz",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_string,col_date,col_datetime,col_tstz",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_core_types():
     parser = cli_tools.configure_arg_parser()
     # TODO Change --hash option to * below when issue-765 is complete.
     args = parser.parse_args(
@@ -131,6 +205,35 @@ def test_row_validation_core_types(mock_conn):
             "--primary-keys=id",
             "--filter-status=fail",
             "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_core_types_to_bigquery():
+    parser = cli_tools.configure_arg_parser()
+    # TODO Change --hash option to include col_date,col_datetime,col_tstz when issue-765 is complete.
+    # TODO Change --hash string below to include col_float32,col_float64 when issue-XXX is complete.
+    args = parser.parse_args(
+        [
+            "validate",
+            "row",
+            "-sc=hive-conn",
+            "-tc=bq-conn",
+            "-tbls=pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_varchar_30,col_char_2,col_string",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -223,7 +223,7 @@ def test_row_validation_core_types():
 def test_row_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # TODO Change --hash option to include col_date,col_datetime,col_tstz when issue-765 is complete.
-    # TODO Change --hash string below to include col_float32,col_float64 when issue-XXX is complete.
+    # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [
             "validate",

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -227,8 +227,8 @@ def test_row_validation_core_types():
     new=mock_get_connection_config,
 )
 def test_row_validation_core_types_to_bigquery():
-    # TODO Change --hash string below to include col_tstz when issue-XXX is complete.
-    # TODO Change --hash string below to include col_float32,col_float64 when issue-XXX is complete.
+    # TODO Change --hash string below to include col_tstz when issue-706 is complete.
+    # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -117,7 +117,7 @@ def test_schema_validation_core_types_to_bigquery():
                 # Oracle NUMBERS that map to BigQuery NUMERIC.
                 "decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
                 # Oracle NUMBERS that map to BigQuery BIGNUMERIC.
-                # This is incorrect and needs an issue raising.
+                # When issue-839 is resolved we need to edit the line below as appropriate.
                 "decimal(38,0):decimal(38,9),"
                 # BigQuery does not have a float32 type.
                 "float32:float64"

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -170,7 +170,7 @@ def test_column_validation_core_types():
 def test_column_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # TODO Change --sum string below to include col_datetime and col_tstz when issue-762 is complete.
-    # TODO Change --min/max strings below to include col_tstz when issue-XXX is complete.
+    # TODO Change --min/max strings below to include col_tstz when issue-706 is complete.
     # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
     args = parser.parse_args(
         [

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -383,31 +383,3 @@ def test_row_validation_core_types_to_bigquery():
     df = validator.execute()
     # With filter on failures the data frame should be empty
     assert len(df) == 0
-
-
-@mock.patch(
-    "data_validation.state_manager.StateManager.get_connection_config",
-    new=mock_get_connection_config,
-)
-def test_row_validation_core_types_to_bigquery():
-    parser = cli_tools.configure_arg_parser()
-    # TODO Change --hash string below to include col_tstz when issue-706 is complete.
-    args = parser.parse_args(
-        [
-            "validate",
-            "row",
-            "-sc=pg-conn",
-            "-tc=bq-conn",
-            "-tbls=pso_data_validator.dvt_core_types",
-            "--primary-keys=id",
-            "--filter-status=fail",
-            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime",
-        ]
-    )
-    config_managers = main.build_config_managers_from_args(args)
-    assert len(config_managers) == 1
-    config_manager = config_managers[0]
-    validator = data_validation.DataValidation(config_manager.config, verbose=False)
-    df = validator.execute()
-    # With filter on failures the data frame should be empty
-    assert len(df) == 0

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -363,7 +363,7 @@ def test_row_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # TODO When issue-834 is complete add col_string to --hash string below.
     # TODO Change --hash string below to include col_tstz when issue-XXX is complete.
-    # TODO Change --hash string below to include col_float32,col_float64 when issue-XXX is complete.
+    # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [
             "validate",

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -270,6 +270,8 @@ def test_schema_validation_core_types_to_bigquery():
 )
 def test_column_validation_core_types():
     parser = cli_tools.configure_arg_parser()
+    # TODO When issue-832 is complete add col_varchar_30,col_char_2,col_string to --sum/min/max strings below.
+    # TODO When issue-833 is complete add col_datetime,col_tstz to --sum string below.
     args = parser.parse_args(
         [
             "validate",
@@ -278,9 +280,9 @@ def test_column_validation_core_types():
             "-tc=mock-conn",
             "-tbls=pso_data_validator.dvt_core_types",
             "--filter-status=fail",
-            "--sum=*",
-            "--min=*",
-            "--max=*",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_date",
+            "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_date,col_datetime,col_tstz",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_date,col_datetime,col_tstz",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -245,7 +245,7 @@ def test_schema_validation_core_types_to_bigquery():
                 # SQL Server decimals that map to BigQuery NUMERIC.
                 "decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
                 # SQL Server decimals that map to BigQuery BIGNUMERIC.
-                # This is incorrect and needs an issue raising.
+                # When issue-839 is resolved we need to edit the line below as appropriate.
                 "decimal(38,0):decimal(38,9),"
                 # BigQuery does not have a float32 type.
                 "float32:float64,"

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -303,7 +303,7 @@ def test_column_validation_core_types_to_bigquery():
     # TODO When issue-832 is complete add col_varchar_30,col_char_2,col_string to --sum/min/max strings below.
     # TODO When issue-833 is complete add col_datetime,col_tstz to --sum string below.
     # TODO When issue-XXX is complete add col_dec_10_2,col_dec_20,col_dec_38 to --sum/min/max strings below.
-    # TODO Change --min/max strings below to include col_tstz when issue-XXX is complete.
+    # TODO Change --min/max strings below to include col_tstz when issue-706 is complete.
     # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
     args = parser.parse_args(
         [
@@ -362,7 +362,7 @@ def test_row_validation_core_types():
 def test_row_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # TODO When issue-834 is complete add col_string to --hash string below.
-    # TODO Change --hash string below to include col_tstz when issue-XXX is complete.
+    # TODO Change --hash string below to include col_tstz when issue-706 is complete.
     # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [
@@ -374,6 +374,34 @@ def test_row_validation_core_types_to_bigquery():
             "--primary-keys=id",
             "--filter-status=fail",
             "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_varchar_30,col_char_2,col_date,col_datetime",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_core_types_to_bigquery():
+    parser = cli_tools.configure_arg_parser()
+    # TODO Change --hash string below to include col_tstz when issue-706 is complete.
+    args = parser.parse_args(
+        [
+            "validate",
+            "row",
+            "-sc=pg-conn",
+            "-tc=bq-conn",
+            "-tbls=pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 from data_validation import __main__ as main
 from data_validation import cli_tools, data_validation, consts
+from tests.system.data_sources.test_bigquery import BQ_CONN
 
 
 TERADATA_USER = os.getenv("TERADATA_USER", "udf")
@@ -192,11 +193,18 @@ def test_row_validator():
     assert df["validation_status"][0] == "success"
 
 
+def mock_get_connection_config(*args):
+    if args[1] in ("td-conn", "mock-conn"):
+        return CONN
+    elif args[1] == "bq-conn":
+        return BQ_CONN
+
+
 @mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
-    return_value=CONN,
+    new=mock_get_connection_config,
 )
-def test_schema_validation_core_types(mock_conn):
+def test_schema_validation_core_types():
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [
@@ -219,11 +227,47 @@ def test_schema_validation_core_types(mock_conn):
 
 @mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
-    return_value=CONN,
+    new=mock_get_connection_config,
 )
-def test_column_validation_core_types(mock_conn):
+def test_schema_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
-    # TODO Add col_datetime,col_tstz to --sum string below when issue-762 is complete. Or change whole string to * if YYY is also complete.
+    args = parser.parse_args(
+        [
+            "validate",
+            "schema",
+            "-sc=td-conn",
+            "-tc=bq-conn",
+            "-tbls=udf.dvt_core_types=pso_data_validator.dvt_core_types",
+            "--filter-status=fail",
+            (
+                # Teradata integrals go to BigQuery INT64.
+                "--allow-list=int8:int64,int16:int64,"
+                # Teradata NUMBERS that map to BigQuery NUMERIC.
+                #"decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
+                # When fix issue 838 then uncomment line above and remove line below.
+                "float64:decimal(38,9),"
+                # Teradata NUMBERS that map to BigQuery BIGNUMERIC.
+                # When issue-839 is resolved we need to edit the line below as appropriate.
+                "decimal(38,0):decimal(38,9)"
+            ),
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_core_types():
+    parser = cli_tools.configure_arg_parser()
+    # TODO Add col_datetime,col_tstz to --sum string below when issue-762 is complete.
     args = parser.parse_args(
         [
             "validate",
@@ -248,9 +292,39 @@ def test_column_validation_core_types(mock_conn):
 
 @mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
-    return_value=CONN,
+    new=mock_get_connection_config,
 )
-def test_row_validation_core_types(mock_conn):
+def test_column_validation_core_types_to_bigquery():
+    parser = cli_tools.configure_arg_parser()
+    # TODO Add col_datetime,col_tstz to --sum string below when issue-762 is complete.
+    # TODO Add col_dec_20,col_dec_38,col_dec_10_2 to --sum/min/max string below when issue-838 is complete.
+    args = parser.parse_args(
+        [
+            "validate",
+            "column",
+            "-sc=td-conn",
+            "-tc=bq-conn",
+            "-tbls=udf.dvt_core_types=pso_data_validator.dvt_core_types",
+            "--filter-status=fail",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date",
+            "--min=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_core_types():
     parser = cli_tools.configure_arg_parser()
     # Excluded col_string because LONG VARCHAR column causes exception regardless of column contents:
     # [Error 3798] A column or character expression is larger than the max size.
@@ -264,6 +338,37 @@ def test_row_validation_core_types(mock_conn):
             "--primary-keys=id",
             "--filter-status=fail",
             "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_date,col_datetime,col_tstz",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_core_types_to_bigquery():
+    parser = cli_tools.configure_arg_parser()
+    # Excluded col_string because LONG VARCHAR column causes exception regardless of column contents:
+    # [Error 3798] A column or character expression is larger than the max size.
+    # TODO Change --hash option to include col_tstz when issue-706 is complete.
+    # TODO Change --hash option to include col_float32,col_float64 when issue-XXX is complete.
+    args = parser.parse_args(
+        [
+            "validate",
+            "row",
+            "-sc=td-conn",
+            "-tc=bq-conn",
+            "-tbls=udf.dvt_core_types=pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_varchar_30,col_char_2,col_date,col_datetime",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -358,7 +358,7 @@ def test_row_validation_core_types_to_bigquery():
     # Excluded col_string because LONG VARCHAR column causes exception regardless of column contents:
     # [Error 3798] A column or character expression is larger than the max size.
     # TODO Change --hash option to include col_tstz when issue-706 is complete.
-    # TODO Change --hash option to include col_float32,col_float64 when issue-XXX is complete.
+    # TODO Change --hash option to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [
             "validate",

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -243,7 +243,7 @@ def test_schema_validation_core_types_to_bigquery():
                 # Teradata integrals go to BigQuery INT64.
                 "--allow-list=int8:int64,int16:int64,"
                 # Teradata NUMBERS that map to BigQuery NUMERIC.
-                #"decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
+                # "decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
                 # When fix issue 838 then uncomment line above and remove line below.
                 "float64:decimal(38,9),"
                 # Teradata NUMBERS that map to BigQuery BIGNUMERIC.


### PR DESCRIPTION
Prior to this PR all integration tests validate an engine with itself. This is good for proving things like data type and function coverage but doesn't ensure end-to-end comparisons are good.

Based on the assumption that BigQuery is our most mature engine support then we've decided to add cross engine comparisons for other engines to BigQuery. If they all match BigQuery then they should all match each other.

We've used our CORE_DVT_TYPES test table for these comparisons. There will be a requirement for some other cross engine tests, for example for engine specific data types that are not covered by our CORE_DVT_TYPES test table. These can come later via different issues. 

It is worth noting that the addition of 3 new Hive tests caused the integration tests to hit the 2 hour timeout. Because of this I've disabled the original Hive to Hive integration tests in favour of the new Hive to BigQuery versions. This is not ideal because there are a small number of columns excluded from the Hive to BigQuery tests that are no longer tested. Happy to take guidance on any better solution.

I've spun a number of new issues out of this work and left comments in the new tests where workarounds have been implemented.