### PR TITLE
feat: Add support for SQL Server's IMAGE, BINARY, VARBINARY, NCHAR, NTEXT, NVARCHAR data types (#858)

### DIFF
--- a/third_party/ibis/ibis_mssql/client.py
+++ b/third_party/ibis/ibis_mssql/client.py
@@ -70,6 +70,21 @@ def sa_image(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.NCHAR)
+def sa_nchar(_, satype, nullable=True):
+    return dt.String(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.NTEXT)
+def sa_ntext(_, satype, nullable=True):
+    return dt.String(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.NVARCHAR)
+def sa_nvarchar(_, satype, nullable=True):
+    return dt.String(nullable=nullable)
+
+
 class MSSQLTable(alch.AlchemyTable):
     pass
 

--- a/third_party/ibis/ibis_mssql/client.py
+++ b/third_party/ibis/ibis_mssql/client.py
@@ -55,6 +55,11 @@ def sa_money(_, satype, nullable=True):
     return dt.Int64(nullable=nullable)
 
 
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.IMAGE)
+def sa_image(_, satype, nullable=True):
+    return dt.Binary(nullable=nullable)
+
+
 class MSSQLTable(alch.AlchemyTable):
     pass
 

--- a/third_party/ibis/ibis_mssql/client.py
+++ b/third_party/ibis/ibis_mssql/client.py
@@ -55,6 +55,16 @@ def sa_money(_, satype, nullable=True):
     return dt.Int64(nullable=nullable)
 
 
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.BINARY)
+def sa_binary(_, satype, nullable=True):
+    return dt.Binary(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.VARBINARY)
+def sa_varbinary(_, satype, nullable=True):
+    return dt.Binary(nullable=nullable)
+
+
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.IMAGE)
 def sa_image(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -489,6 +489,7 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
     _registry = _operation_registry
     _rewrites = alch.AlchemyExprTranslator._rewrites.copy()
     _type_map = alch.AlchemyExprTranslator._type_map.copy()
+    # only used to map SQLAlchemy types back to SQL Server types, it does not add support to new data types, for that go to client.py
     _type_map.update(
         {
             dt.Boolean: mssql.BIT,
@@ -498,15 +499,6 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
             dt.Float: mssql.REAL,
             dt.Double: mssql.REAL,
             dt.String: mssql.VARCHAR,
-            dt.Int64: mssql.MONEY,
-            # Unicode character strings
-            dt.String: mssql.NCHAR,
-            dt.String: mssql.NTEXT,
-            dt.String: mssql.NVARCHAR,
-            # Binary string
-            dt.Binary: mssql.BINARY,
-            dt.Binary: mssql.IMAGE,
-            dt.Binary: mssql.VARBINARY, 
         }
     )
 

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -499,6 +499,7 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
             dt.Double: mssql.REAL,
             dt.String: mssql.VARCHAR,
             dt.Int64: mssql.MONEY,
+            dt.Binary: mssql.IMAGE,
         }
     )
 

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -499,7 +499,14 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
             dt.Double: mssql.REAL,
             dt.String: mssql.VARCHAR,
             dt.Int64: mssql.MONEY,
+            # Unicode character strings
+            dt.String: mssql.NCHAR,
+            dt.String: mssql.NTEXT,
+            dt.String: mssql.NVARCHAR,
+            # Binary string
+            dt.Binary: mssql.BINARY,
             dt.Binary: mssql.IMAGE,
+            dt.Binary: mssql.VARBINARY, 
         }
     )
 


### PR DESCRIPTION
Related to #858: adding some of the missing data types such as IMAGE, BINARY, VARBINARY, NCHAR, NTEXT, NVARCHAR