### PR TITLE
fix: Prevent failure of column validation config generation if source column other than allow-list not present in target table.

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -705,7 +705,7 @@ class ConfigManager(object):
 
             target_column_ibis_type = target_table[
                 casefold_target_columns[column]
-            ].type()   
+            ].type()
 
             if (
                 (column_type == "string" or column_type == "!string")

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -687,9 +687,6 @@ class ConfigManager(object):
             source_column_ibis_type = source_table[
                 casefold_source_columns[column]
             ].type()
-            target_column_ibis_type = target_table[
-                casefold_target_columns[column]
-            ].type()
             column_type = str(source_column_ibis_type).split("(")[0]
 
             if column not in allowlist_columns:
@@ -705,6 +702,10 @@ class ConfigManager(object):
                         f"Skipping {agg_type} on {column} due to data type: {column_type}"
                     )
                 continue
+
+            target_column_ibis_type = target_table[
+                casefold_target_columns[column]
+            ].type()   
 
             if (
                 (column_type == "string" or column_type == "!string")


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/973 
