### PR TITLE
feat: Adding Exclude columns flag for aggregations in column validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ data-validation (--verbose or -v) (--log-level or -ll) validate column
   [--max COLUMNS]       Comma separated list of columns for max or * for all numeric
   [--avg COLUMNS]       Comma separated list of columns for avg or * for all numeric
   [--std COLUMNS]       Comma separated list of columns for stddev_samp or * for all numeric
+  [--exclude-columns or -ec]   Flag to indicate the list of columns provided should be excluded and not included.
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
@@ -310,8 +311,8 @@ data-validation (--verbose or -v) (--log-level or -ll) validate custom-query col
   [--min COLUMNS]       Comma separated list of columns for min or * for all numeric
   [--max COLUMNS]       Comma separated list of columns for max or * for all numeric
   [--avg COLUMNS]       Comma separated list of columns for avg or * for all numeric
-  [--exclude-columns or -ec]   Flag to indicate the list of columns provided should be excluded and not included.
   [--std COLUMNS]       Comma separated list of columns for stddev_samp or * for all numeric
+  [--exclude-columns or -ec]   Flag to indicate the list of columns provided should be excluded and not included.
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ data-validation (--verbose or -v) (--log-level or -ll) validate custom-query col
   [--min COLUMNS]       Comma separated list of columns for min or * for all numeric
   [--max COLUMNS]       Comma separated list of columns for max or * for all numeric
   [--avg COLUMNS]       Comma separated list of columns for avg or * for all numeric
+  [--exclude-columns or -ec]   Flag to indicate the list of columns provided should be excluded and not included.
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -83,19 +83,18 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         supported_data_types.extend(["timestamp", "!timestamp", "date", "!date"])
 
     cast_to_bigint = True if args.cast_to_bigint else False
-    exclude_cols = True if args.exclude_columns else False
 
     if args.count:
         col_args = None if args.count == "*" else cli_tools.get_arg_list(args.count)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "count", col_args, exclude_cols, None, cast_to_bigint=cast_to_bigint
+            "count", col_args, args.exclude_columns, None, cast_to_bigint=cast_to_bigint
         )
     if args.sum:
         col_args = None if args.sum == "*" else cli_tools.get_arg_list(args.sum)
         aggregate_configs += config_manager.build_config_column_aggregates(
             "sum",
             col_args,
-            exclude_cols,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -104,7 +103,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "avg",
             col_args,
-            exclude_cols,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -113,7 +112,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "min",
             col_args,
-            exclude_cols,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -122,7 +121,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "max",
             col_args,
-            exclude_cols,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -131,7 +130,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "bit_xor",
             col_args,
-            exclude_cols,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -140,7 +139,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "std",
             col_args,
-            exclude_cols,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -138,7 +138,11 @@ def get_aggregate_config(args, config_manager: ConfigManager):
     if args.std:
         col_args = None if args.std == "*" else cli_tools.get_arg_list(args.std)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "std", col_args, supported_data_types, cast_to_bigint=cast_to_bigint
+            "std",
+            col_args,
+            exclude_cols,
+            supported_data_types,
+            cast_to_bigint=cast_to_bigint,
         )
     return aggregate_configs
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -83,36 +83,57 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         supported_data_types.extend(["timestamp", "!timestamp"])
 
     cast_to_bigint = True if args.cast_to_bigint else False
+    exclude_cols = True if args.exclude_columns else False
 
     if args.count:
         col_args = None if args.count == "*" else cli_tools.get_arg_list(args.count)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "count", col_args, None, cast_to_bigint=cast_to_bigint
+            "count", col_args, exclude_cols, None, cast_to_bigint=cast_to_bigint
         )
     if args.sum:
         col_args = None if args.sum == "*" else cli_tools.get_arg_list(args.sum)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "sum", col_args, supported_data_types, cast_to_bigint=cast_to_bigint
+            "sum",
+            col_args,
+            exclude_cols,
+            supported_data_types,
+            cast_to_bigint=cast_to_bigint,
         )
     if args.avg:
         col_args = None if args.avg == "*" else cli_tools.get_arg_list(args.avg)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "avg", col_args, supported_data_types, cast_to_bigint=cast_to_bigint
