### PR TITLE
fix: No column filtering for csv/json text output

### DIFF
--- a/data_validation/result_handlers/text.py
+++ b/data_validation/result_handlers/text.py
@@ -36,6 +36,18 @@ class TextResultHandler(object):
         self.cols_filter_list = cols_filter_list
         self.status_list = status_list
 
+    def _get_formatted(self, result_df):
+        if self.format == "text":
+            return result_df.drop(self.cols_filter_list, axis=1).to_string(index=False)
+        elif self.format == "csv":
+            return result_df.to_csv(index=False)
+        elif self.format == "json":
+            return result_df.to_json(orient="index")
+        else:
+            return result_df.drop(self.cols_filter_list, axis=1).to_markdown(
+                tablefmt="fancy_grid", index=False
+            )
+
     def print_formatted_(self, result_df):
         """
         Utility for printing formatted results
@@ -44,18 +56,7 @@ class TextResultHandler(object):
         if self.status_list is not None:
             result_df = filter_validation_status(self.status_list, result_df)
 
-        if self.format == "text":
-            print(result_df.drop(self.cols_filter_list, axis=1).to_string(index=False))
-        elif self.format == "csv":
-            print(result_df.drop(self.cols_filter_list, axis=1).to_csv(index=False))
-        elif self.format == "json":
-            print(result_df.drop(self.cols_filter_list, axis=1).to_json(orient="index"))
-        else:
-            print(
-                result_df.drop(self.cols_filter_list, axis=1).to_markdown(
-                    tablefmt="fancy_grid", index=False
-                )
-            )
+        print(self._get_formatted(result_df))
 
         if self.format not in consts.FORMAT_TYPES:
             error_msg = (

--- a/tests/unit/result_handlers/test_text.py
+++ b/tests/unit/result_handlers/test_text.py
@@ -16,11 +16,11 @@ import pytest
 
 from pandas import DataFrame
 
-from data_validation.consts import VALIDATION_STATUS_FAIL
+from data_validation import consts
 
 SAMPLE_CONFIG = {}
 SAMPLE_CONFIG_FILTER_STATUS = [
-    VALIDATION_STATUS_FAIL,
+    consts.VALIDATION_STATUS_FAIL,
 ]
 
 SAMPLE_RESULT_DATA = [
@@ -119,3 +119,29 @@ def test_columns_to_print(module_under_test, capsys):
         .replace("╘═════╧═════╛", "")
     )
     assert printed_text == grid_text
+
+
+@pytest.mark.parametrize(
+    "format,module_under_test",
+    [
+        ("csv", None),
+        ("json", None),
+        ("text", None),
+        ("fancy_grid", None),
+    ],
+    indirect=["module_under_test"],
+)
+def test_column_filter_list(format, module_under_test):
+    """CSV and JSON don't filter out columns."""
+    result_df = DataFrame(SAMPLE_RESULT_DATA, columns=SAMPLE_RESULT_COLUMNS)
+    result_handler = module_under_test.TextResultHandler(
+        format, cols_filter_list=SAMPLE_RESULT_COLUMNS_FILTER_LIST
+    )
+    printed_output = result_handler._get_formatted(result_df)
+    print("printed_output", printed_output)
+    if format in ("csv", "json"):
+        # CSV and JSON don't filter out columns.
+        assert "validation_type" in printed_output
+    else:
+        # Other formats do filter out columns.
+        assert "validation_type" not in printed_output


### PR DESCRIPTION
Revert part of the fix for issue [753](https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/753).

The intention of 753 was to make text output consistent with the fancy_grid output but it also removed extra columns from CSV and JSON output which was a mistake. This PR reinstates those by reversing the CSV/JSON parts of this change:

https://github.com/GoogleCloudPlatform/professional-services-data-validator/commit/b92eb91feb3b4a83c6ad74c4b9c5af65dcbc21f8

