### PR TITLE
fix: Add missing operations for SQL Server - ExtractEpochSeconds, ExtractDayOfYear, ExtractWeekOfYear

### DIFF
--- a/third_party/ibis/ibis_mssql/compiler.py
+++ b/third_party/ibis/ibis_mssql/compiler.py
@@ -377,23 +377,6 @@ def _string_join(t, expr):
     return sa.func.concat(*map(t.translate, elements))
 
 
-def _timestamp_truncate(t, op):
-    arg = t.translate(op.arg)
-    unit = op.unit.short
-    if unit not in _truncate_precisions:
-        raise com.UnsupportedOperationError(f'Unsupported truncate unit {op.unit!r}')
-
-    return sa.func.datetrunc(sa.text(_truncate_precisions[unit]), arg)
-
-
-def _timestamp_from_unix(x, unit='s'):
-    if unit == 's':
-        return sa.func.dateadd(sa.text('s'), x, '1970-01-01 00:00:00')
-    if unit == 'ms':
-        return sa.func.dateadd(sa.text('s'), x / 1_000, '1970-01-01 00:00:00')
-    raise com.UnsupportedOperationError(f"{unit!r} unit is not supported!")
-
-
 _operation_registry = alch._operation_registry.copy()
 
 _operation_registry.update(
@@ -450,12 +433,6 @@ _operation_registry.update(
             ),
             1,
         ),
-        ops.TimestampFromUNIX: lambda t, op: _timestamp_from_unix(
-            t.translate(op.arg), op.unit.short
-        ),
-        ops.TimestampTruncate: _timestamp_truncate,
-        ops.DateTruncate: _timestamp_truncate,
-        ops.Hash: unary(sa.func.checksum),
         # newly added
         ops.Lag: _lag,
         ops.Lead: _lead,


### PR DESCRIPTION
Closes #869 

/gcbrun