+            "avg",
+            col_args,
+            exclude_cols,
+            supported_data_types,
+            cast_to_bigint=cast_to_bigint,
         )
     if args.min:
         col_args = None if args.min == "*" else cli_tools.get_arg_list(args.min)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "min", col_args, supported_data_types, cast_to_bigint=cast_to_bigint
+            "min",
+            col_args,
+            exclude_cols,
+            supported_data_types,
+            cast_to_bigint=cast_to_bigint,
         )
     if args.max:
         col_args = None if args.max == "*" else cli_tools.get_arg_list(args.max)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "max", col_args, supported_data_types, cast_to_bigint=cast_to_bigint
+            "max",
+            col_args,
+            exclude_cols,
+            supported_data_types,
+            cast_to_bigint=cast_to_bigint,
         )
     if args.bit_xor:
         col_args = None if args.bit_xor == "*" else cli_tools.get_arg_list(args.bit_xor)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "bit_xor", col_args, supported_data_types, cast_to_bigint=cast_to_bigint
+            "bit_xor",
+            col_args,
+            exclude_cols,
+            supported_data_types,
+            cast_to_bigint=cast_to_bigint,
         )
     return aggregate_configs
 

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -559,7 +559,7 @@ def _configure_column_parser(column_parser):
     optional_arguments.add_argument(
         "--exclude-columns",
         "-ec",
-        action="store_false",
+        action="store_true",
         help="Flag to indicate the list of columns should be excluded from validation and not included.",
     )
     optional_arguments.add_argument(
@@ -805,7 +805,7 @@ def _configure_custom_query_column_parser(custom_query_column_parser):
     optional_arguments.add_argument(
         "--exclude-columns",
         "-ec",
-        action="store_false",
+        action="store_true",
         help="Flag to indicate the list of columns should be excluded from validation and not included.",
     )
     optional_arguments.add_argument(

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -798,6 +798,11 @@ def _configure_custom_query_column_parser(custom_query_column_parser):
         help="Comma separated list of columns for hashing a concatenate 'col_a,col_b' or * for all columns",
     )
     optional_arguments.add_argument(
+        "--std",
+        "-std",
+        help="Comma separated list of columns for standard deviation 'col_a,col_b' or * for all columns",
+    )
+    optional_arguments.add_argument(
         "--exclude-columns",
         "-ec",
         action="store_false",

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -797,9 +797,10 @@ def _configure_custom_query_column_parser(custom_query_column_parser):
         help="Comma separated list of columns for hashing a concatenate 'col_a,col_b' or * for all columns",
     )
     optional_arguments.add_argument(
-        "--std",
-        "-std",
-        help="Comma separated list of columns for standard deviation 'col_a,col_b' or * for all columns",
+        "--exclude-columns",
+        "-ec",
+        action="store_false",
+        help="Flag to indicate the list of columns should be excluded from validation and not included.",
     )
     optional_arguments.add_argument(
         "--wildcard-include-string-len",

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -551,6 +551,12 @@ def _configure_column_parser(column_parser):
         help="Comma separated list of columns to use in GroupBy 'col_a,col_b'",
     )
     optional_arguments.add_argument(
+        "--exclude-columns",
+        "-ec",
+        action="store_false",
+        help="Flag to indicate the list of columns should be excluded from validation and not included.",
+    )
+    optional_arguments.add_argument(
         "--threshold",
         "-th",
         type=threshold_float,

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -734,6 +734,11 @@ class ConfigManager(object):
                     "binary",
                     "!binary",
                 ]
+        else:
+            if exclude_cols:
+                raise ValueError(
+                    "Exclude columns flag cannot be present with '*' column aggregation"
+                )
 
         allowlist_columns = arg_value or casefold_source_columns
         for column_position, column in enumerate(casefold_source_columns):

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -713,11 +713,11 @@ class ConfigManager(object):
         if arg_value:
             if exclude_cols:
                 cols_excluded = [x.casefold() for x in arg_value]
-                included_cols = []
-                for column in casefold_source_columns:
-                    if column not in cols_excluded:
-                        included_cols.append(column)
-
+                included_cols = [
+                    column
+                    for column in casefold_source_columns
+                    if column not in cols_excluded
+                ]
                 arg_value = included_cols
             else:
                 arg_value = [x.casefold() for x in arg_value]

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -713,12 +713,11 @@ class ConfigManager(object):
         if arg_value:
             if exclude_cols:
                 cols_excluded = [x.casefold() for x in arg_value]
-                included_cols = [
+                arg_value = [
                     column
                     for column in casefold_source_columns
                     if column not in cols_excluded
                 ]
-                arg_value = included_cols
             else:
                 arg_value = [x.casefold() for x in arg_value]
 

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -711,15 +711,14 @@ class ConfigManager(object):
         casefold_target_columns = {x.casefold(): str(x) for x in target_table.columns}
 
         if arg_value:
+            arg_value = [x.casefold() for x in arg_value]
             if exclude_cols:
-                cols_excluded = [x.casefold() for x in arg_value]
-                arg_value = [
+                included_cols = [
                     column
                     for column in casefold_source_columns
-                    if column not in cols_excluded
+                    if column not in arg_value
                 ]
-            else:
-                arg_value = [x.casefold() for x in arg_value]
+                arg_value = included_cols
 
             if supported_types:
                 # This mutates external supported_types, making it local as part of adding more values.

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -645,7 +645,7 @@ class ConfigManager(object):
         return aggregate_config
 
     def build_config_column_aggregates(
-        self, agg_type, arg_value, supported_types, cast_to_bigint=False
+        self, agg_type, arg_value, exclude_cols, supported_types, cast_to_bigint=False
     ):
         """Return list of aggregate objects of given agg_type."""
 
@@ -677,7 +677,17 @@ class ConfigManager(object):
         casefold_target_columns = {x.casefold(): str(x) for x in target_table.columns}
 
         if arg_value:
-            arg_value = [x.casefold() for x in arg_value]
+            if exclude_cols:
+                cols_excluded = [x.casefold() for x in arg_value]
+                included_cols = []
+                for column in casefold_source_columns:
+                    if column not in cols_excluded:
+                        included_cols.append(column)
+
+                arg_value = included_cols
+            else:
+                arg_value = [x.casefold() for x in arg_value]
+
             if supported_types:
                 supported_types.extend(["string", "!string", "timestamp", "!timestamp"])
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -74,9 +74,16 @@ AGGREGATE_CONFIG_B = {
 }
 
 AGGREGATE_CONFIG_C = {
-    consts.CONFIG_SOURCE_COLUMN: "c",
-    consts.CONFIG_TARGET_COLUMN: "c",
-    consts.CONFIG_FIELD_ALIAS: "sum__c",
+    consts.CONFIG_SOURCE_COLUMN: "length__c",
+    consts.CONFIG_TARGET_COLUMN: "length__c",
+    consts.CONFIG_FIELD_ALIAS: "min__length__c",
+    consts.CONFIG_TYPE: "min",
+}
+
+AGGREGATE_CONFIG_D = {
+    consts.CONFIG_SOURCE_COLUMN: "d",
+    consts.CONFIG_TARGET_COLUMN: "d",
+    consts.CONFIG_FIELD_ALIAS: "sum__d",
     consts.CONFIG_TYPE: "sum",
 }
 
@@ -85,13 +92,6 @@ GROUPED_COLUMN_CONFIG_A = {
     consts.CONFIG_TARGET_COLUMN: "a",
     consts.CONFIG_FIELD_ALIAS: "a",
     consts.CONFIG_CAST: None,
-}
-
-AGGREGATE_CONFIG_C = {
-    consts.CONFIG_SOURCE_COLUMN: "length__c",
-    consts.CONFIG_TARGET_COLUMN: "length__c",
-    consts.CONFIG_FIELD_ALIAS: "min__length__c",
-    consts.CONFIG_TYPE: "min",
 }
 
 CUSTOM_QUERY_VALIDATION_CONFIG = {
@@ -137,7 +137,7 @@ class MockIbisClient(object):
 
 class MockIbisTable(object):
     def __init__(self):
-        self.columns = ["a", "b", "c"]
+        self.columns = ["a", "b", "c", "d"]
 
     def __getitem__(self, key):
         return MockIbisColumn(key)
@@ -309,7 +309,9 @@ def test_build_config_aggregates(module_under_test):
     assert len(aggregate_configs) == 1
     assert aggregate_configs[0] == AGGREGATE_CONFIG_A
 
-    aggregate_configs = config_manager.build_config_column_aggregates("min", ["c"], [])
+    aggregate_configs = config_manager.build_config_column_aggregates(
+        "min", ["c"], False, []
+    )
     assert aggregate_configs[0] == AGGREGATE_CONFIG_C
 
 
@@ -319,11 +321,11 @@ def test_build_config_aggregates_ec(module_under_test):
     )
 
     aggregate_configs = config_manager.build_config_column_aggregates(
-        "sum", ["a"], True, []
+        "sum", ["a", "c"], True, []
     )
     assert len(aggregate_configs) == 2
     assert aggregate_configs[0] == AGGREGATE_CONFIG_B
-    assert aggregate_configs[1] == AGGREGATE_CONFIG_C
+    assert aggregate_configs[1] == AGGREGATE_CONFIG_D
 
 
 def test_build_config_aggregates_no_match(module_under_test):

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -328,6 +328,19 @@ def test_build_config_aggregates_ec(module_under_test):
     assert aggregate_configs[1] == AGGREGATE_CONFIG_D
 
 
+def test_build_config_aggregates_ec_exception(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        config_manager.build_config_column_aggregates("sum", None, True, [])
+    assert (
+        str(excinfo.value)
+        == "Exclude columns flag cannot be present with '*' column aggregation"
+    )
+
+
 def test_build_config_aggregates_no_match(module_under_test):
     config_manager = module_under_test.ConfigManager(
         copy.copy(SAMPLE_CONFIG), MockIbisClient(), MockIbisClient(), verbose=False

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -65,6 +65,20 @@ AGGREGATE_CONFIG_A = {
     consts.CONFIG_TYPE: "sum",
 }
 
+AGGREGATE_CONFIG_B = {
+    consts.CONFIG_SOURCE_COLUMN: "b",
+    consts.CONFIG_TARGET_COLUMN: "b",
+    consts.CONFIG_FIELD_ALIAS: "sum__b",
+    consts.CONFIG_TYPE: "sum",
+}
+
+AGGREGATE_CONFIG_C = {
+    consts.CONFIG_SOURCE_COLUMN: "c",
+    consts.CONFIG_TARGET_COLUMN: "c",
+    consts.CONFIG_FIELD_ALIAS: "sum__c",
+    consts.CONFIG_TYPE: "sum",
+}
+
 GROUPED_COLUMN_CONFIG_A = {
     consts.CONFIG_SOURCE_COLUMN: "a",
     consts.CONFIG_TARGET_COLUMN: "a",
@@ -273,8 +287,24 @@ def test_build_config_aggregates(module_under_test):
         SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
     )
 
-    aggregate_configs = config_manager.build_config_column_aggregates("sum", ["a"], [])
+    aggregate_configs = config_manager.build_config_column_aggregates(
+        "sum", ["a"], False, []
+    )
+    assert len(aggregate_configs) == 1
     assert aggregate_configs[0] == AGGREGATE_CONFIG_A
+
+
+def test_build_config_aggregates_ec(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+
+    aggregate_configs = config_manager.build_config_column_aggregates(
+        "sum", ["a"], True, []
+    )
+    assert len(aggregate_configs) == 2
+    assert aggregate_configs[0] == AGGREGATE_CONFIG_B
+    assert aggregate_configs[1] == AGGREGATE_CONFIG_C
 
 
 def test_build_config_aggregates_no_match(module_under_test):
@@ -283,7 +313,7 @@ def test_build_config_aggregates_no_match(module_under_test):
     )
 
     aggregate_configs = config_manager.build_config_column_aggregates(
-        "sum", ["a"], ["float64"]
+        "sum", ["a"], False, ["float64"]
     )
     assert not aggregate_configs
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -313,6 +313,7 @@ def test_build_config_aggregates(module_under_test):
         "min", ["c"], False, []
     )
     assert aggregate_configs[0] == AGGREGATE_CONFIG_C
+    assert len(aggregate_configs) == 1
 
 
 def test_build_config_aggregates_ec(module_under_test):


### PR DESCRIPTION
Closes issue #880 

* Added parameter --exclude-columns or -ec to column validation to get a flag that identifies the column list as an exclusion, and not an inclusion.
* Updated Read Me to document the new parameter.
* Modified logic in Config Manager to process the column list accordingly to exclusion or inclusion commands.
* Added unit test to test exclusion configuration.