### PR TITLE
feat: [ON HOLD] Add support to other missing SQL Server data types - check list on commit 

### DIFF
--- a/third_party/ibis/ibis_mssql/client.py
+++ b/third_party/ibis/ibis_mssql/client.py
@@ -55,6 +55,7 @@ def sa_money(_, satype, nullable=True):
     return dt.Int64(nullable=nullable)
 
 
+<<<<<<< HEAD
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.BINARY)
 def sa_binary(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
@@ -65,11 +66,14 @@ def sa_varbinary(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
+=======
+>>>>>>> feat: Add support for SQL Server's IMAGE data type (#858)
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.IMAGE)
 def sa_image(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
+<<<<<<< HEAD
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.NCHAR)
 def sa_nchar(_, satype, nullable=True):
     return dt.String(nullable=nullable)
@@ -85,6 +89,8 @@ def sa_nvarchar(_, satype, nullable=True):
     return dt.String(nullable=nullable)
 
 
+=======
+>>>>>>> feat: Add support for SQL Server's IMAGE data type (#858)
 class MSSQLTable(alch.AlchemyTable):
     pass
 

--- a/third_party/ibis/ibis_mssql/client.py
+++ b/third_party/ibis/ibis_mssql/client.py
@@ -80,6 +80,16 @@ def sa_image(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.CHAR)
+def sa_char(_, satype, nullable=True):
+    return dt.String(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.TEXT)
+def sa_text(_, satype, nullable=True):
+    return dt.String(nullable=nullable)
+
+
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.NCHAR)
 def sa_nchar(_, satype, nullable=True):
     return dt.String(nullable=nullable)
@@ -104,11 +114,7 @@ def sa_nvarchar(_, satype, nullable=True):
     dt.Timestamp: mssql.DATETIME2,
     dt.Timestamp: mssql.DATETIME,
     dt.Timestamp: mssql.SMALLDATETIME,
