### PR TITLE
fix: Adding enhancements to allow-list in schema validation

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -314,6 +314,7 @@ class ConfigManager(object):
 
     def append_allow_list(self, allow_list):
         """Append allow_list of datatype to existing config."""
+        allow_list = allow_list.replace(" ", "")
         self._config[consts.CONFIG_ALLOW_LIST] = allow_list
 
     def get_source_ibis_table(self):

--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -146,15 +146,11 @@ def schema_validation_matching(
             elif (
                 string_val(source_field_type) in allow_list_map
                 and string_val(target_field_type)
-                == allow_list_map[string_val(source_field_type)]
+                in allow_list_map[string_val(source_field_type)]
             ):
 
-                allowed_target_field_type = allow_list_map[
-                    string_val(source_field_type)
-                ]
-
                 (higher_precision, lower_precision,) = parse_n_validate_datatypes(
-                    string_val(source_field_type), allowed_target_field_type
+                    string_val(source_field_type), string_val(target_field_type)
                 )
                 if lower_precision:
                     results.append(
@@ -219,7 +215,7 @@ def schema_validation_matching(
             )
     return results
 
-
+# Converting allow list from string to map, to ease validation.
 def parse_allow_list(st):
     output = {}
     stack = []
@@ -227,12 +223,13 @@ def parse_allow_list(st):
     for i in range(len(st)):
         if st[i] == ":":
             key = "".join(stack)
-            output[key] = None
+            if key not in output:
+                output[key] = []
             stack = []
             continue
         if st[i] == "," and not st[i + 1].isdigit():
             value = "".join(stack)
-            output[key] = value
+            output[key].append(value)
             stack = []
             i += 1
             continue

--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -215,6 +215,7 @@ def schema_validation_matching(
             )
     return results
 
+
 # Converting allow list from string to map, to ease validation.
 def parse_allow_list(st):
     output = {}

--- a/tests/unit/test_schema_validation.py
+++ b/tests/unit/test_schema_validation.py
@@ -141,6 +141,7 @@ def _get_fake_json_data(data):
 def test_import(module_under_test):
     assert True
 
+
 # Basic unit test  for schema validation.
 def test_schema_validation_matching(module_under_test):
     source_fields = {"FIELD1": "string", "fiEld2": "datetime", "field3": "string"}
@@ -180,6 +181,7 @@ def test_schema_validation_matching(module_under_test):
         source_fields, target_fields, [], ""
     )
 
+
 # Unit test adding validation for exclusion columns in schema validation.
 def test_schema_validation_matching_exclusion_columns(module_under_test):
     source_fields = {"FIELD1": "string", "fiEld2": "datetime", "field3": "string"}
@@ -212,6 +214,7 @@ def test_schema_validation_matching_exclusion_columns(module_under_test):
     assert expected_results == module_under_test.schema_validation_matching(
         source_fields, target_fields, ["field2"], ""
     )
+
 
 # Testing for allow list functionality, covers allowing multiple vallues for a same datatype.
 def test_schema_validation_matching_allowlist_columns(module_under_test):

--- a/tests/unit/test_schema_validation.py
+++ b/tests/unit/test_schema_validation.py
@@ -141,7 +141,7 @@ def _get_fake_json_data(data):
 def test_import(module_under_test):
     assert True
 
-
+# Basic unit test  for schema validation.
 def test_schema_validation_matching(module_under_test):
     source_fields = {"FIELD1": "string", "fiEld2": "datetime", "field3": "string"}
     target_fields = {"field1": "string", "field2": "timestamp", "field_3": "string"}
@@ -180,7 +180,7 @@ def test_schema_validation_matching(module_under_test):
         source_fields, target_fields, [], ""
     )
 
-
+# Unit test adding validation for exclusion columns in schema validation.
 def test_schema_validation_matching_exclusion_columns(module_under_test):
     source_fields = {"FIELD1": "string", "fiEld2": "datetime", "field3": "string"}
     target_fields = {"field1": "string", "field2": "timestamp", "field_3": "string"}
@@ -211,6 +211,77 @@ def test_schema_validation_matching_exclusion_columns(module_under_test):
 
     assert expected_results == module_under_test.schema_validation_matching(
         source_fields, target_fields, ["field2"], ""
+    )
+
+# Testing for allow list functionality, covers allowing multiple vallues for a same datatype.
+def test_schema_validation_matching_allowlist_columns(module_under_test):
+    source_fields = {
+        "FIELD1": "string",
+        "fiEld2": "datetime",
+        "field3": "decimal(38, 0)",
+        "field4": "int32",
+        "field5": "decimal(38,0)",
+        "field6": "int64",
+    }
+    target_fields = {
+        "field1": "string",
+        "field2": "timestamp",
+        "field3": "int64",
+        "field4": "int64",
+        "field5": "decimal(1000,0)",
+        "field6": "int32",
+    }
+
+    expected_results = [
+        [
+            "field1",
+            "field1",
+            "string",
+            "string",
+            consts.VALIDATION_STATUS_SUCCESS,
+        ],
+        [
+            "field2",
+            "field2",
+            "datetime",
+            "timestamp",
+            consts.VALIDATION_STATUS_FAIL,
+        ],
+        [
+            "field3",
+            "field3",
+            "decimal(38,0)",
+            "int64",
+            consts.VALIDATION_STATUS_SUCCESS,
+        ],
+        [
+            "field4",
+            "field4",
+            "int32",
+            "int64",
+            consts.VALIDATION_STATUS_SUCCESS,
+        ],
+        [
+            "field5",
+            "field5",
+            "decimal(38,0)",
+            "decimal(1000,0)",
+            consts.VALIDATION_STATUS_SUCCESS,
+        ],
+        [
+            "field6",
+            "field6",
+            "int64",
+            "int32",
+            consts.VALIDATION_STATUS_FAIL,
+        ],
+    ]
+
+    assert expected_results == module_under_test.schema_validation_matching(
+        source_fields,
+        target_fields,
+        None,
+        "decimal(38,0):int64,decimal(38,0):decimal(1000,0),int32:int64",
     )
 
 


### PR DESCRIPTION
Closes #751 

Adding two enhancements to allow list in Schema Validation:
1. Removing spaces from allow-list parameter to avoid issues when matching data types during validation.
2. Adding functionality to match the same datatype in source to different datatypes in target, by changing the values in the allow list dictionary to lists instead of strings.