### PR TITLE
feat: Enhance validate schema to support time zoned timestamp columns

### DIFF
--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -119,6 +119,8 @@ def test_schema_validation_core_types_to_bigquery():
                 "decimal(20,0):decimal(38,9),decimal(10,2):decimal(38,9),"
                 # Hive decimals that map to BigQuery BIGNUMERIC.
                 "decimal(38,0):decimal(76,38),"
+                # Hive does not have a time zoned
+                "timestamp:timestamp('UTC'),"
                 # BigQuery does not have a float32 type.
                 "float32:float64"
             ),

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -169,7 +169,7 @@ def test_column_validation_core_types():
 def test_column_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # TODO Change --sum string below to include col_datetime and col_tstz when issue-762 is complete.
-    # TODO Change --min/max strings below to include col_tstz when issue-706 is complete.
+    # TODO Change --min/max strings below to include col_tstz when issue-917 is complete.
     # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
     args = parser.parse_args(
         [
@@ -226,7 +226,7 @@ def test_row_validation_core_types():
     new=mock_get_connection_config,
 )
 def test_row_validation_core_types_to_bigquery():
-    # TODO Change --hash string below to include col_tstz when issue-706 is complete.
+    # TODO Change --hash string below to include col_tstz when issue-917 is complete.
     # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -616,7 +616,7 @@ def test_column_validation_core_types():
 )
 def test_column_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
-    # TODO Change --min/max strings below to include col_tstz when issue-706 is complete.
+    # TODO Change --min/max strings below to include col_tstz when issue-917 is complete.
     # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
     # TODO Change --sum and --max options to include col_char_2 when issue-842 is complete.
     args = parser.parse_args(

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -569,9 +569,7 @@ def test_schema_validation_core_types_to_bigquery():
                 # Oracle NUMBERS that map to BigQuery BIGNUMERIC.
                 "decimal(38,0):decimal(76,38),"
                 # BigQuery does not have a float32 type.
-                "float32:float64,"
-                # TODO When issue-706 is complete remove the timestamp line below
-                "timestamp('UTC'):timestamp"
+                "float32:float64"
             ),
         ]
     )

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -230,7 +230,6 @@ def test_schema_validation_core_types():
 )
 def test_schema_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
-    # TODO When issue-706 is complete remove the timestamp line below
     args = parser.parse_args(
         [
             "validate",
@@ -248,7 +247,6 @@ def test_schema_validation_core_types_to_bigquery():
                 "decimal(38,0):decimal(76,38),"
                 # BigQuery does not have a float32 type.
                 "float32:float64,"
-                "timestamp('UTC'):timestamp,"
                 # Ignore ID column, we're not testing that one.
                 "!int32:int64"
             ),

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -295,7 +295,7 @@ def test_column_validation_core_types():
 )
 def test_column_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
-    # TODO Change --sum/min/max strings below to include col_tstz when issue-706 is complete.
+    # TODO Change --sum/min/max strings below to include col_tstz when issue-917 is complete.
     # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
     # We've excluded col_char_2 since the data stored in MSSQL has a trailing space which is counted in the LEN()
     args = parser.parse_args(
@@ -355,7 +355,7 @@ def test_row_validation_core_types():
 def test_row_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # TODO When issue-834 is complete add col_string to --hash string below.
-    # TODO Change --hash string below to include col_tstz when issue-706 is complete.
+    # TODO Change --hash string below to include col_tstz when issue-917 is complete.
     # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -353,7 +353,7 @@ def test_row_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # Excluded col_string because LONG VARCHAR column causes exception regardless of column contents:
     # [Error 3798] A column or character expression is larger than the max size.
-    # TODO Change --hash option to include col_tstz when issue-706 is complete.
+    # TODO Change --hash option to include col_tstz when issue-917 is complete.
     # TODO Change --hash option to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -32,6 +32,7 @@ from ibis.backends.base.sql.alchemy.registry import \
 from ibis.backends.base.sql.alchemy.translator import AlchemyExprTranslator
 from ibis.backends.base.sql.compiler.translator import ExprTranslator
 from ibis.backends.base.sql.registry import fixed_arity
+from ibis.backends.bigquery.client import _DTYPE_TO_IBIS_TYPE
 from ibis.backends.bigquery.compiler import BigQueryExprTranslator
 from ibis.backends.bigquery.registry import \
     STRFTIME_FORMAT_FUNCTIONS as BQ_STRFTIME_FORMAT_FUNCTIONS
@@ -300,6 +301,7 @@ TemporalValue.to_char = compile_to_char
 BigQueryExprTranslator._registry[HashBytes] = format_hashbytes_bigquery
 BigQueryExprTranslator._registry[RawSQL] = format_raw_sql
 BigQueryExprTranslator._registry[Strftime] = strftime_bigquery
+_DTYPE_TO_IBIS_TYPE["TIMESTAMP"] = dt.Timestamp(timezone="UTC")
 
 AlchemyExprTranslator._registry[RawSQL] = format_raw_sql
 AlchemyExprTranslator._registry[HashBytes] = format_hashbytes_alchemy

--- a/third_party/ibis/ibis_oracle/datatypes.py
+++ b/third_party/ibis/ibis_oracle/datatypes.py
@@ -40,7 +40,7 @@ class _FieldDescription(TypedDict):
     internal_size: Optional[int]
     precision: Optional[int]
     scale: Optional[int]
-    null_ok: Optional[int] 
+    null_ok: Optional[int]
 
 
 def _get_type(col: _FieldDescription) -> dt.DataType:
@@ -50,7 +50,7 @@ def _get_type(col: _FieldDescription) -> dt.DataType:
         raise NotImplementedError(
             f"Oracle type {typename} is not supported"
         )
-    
+
     if typename == cx_Oracle.DB_TYPE_NUMBER:
         if col[4] == 0 and col[5] == -127:
             # This will occur if type is NUMBER with no precision/scale
@@ -140,7 +140,10 @@ def sa_oracle_NCHAR(_, satype, nullable=True):
 
 @dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.TIMESTAMP)
 def sa_oracle_TIMESTAMP(_, satype, nullable=True):
-    return dt.Timestamp(nullable=nullable)
+    if satype.timezone:
+        return dt.Timestamp(timezone="UTC", nullable=nullable)
+    else:
+        return dt.Timestamp(nullable=nullable)
 
 @dt.dtype.register(OracleDialect_cx_oracle, sa.dialects.oracle.BLOB)
 def sa_oracle_BLOB(_, satype, nullable=True):

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -140,7 +140,7 @@ class TeradataTypeTranslator(object):
     @classmethod
     def to_ibis_from_SZ(cls, col_data, return_ibis_type=True):
         if return_ibis_type:
-            return dt.timestamp
+            return dt.timestamp(timezone="UTC")
 
         return "TIMESTAMP"
 


### PR DESCRIPTION
This check ensures all engines (where relevant) pick up the time zone for time zoned timestamp columns.
Also enabled integration tests for col_tstz columns.
There are still problems with column and row validation, this PR is only for schema validation.