-    dt.Time: mssql.TIME,
-    # Character string
-    dt.String: mssql.CHAR,
-    dt.String: mssql.TEXT,
-    dt.String: mssql.VARCHAR,     
+    dt.Time: mssql.TIME,  
 """    
 
 

--- a/third_party/ibis/ibis_mssql/client.py
+++ b/third_party/ibis/ibis_mssql/client.py
@@ -31,18 +31,23 @@ import pyodbc  # NOQA fail early if the driver is missing
 
 
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.UNIQUEIDENTIFIER)
-def sa_string(_, satype, nullable=True):
-    return dt.String(nullable=nullable)
+def sa_uuid(_, satype, nullable=True):
+    return dt.UUID()(nullable=nullable)
 
 
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.BIT)
-def sa_boolean(_, satype, nullable=True):
+def sa_bit(_, satype, nullable=True):
     return dt.Boolean(nullable=nullable)
 
 
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.DATETIMEOFFSET)
 def sa_timestamp_tz(_, satype, nullable=True):
     return dt.Timestamp("UTC", nullable=nullable)
+
+
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.TIMESTAMP)
+def sa_timestamp(_, satype, nullable=True):
+    return dt.Binary(nullable=nullable)
 
 
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.FLOAT)
@@ -55,7 +60,11 @@ def sa_money(_, satype, nullable=True):
     return dt.Int64(nullable=nullable)
 
 
-<<<<<<< HEAD
+@dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.SMALLMONEY)
+def sa_smallmoney(_, satype, nullable=True):
+    return dt.Int32(nullable=nullable)
+
+
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.BINARY)
 def sa_binary(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
@@ -66,14 +75,11 @@ def sa_varbinary(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
-=======
->>>>>>> feat: Add support for SQL Server's IMAGE data type (#858)
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.IMAGE)
 def sa_image(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
-<<<<<<< HEAD
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.NCHAR)
 def sa_nchar(_, satype, nullable=True):
     return dt.String(nullable=nullable)
@@ -89,8 +95,6 @@ def sa_nvarchar(_, satype, nullable=True):
     return dt.String(nullable=nullable)
 
 
-=======
->>>>>>> feat: Add support for SQL Server's IMAGE data type (#858)
 class MSSQLTable(alch.AlchemyTable):
     pass
 

--- a/third_party/ibis/ibis_mssql/client.py
+++ b/third_party/ibis/ibis_mssql/client.py
@@ -31,8 +31,8 @@ import pyodbc  # NOQA fail early if the driver is missing
 
 
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.UNIQUEIDENTIFIER)
-def sa_uuid(_, satype, nullable=True):
-    return dt.UUID()(nullable=nullable)
+def sa_uniqueidentifier(_, satype, nullable=True):
+    return dt.String(nullable=nullable)
 
 
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.BIT)
@@ -51,7 +51,7 @@ def sa_timestamp(_, satype, nullable=True):
 
 
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.FLOAT)
-def sa_float64(_, satype, nullable=True):
+def sa_float(_, satype, nullable=True):
     return dt.Float64(nullable=nullable)
 
 
@@ -93,6 +93,23 @@ def sa_ntext(_, satype, nullable=True):
 @dt.dtype.register(MSDialect_pyodbc, sa.dialects.mssql.NVARCHAR)
 def sa_nvarchar(_, satype, nullable=True):
     return dt.String(nullable=nullable)
+
+
+"""     
+    TODO(issue-858): Check the mapping below before adding register
+    dt.Decimal: mssql.DECIMAL,
+    dt.Decimal: mssql.NUMERIC,
+    # Date and time
+    dt.Date: mssql.DATE,
+    dt.Timestamp: mssql.DATETIME2,
+    dt.Timestamp: mssql.DATETIME,
+    dt.Timestamp: mssql.SMALLDATETIME,
+    dt.Time: mssql.TIME,
+    # Character string
+    dt.String: mssql.CHAR,
+    dt.String: mssql.TEXT,
+    dt.String: mssql.VARCHAR,     
+"""    
 
 
 class MSSQLTable(alch.AlchemyTable):

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -492,7 +492,6 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
     # only used to map SQLAlchemy types back to SQL Server types, it does not add support to new data types, for that go to client.py
     _type_map.update(
         {
-            # Exact numerics
             dt.Boolean: mssql.BIT,
             dt.Int8: mssql.TINYINT,
             dt.Int16: mssql.SMALLINT,
@@ -502,7 +501,7 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
             dt.Double: mssql.REAL,
             dt.String: mssql.VARCHAR,
         }
-)
+    )
 
 
 rewrites = MSSQLExprTranslator.rewrites

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -498,18 +498,9 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
             dt.Int16: mssql.SMALLINT,
             dt.Int32: mssql.INTEGER,
             dt.Int64: mssql.BIGINT,
-            dt.Float16: mssql.FLOAT,
-            dt.Float32: mssql.FLOAT,
-            dt.Float64: mssql.REAL,
-            dt.Int64: mssql.MONEY,
-            # Unicode character strings
-            dt.String: mssql.NCHAR,
-            dt.String: mssql.NTEXT,
-            dt.String: mssql.NVARCHAR,
-            # Binary string
-            dt.Binary: mssql.BINARY,
-            dt.Binary: mssql.IMAGE,
-            dt.Binary: mssql.VARBINARY, 
+            dt.Float: mssql.REAL,
+            dt.Double: mssql.REAL,
+            dt.String: mssql.VARCHAR,
         }
 )
 

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -502,26 +502,14 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
             dt.Float32: mssql.FLOAT,
             dt.Float64: mssql.REAL,
             dt.Int64: mssql.MONEY,
-            dt.Decimal: mssql.DECIMAL,
-            dt.Decimal: mssql.NUMERIC,
-            dt.Int16: mssql.SMALLINT,
-            dt.Int32: mssql.SMALLMONEY, 
-            # Date and time
-            dt.Date: mssql.DATE,
-            dt.Timestamp: mssql.DATETIME2,
-            dt.Timestamp: mssql.DATETIME,
-            dt.Timestamp: mssql.DATETIMEOFFSET,
-            dt.Timestamp: mssql.SMALLDATETIME,
-            dt.Time: mssql.TIME,
-            # Character string
-            dt.String: mssql.CHAR,
-            dt.String: mssql.TEXT,
-            dt.String: mssql.VARCHAR,
             # Unicode character strings
             dt.String: mssql.NCHAR,
             dt.String: mssql.NTEXT,
             dt.String: mssql.NVARCHAR,
-            dt.String: mssql.VARCHAR,
+            # Binary string
+            dt.Binary: mssql.BINARY,
+            dt.Binary: mssql.IMAGE,
+            dt.Binary: mssql.VARBINARY, 
         }
 )
 

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -494,10 +494,14 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
         {
             dt.Boolean: mssql.BIT,
             dt.Int8: mssql.TINYINT,
+            dt.Int16: mssql.SMALLINT,
             dt.Int32: mssql.INTEGER,
+            dt.Int32: mssql.INT,
             dt.Int64: mssql.BIGINT,
-            dt.Float: mssql.REAL,
-            dt.Double: mssql.REAL,
+            dt.Float16: mssql.FLOAT,
+            dt.Float32: mssql.FLOAT,
+            dt.Float64: mssql.REAL, 
+            dt.String: mssql.NVARCHAR,
             dt.String: mssql.VARCHAR,
         }
     )

--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -492,19 +492,38 @@ class MSSQLExprTranslator(alch.AlchemyExprTranslator):
     # only used to map SQLAlchemy types back to SQL Server types, it does not add support to new data types, for that go to client.py
     _type_map.update(
         {
+            # Exact numerics
             dt.Boolean: mssql.BIT,
             dt.Int8: mssql.TINYINT,
             dt.Int16: mssql.SMALLINT,
             dt.Int32: mssql.INTEGER,
-            dt.Int32: mssql.INT,
             dt.Int64: mssql.BIGINT,
             dt.Float16: mssql.FLOAT,
             dt.Float32: mssql.FLOAT,
-            dt.Float64: mssql.REAL, 
+            dt.Float64: mssql.REAL,
+            dt.Int64: mssql.MONEY,
+            dt.Decimal: mssql.DECIMAL,
+            dt.Decimal: mssql.NUMERIC,
+            dt.Int16: mssql.SMALLINT,
+            dt.Int32: mssql.SMALLMONEY, 
+            # Date and time
+            dt.Date: mssql.DATE,
+            dt.Timestamp: mssql.DATETIME2,
+            dt.Timestamp: mssql.DATETIME,
+            dt.Timestamp: mssql.DATETIMEOFFSET,
+            dt.Timestamp: mssql.SMALLDATETIME,
+            dt.Time: mssql.TIME,
+            # Character string
+            dt.String: mssql.CHAR,
+            dt.String: mssql.TEXT,
+            dt.String: mssql.VARCHAR,
+            # Unicode character strings
+            dt.String: mssql.NCHAR,
+            dt.String: mssql.NTEXT,
             dt.String: mssql.NVARCHAR,
             dt.String: mssql.VARCHAR,
         }
-    )
+)
 
 
 rewrites = MSSQLExprTranslator.rewrites


### PR DESCRIPTION
Closes #858 -> Added types: SMALLINT, TIMESTAMP, SMALLMONEY,

In progress: DECIMAL, NUMERIC,  DATE, DATETIME2, DATETIME, DATETIMEOFFSEST, SMALLDATETIME, TIME, CHAR, TEXT