### PR TITLE
feat: support timestamp aggregation for Oracle and TD

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ Below is the command syntax for column validations. To run a grouped column
 validation, simply specify the `--grouped-columns` flag.
 
 You can specify a list of string columns for aggregations in order to calculate
-an aggregation over the `length(string_col)`. Running an aggregation
+an aggregation over the `length(string_col)`. Similarly, you can specify timestamp
+columns for aggregation over the `unix_seconds(timestamp_col)`. Running an aggregation
 over all columns ('*') will only run over numeric columns, unless the
-`--wildcard-include-string-len` flag is present.
+`--wildcard-include-string-len` or `--wildcard-include-timestamp` flags are present.
 
 ```
 data-validation (--verbose or -v) (--log-level or -ll) validate column
@@ -112,6 +113,8 @@ data-validation (--verbose or -v) (--log-level or -ll) validate column
                         Service account to use for BigQuery result handler output.
   [--wildcard-include-string-len or -wis]
                         If flag is present, include string columns in aggregation as len(string_col)
+  [--wildcard-include-timestamp or -wit]
+                        If flag is present, include timestamp columns in aggregation as unix_timestamp(ts_col)
   [--cast-to-bigint or -ctb]
                         If flag is present, cast all int32 columns to int64 before aggregation
   [--filters SOURCE_FILTER:TARGET_FILTER]

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ data-validation (--verbose or -v) (--log-level or -ll) validate column
   [--wildcard-include-string-len or -wis]
                         If flag is present, include string columns in aggregation as len(string_col)
   [--wildcard-include-timestamp or -wit]
-                        If flag is present, include timestamp columns in aggregation as unix_timestamp(ts_col)
+                        If flag is present, include timestamp columns in aggregation as unix_seconds(ts_col)
   [--cast-to-bigint or -ctb]
                         If flag is present, cast all int32 columns to int64 before aggregation
   [--filters SOURCE_FILTER:TARGET_FILTER]

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -67,7 +67,6 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         "int32",
         "int64",
         "decimal",
-        "timestamp",
         "!float64",
         "!float32",
         "!int8",
@@ -75,11 +74,13 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         "!int32",
         "!int64",
         "!decimal",
-        "!timestamp",
     ]
 
     if args.wildcard_include_string_len:
-        supported_data_types.append("string")
+        supported_data_types.extend(["string", "!string"])
+
+    if args.wildcard_include_timestamp:
+        supported_data_types.extend(["timestamp", "!timestamp"])
 
     cast_to_bigint = True if args.cast_to_bigint else False
 

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -579,6 +579,12 @@ def _configure_column_parser(column_parser):
         help="Include string fields for wildcard aggregations.",
     )
     optional_arguments.add_argument(
+        "--wildcard-include-timestamp",
+        "-wit",
+        action="store_true",
+        help="Include timestamp fields for wildcard aggregations.",
+    )
+    optional_arguments.add_argument(
         "--cast-to-bigint",
         "-ctb",
         action="store_true",
@@ -784,6 +790,12 @@ def _configure_custom_query_column_parser(custom_query_column_parser):
         "-wis",
         action="store_true",
         help="Include string fields for wildcard aggregations.",
+    )
+    optional_arguments.add_argument(
+        "--wildcard-include-timestamp",
+        "-wit",
+        action="store_true",
+        help="Include timestamp fields for wildcard aggregations.",
     )
     optional_arguments.add_argument(
         "--cast-to-bigint",

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -679,7 +679,7 @@ class ConfigManager(object):
         if arg_value:
             arg_value = [x.casefold() for x in arg_value]
             if supported_types:
-                supported_types.append("string")
+                supported_types.extend(["string", "!string", "timestamp", "!timestamp"])
 
         allowlist_columns = arg_value or casefold_source_columns
         for column_position, column in enumerate(casefold_source_columns):

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -311,7 +311,7 @@ CLI_CONFIG_DIR_RUN_ARGS_LOCAL = [
 ]
 CLI_CONFIG_DIR_RUN_ARGS_GCS = ["configs", "run", "--config-dir", "gs://"]
 
-CLI_WILDCARD_STRING_ARGS = [
+CLI_WILDCARD_COLUMN_ARGS = [
     "validate",
     "column",
     "--source-conn",
@@ -323,6 +323,7 @@ CLI_WILDCARD_STRING_ARGS = [
     "--sum",
     "*",
     "--wildcard-include-string-len",
+    "--wildcard-include-timestamp",
     "--config-file",
     CLI_CONFIG_FILE,
 ]
@@ -605,9 +606,9 @@ def test_cli_store_yaml_then_run_directory_local():
 
 
 def test_wildcard_column_agg_yaml():
-    """Test storing column validation YAML with string fields."""
+    """Test storing column validation YAML with string and timestamp fields."""
     _test_cli_yaml_local_runner(
-        CLI_WILDCARD_STRING_ARGS, EXPECTED_NUM_YAML_LINES_WILDCARD
+        CLI_WILDCARD_COLUMN_ARGS, EXPECTED_NUM_YAML_LINES_WILDCARD
     )
 
 

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -188,7 +188,6 @@ def test_schema_validation_core_types_to_bigquery():
 def test_column_validation_core_types():
     """Oracle to Oracle dvt_core_types column validation"""
     parser = cli_tools.configure_arg_parser()
-    # TODO Change --sum string below to * when issue-762 is complete.
     args = parser.parse_args(
         [
             "validate",
@@ -197,7 +196,7 @@ def test_column_validation_core_types():
             "-tc=mock-conn",
             "-tbls=pso_data_validator.dvt_core_types",
             "--filter-status=fail",
-            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_dec_20,col_dec_38",
+            "--sum=*",
             "--min=*",
             "--max=*",
         ]
@@ -217,7 +216,6 @@ def test_column_validation_core_types():
 )
 def test_column_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
-    # TODO Change --sum string below to include col_datetime and col_tstz when issue-762 is complete.
     # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
     args = parser.parse_args(
         [
@@ -227,7 +225,7 @@ def test_column_validation_core_types_to_bigquery():
             "-tc=bq-conn",
             "-tbls=pso_data_validator.dvt_core_types",
             "--filter-status=fail",
-            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
             "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
             "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
         ]

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -265,7 +265,6 @@ def test_schema_validation_core_types_to_bigquery():
 )
 def test_column_validation_core_types():
     parser = cli_tools.configure_arg_parser()
-    # TODO Add col_datetime,col_tstz to --sum string below when issue-762 is complete.
     args = parser.parse_args(
         [
             "validate",
@@ -274,7 +273,7 @@ def test_column_validation_core_types():
             "-tc=mock-conn",
             "-tbls=udf.dvt_core_types",
             "--filter-status=fail",
-            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
             "--min=*",
             "--max=*",
         ]
@@ -294,7 +293,6 @@ def test_column_validation_core_types():
 )
 def test_column_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
-    # TODO Add col_datetime,col_tstz to --sum string below when issue-762 is complete.
     args = parser.parse_args(
         [
             "validate",
@@ -303,9 +301,9 @@ def test_column_validation_core_types_to_bigquery():
             "-tc=bq-conn",
             "-tbls=udf.dvt_core_types=pso_data_validator.dvt_core_types",
             "--filter-status=fail",
-            "--sum=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_dec_20,col_dec_38,col_dec_10_2",
-            "--min=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_dec_20,col_dec_38,col_dec_10_2",
-            "--max=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_dec_20,col_dec_38,col_dec_10_2",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_dec_20,col_dec_38,col_dec_10_2,col_datetime",
+            "--min=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_dec_20,col_dec_38,col_dec_10_2,col_datetime",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_dec_20,col_dec_38,col_dec_10_2,col_datetime",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/third_party/ibis/ibis_oracle/registry.py
+++ b/third_party/ibis/ibis_oracle/registry.py
@@ -391,7 +391,7 @@ def _random(t, op):
 
 def _extract_epoch(t, op):
     sub = operator.sub(sa.cast(t.translate(op.arg), sa.DATE), sa.sql.literal_column("DATE '1970-01-01'")).self_group()
-    mult = sa.cast(operator.mul(sub, sa.sql.literal_column("86400")), sa.NUMERIC)
+    mult = sa.cast(operator.mul(sub, sa.sql.literal_column("86400")), sa.dialects.oracle.NUMBER)
     return mult
 
 

--- a/third_party/ibis/ibis_oracle/registry.py
+++ b/third_party/ibis/ibis_oracle/registry.py
@@ -389,6 +389,11 @@ def _day_of_week_name(t, op):
 def _random(t, op):
     return sa.sql.literal_column("DBMS_RANDOM.VALUE")
 
+def _extract_epoch(t, op):
+    sub = operator.sub(sa.cast(t.translate(op.arg), sa.DATE), sa.sql.literal_column("DATE '1970-01-01'")).self_group()
+    mult = sa.cast(operator.mul(sub, sa.sql.literal_column("86400")), sa.NUMERIC)
+    return mult
+
 
 operation_registry.update(
     {
@@ -442,12 +447,7 @@ operation_registry.update(
         ops.ExtractDay: _extract('day'),
         ops.ExtractDayOfYear: _extract('doy'),
         ops.ExtractQuarter: _extract('quarter'),
-        ops.ExtractEpochSeconds: fixed_arity(
-            lambda x: sa.cast(
-                sa.func.datediff(sa.text('s'), '1970-01-01 00:00:00', x), sa.BIGINT
-            ),
-            1,
-        ),
+        ops.ExtractEpochSeconds: _extract_epoch,
         ops.ExtractHour: _extract('hour'),
         ops.ExtractMinute: _extract('minute'),
         ops.ExtractSecond: _second,

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -170,13 +170,6 @@ class TeradataTypeTranslator(object):
             )
 
         return "TIMESTAMP WITH TIME ZONE"
-    
-    @classmethod
-    def to_ibis_from_TZ(cls, col_data, return_ibis_type=True):
-        if return_ibis_type:
-            return dt.timestamp(timezone="UTC")
-
-        return "TIMESTAMP WITH TIME ZONE"
 
 
 ibis_type_to_teradata_type = Dispatcher("ibis_type_to_teradata_type")

--- a/third_party/ibis/ibis_teradata/datatypes.py
+++ b/third_party/ibis/ibis_teradata/datatypes.py
@@ -159,7 +159,14 @@ class TeradataTypeTranslator(object):
         if return_ibis_type:
             return dt.timestamp(timezone="UTC")
 
-        return "TIMESTAMP"
+        return "TIMESTAMP WITH TIME ZONE"
+    
+    @classmethod
+    def to_ibis_from_TZ(cls, col_data, return_ibis_type=True):
+        if return_ibis_type:
+            return dt.timestamp(timezone="UTC")
+
+        return "TIMESTAMP WITH TIME ZONE"
 
 
 ibis_type_to_teradata_type = Dispatcher("ibis_type_to_teradata_type")

--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -228,20 +228,14 @@ def _string_join(translator, op):
 
 def _extract_epoch(translator, op):
     arg = translator.translate(op.arg)
-    if op.arg.output_dtype.timezone:
-        return (
-            f"(CAST ({arg} AS DATE AT TIME ZONE 'GMT') - DATE '1970-01-01') * 86400 + "
-            f"(EXTRACT(HOUR FROM {arg} AT TIME ZONE 'GMT') * 3600) + "
-            f"(EXTRACT(MINUTE FROM {arg} AT TIME ZONE 'GMT') * 60) + "
-            f"(EXTRACT(SECOND FROM {arg} AT TIME ZONE 'GMT'))"
-        )
-    else:
-        return (
-            f"(CAST ({arg} AS DATE) - DATE '1970-01-01') * 86400 + "
-            f"(EXTRACT(HOUR FROM {arg}) * 3600) + "
-            f"(EXTRACT(MINUTE FROM {arg}) * 60) + "
-            f"(EXTRACT(SECOND FROM {arg}))"
-        )
+    utc_expression = "AT TIME ZONE 'GMT'" if op.arg.output_dtype.timezone else ""
+    
+    return (
+        f"(CAST ({arg} AS DATE {utc_expression}) - DATE '1970-01-01') * 86400 + "
+        f"(EXTRACT(HOUR FROM {arg} {utc_expression}) * 3600) + "
+        f"(EXTRACT(MINUTE FROM {arg} {utc_expression}) * 60) + "
+        f"(EXTRACT(SECOND FROM {arg} {utc_expression}))"
+    )
 
 
 """ Add New Customizations to Operations registry """


### PR DESCRIPTION
Closes #762 

This removes timestamp from being included in wildcard aggregations by default.

Adds new flag `--wildcard-include-timestamp` to include timestamp columns in wildcard aggregations i.e. `--sum='*'`. This will calculate the SUM(UNIX_SECONDS(ts_column))

When manually specifying `--sum ts_column`, the aggregation will run over SUM(UNIX_SECONDS(ts_column)).
