### PR TITLE
fix: Support casting TD PKs to VARCHAR

### DIFF
--- a/data_validation/query_builder/query_builder.py
+++ b/data_validation/query_builder/query_builder.py
@@ -201,7 +201,7 @@ class ComparisonField(object):
         comparison_field = ibis_table[self.field_name]
         alias = self.alias or self.field_name
         if self.cast:
-            comparison_field = comparison_field.cast(self.cast)
+            comparison_field = comparison_field.force_cast(self.cast)
         comparison_field = comparison_field.name(alias)
 
         return comparison_field

--- a/third_party/ibis/ibis_addon/api.py
+++ b/third_party/ibis/ibis_addon/api.py
@@ -21,11 +21,12 @@ from ibis.expr.types.generic import Value
 def cast(self, target_type: dt.DataType) -> Value:
     """Override ibis.expr.api's cast method.
     This allows for Timestamp-typed columns to be cast to Timestamp, since Ibis interprets some similar but non-equivalent types (eg. DateTime) to Timestamp (GitHub issue #451).
+    This allows for String-typed columns to be cast to String, since there may be a need to cast CHAR to VARCHAR as per Issue #927.
     """
     # validate
     op = ops.Cast(self, to=target_type)
-
-    if op.to == self.type() and not op.to.is_timestamp():
+    
+    if op.to == self.type() and not op.to.is_timestamp() and not op.to.is_string():
         # noop case if passed type is the same
         return self
 
@@ -36,3 +37,6 @@ def cast(self, target_type: dt.DataType) -> Value:
             return self
 
     return op.to_expr()
+
+
+Value.cast = cast


### PR DESCRIPTION
Closes Issue #927 

This will allow users to cast string values to string to support nuances in string data types.
In this case we need to cast TD CHAR to VARCHAR so extra whitespace isn't added by teradatasql as mentioned in the issue.

Example YAML:
```
primary_keys:
  - cast: string
    field_alias: col_char_2
    source_column: col_char_2
    target_column: col_char_2
```

This will result in the following SQL: `SELECT CAST(t0."col_char_2" AS VARCHAR(255)) AS "col_char_2"`