### PR TITLE
fix: Fix warning and precision detection when target precision higher than source

### DIFF
--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -187,7 +187,7 @@ def schema_validation_matching(
                 string_val(source_field_type), string_val(target_field_type)
             )
             if higher_precision:
-                # If the target precision is higher then tha validation is acceptable but worth a warning.
+                # If the target precision is higher then the validation is acceptable but worth a warning.
                 logging.warning(
                     "Source and target data type has precision mismatch: %s - %s",
                     string_val(source_field_type),

--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -154,7 +154,6 @@ def schema_validation_matching(
             )
             continue
 
-        # Target field exists
         target_field_type = target_fields_casefold[source_field_name]
         if source_field_type == target_field_type:
             # Target data type matches
@@ -172,26 +171,28 @@ def schema_validation_matching(
             and string_val(target_field_type)
             in allow_list_map[string_val(source_field_type)]
         ):
+            # Data type pair match an allow-list pair.
+            results.append(
+                [
+                    source_field_name,
+                    source_field_name,
+                    string_val(source_field_type),
+                    str(target_field_type),
+                    consts.VALIDATION_STATUS_SUCCESS,
+                ]
+            )
+        else:
+            # Target data type mismatch
             (higher_precision, lower_precision,) = parse_n_validate_datatypes(
                 string_val(source_field_type), string_val(target_field_type)
             )
-            if lower_precision:
-                results.append(
-                    [
-                        source_field_name,
-                        source_field_name,
-                        str(source_field_type),
-                        str(target_field_type),
-                        consts.VALIDATION_STATUS_FAIL,
-                    ]
+            if higher_precision:
+                # If the target precision is higher then tha validation is acceptable but worth a warning.
+                logging.warning(
+                    "Source and target data type has precision mismatch: %s - %s",
+                    string_val(source_field_type),
+                    str(target_field_type),
                 )
-            else:
-                if higher_precision:
-                    logging.warning(
-                        "Source and target data type has precision mismatch: %s - %s",
-                        string_val(source_field_type),
-                        str(target_field_type),
-                    )
                 results.append(
                     [
                         source_field_name,
@@ -201,19 +202,18 @@ def schema_validation_matching(
                         consts.VALIDATION_STATUS_SUCCESS,
                     ]
                 )
-        # target data type mismatch
-        else:
-            results.append(
-                [
-                    source_field_name,
-                    source_field_name,
-                    str(source_field_type),
-                    str(target_field_type),
-                    consts.VALIDATION_STATUS_FAIL,
-                ]
-            )
+            else:
+                results.append(
+                    [
+                        source_field_name,
+                        source_field_name,
+                        str(source_field_type),
+                        str(target_field_type),
+                        consts.VALIDATION_STATUS_FAIL,
+                    ]
+                )
 
-    # source field doesn't exist
+    # Source field doesn't exist
     for target_field_name, target_field_type in target_fields_casefold.items():
         if target_field_name not in source_fields_casefold:
             results.append(
@@ -344,12 +344,14 @@ def get_typea_numeric_sustr(st):
 
 
 # typeb data types: Decimal(10,2)
-def get_typeb_numeric_sustr(st):
-    first_half = st.split(",")[0]
-    second_half = st.split(",")[1]
-    first_half_num = get_typea_numeric_sustr(first_half)
-    second_half_num = get_typea_numeric_sustr(second_half)
-    return first_half_num, second_half_num
+def get_typeb_numeric_sustr(st: str) -> tuple:
+    m = DECIMAL_PRECISION_SCALE_PATTERN.match(st.replace(" ", ""))
+    if not m:
+        return -1, -1
+    _, p, s = m.groups()
+    if s is None:
+        s = 0
+    return int(p), int(s)
 
 
 def string_val(st):
@@ -368,7 +370,7 @@ def strip_null(st):
     return st.replace("!", "")
 
 
-def parse_n_validate_datatypes(source, target):
+def parse_n_validate_datatypes(source, target) -> tuple:
     """
     Args:
         source: Source table datatype string

--- a/tests/unit/test_schema_validation.py
+++ b/tests/unit/test_schema_validation.py
@@ -452,8 +452,16 @@ def test_schema_validation_matching_allowlist_columns(module_under_test):
 
 def test_schema_validation_decimal_precision_mismatch(module_under_test):
     """Test for decimal precision mismatch extra checks, i.e. if target has greater precision then success."""
-    source_fields = {"FIELD1": "decimal(5,0)", "FIELD2": "decimal(5,0)", "FIELD3": "decimal(10,0)"}
-    target_fields = {"field1": "decimal(5,0)", "field2": "decimal(10,0)", "field3": "decimal(5,0)"}
+    source_fields = {
+        "FIELD1": "decimal(5,0)",
+        "FIELD2": "decimal(5,0)",
+        "FIELD3": "decimal(10,0)",
+    }
+    target_fields = {
+        "field1": "decimal(5,0)",
+        "field2": "decimal(10,0)",
+        "field3": "decimal(5,0)",
+    }
 
     expected_results = [
         [

--- a/tests/unit/test_schema_validation.py
+++ b/tests/unit/test_schema_validation.py
@@ -304,7 +304,7 @@ def test_parse_allow_list(test_input: str, expected: dict):
     assert parse_allow_list(test_input) == expected
 
 
-# Basic unit test  for schema validation.
+# Basic unit test for schema validation.
 def test_schema_validation_matching(module_under_test):
     source_fields = {"FIELD1": "string", "fiEld2": "datetime", "field3": "string"}
     target_fields = {"field1": "string", "field2": "timestamp", "field_3": "string"}
@@ -447,6 +447,39 @@ def test_schema_validation_matching_allowlist_columns(module_under_test):
         target_fields,
         None,
         "decimal(38,0):int64,decimal(38,0):decimal(1000,0),int32:int64",
+    )
+
+
+def test_schema_validation_decimal_precision_mismatch(module_under_test):
+    """Test for decimal precision mismatch extra checks, i.e. if target has greater precision then success."""
+    source_fields = {"FIELD1": "decimal(5,0)", "FIELD2": "decimal(5,0)", "FIELD3": "decimal(10,0)"}
+    target_fields = {"field1": "decimal(5,0)", "field2": "decimal(10,0)", "field3": "decimal(5,0)"}
+
+    expected_results = [
+        [
+            "field1",
+            "field1",
+            "decimal(5,0)",
+            "decimal(5,0)",
+            consts.VALIDATION_STATUS_SUCCESS,
+        ],
+        [
+            "field2",
+            "field2",
+            "decimal(5,0)",
+            "decimal(10,0)",
+            consts.VALIDATION_STATUS_SUCCESS,
+        ],
+        [
+            "field3",
+            "field3",
+            "decimal(10,0)",
+            "decimal(5,0)",
+            consts.VALIDATION_STATUS_FAIL,
+        ],
+    ]
+    assert expected_results == module_under_test.schema_validation_matching(
+        source_fields, target_fields, [], ""
     )
 
 


### PR DESCRIPTION
When validating schema for decimal columns the logic for when to warn the user and when to fail was incorrect. I have corrected the logic to match the original intention from prior issue (defined below):

1. If source type = target type exactly then success
2. If source/target match an allow list pair then success
3. If not an exact match and not an allow list pair then
3.1. If base type is same and target precision lower then fail
3.2 If base type is same and target precision higher then success with warning
3.3 Else fail

Also, now the check is in the right place I discovered that the precision extraction code didn't work and precision was always `-1`. So I fixed that too.

Plus added a unit test.