### PR TITLE
fix: Teradata NUMBER with no precision/scale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,12 +657,12 @@ required, if any, with the 'params' block as shown below:
     target_calculated_columns:
     - start_time
     type: custom
-    ibis_expr: ibis.expr.api.TimestampValue.strftime
+    ibis_expr: ibis.expr.types.TemporalValue.strftime
     params:
     - format_str: '%m%d%Y'
 ```
 
-The above block references the [TimestampValue.strftime](https://ibis-project.org/reference/expressions/timestamps/#ibis.expr.types.temporal.TemporalValue.strftime) Ibis API expression.
+The above block references the [TemporalValue.strftime](https://ibis-project.org/reference/expressions/timestamps/#ibis.expr.types.temporal.TemporalValue.strftime) Ibis API expression.
 See the [Examples page](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/docs/examples.md#sample-row-validation-yaml-with-custom-calc-field)
 for a sample YAML with a custom calculated field.
 

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -76,16 +76,33 @@ class TeradataTypeTranslator(object):
 
     @classmethod
     def to_ibis_from_N(cls, col_data, return_ibis_type=True):
-        return cls.to_ibis_from_D(col_data, return_ibis_type=return_ibis_type)
+        precision = int(
+            col_data.get("DecimalTotalDigits", col_data.get("Decimal Total Digits", 38))
+        )
+        scale = int(
+            col_data.get(
+                "DecimalFractionalDigits", col_data.get("Decimal Fractional Digits", 38)
+            )
+        )
+        if return_ibis_type:
+            # No precision or scale specified
+            if precision == -128 or scale ==-128:
+                return dt.Decimal()
+            return dt.Decimal(precision, scale)
+        
+        if precision == -128 or scale ==-128:
+            return "DECIMAL"
+        
+        return "DECIMAL(%d, %d)" % (precision, scale)
 
     @classmethod
     def to_ibis_from_D(cls, col_data, return_ibis_type=True):
         precision = int(
-            col_data.get("DecimalTotalDigits", col_data.get("Decimal Total Digits", 20))
+            col_data.get("DecimalTotalDigits", col_data.get("Decimal Total Digits", 5))
         )
         scale = int(
             col_data.get(
-                "DecimalFractionalDigits", col_data.get("Decimal Fractional Digits", 4)
+                "DecimalFractionalDigits", col_data.get("Decimal Fractional Digits", 0)
             )
         )
         if return_ibis_type:


### PR DESCRIPTION
Closes #913 

- Catches the case where precision/scale = -128 in the HELP COLUMN output, which happens when the column type is 'NUMBER' with no precision/scale in TD.
- Fixes small doc bug after Ibis upgrade