### PR TITLE
Support periods in connection names

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -49,10 +49,10 @@ import json
 import logging
 import sys
 import uuid
-from typing import List, Dict
 from argparse import Namespace
+from typing import Dict, List
 
-from data_validation import consts, state_manager, clients
+from data_validation import clients, consts, state_manager
 
 CONNECTION_SOURCE_FIELDS = {
     "BigQuery": [

--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -80,7 +80,7 @@ class StateManager(object):
         """Returns a list of the connection names that exist."""
         file_names = self._list_directory(self._get_connections_directory())
         return [
-            file_name.split(".")[0]
+            file_name.rsplit(".", 2)[0]
             for file_name in file_names
             if file_name.endswith(".connection.json")
         ]


### PR DESCRIPTION
Split connection names from second last period instead of from the first one when listing connections.