### PR TITLE
feat: Support for null decimal columns and TD access locks

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -65,6 +65,7 @@ CONNECTION_SOURCE_FIELDS = {
         ["user_name", "User used to connect"],
         ["password", "Password for supplied user"],
         ["logmech", "(Optional) Log on mechanism"],
+        ["use_no_lock_tables", "Use an access lock for queries (defaults to False)"],
     ],
     "Oracle": [
         ["host", "Desired Oracle host"],

--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -115,7 +115,12 @@ def _calculate_difference(field_differences, datatype, validation, is_value_comp
         target_value = field_differences["differences_target_value"]
 
     # Does not calculate difference between agg values for row hash due to int64 overflow
-    if is_value_comparison or isinstance(datatype, ibis.expr.datatypes.String):
+    if (
+        is_value_comparison
+        or isinstance(datatype, ibis.expr.datatypes.String)
+        or isinstance(target_value, ibis.expr.types.generic.NullColumn)
+        or isinstance(source_value, ibis.expr.types.generic.NullColumn)
+    ):
         # String data types i.e "None" can be returned for NULL timestamp/datetime aggs
         if is_value_comparison:
             difference = pct_difference = ibis.null()

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -124,6 +124,7 @@ data-validation connections add
     --user-name USER                                    Teradata user
     --password PASSWORD                                 Teradata password
     [--logmech LOGMECH]                                 Teradata logmech, defaults to "TD2"
+    [--use-no-lock-tables USE_NO_LOCK_TABLES]           Use access lock for queries, defaults to "False"  
 ```
 
 ## Oracle

--- a/third_party/ibis/ibis_teradata/__init__.py
+++ b/third_party/ibis/ibis_teradata/__init__.py
@@ -39,7 +39,7 @@ class Backend(BaseSQLBackend):
         password: str = None,
         port: int = 1025,
         logmech: str = "TD2",
-        use_no_lock_tables: bool = False,
+        use_no_lock_tables: str = "False",
     ) -> None:
         self.teradata_config = {
             "host": host,
@@ -51,7 +51,7 @@ class Backend(BaseSQLBackend):
 
         self.client = teradatasql.connect(**self.teradata_config)
         self.con = self.client.cursor()
-        self.use_no_lock_tables = use_no_lock_tables
+        self.use_no_lock_tables = True if use_no_lock_tables.casefold() == "True".casefold() else False
 
     def close(self):
         """Close the connection."""
@@ -210,15 +210,12 @@ class Backend(BaseSQLBackend):
         kwargs.pop("timecontext", None)
         query_ast = self.compiler.to_ast_ensure_limit(expr, limit, params=params)
         sql = query_ast.compile()
-        self._log(sql)
-
-        schema = self.ast_schema(query_ast, **kwargs)
-
         self._register_in_memory_tables(expr)
 
         if self.use_no_lock_tables and sql.strip().startswith("SELECT"):
-            sql = self.NO_LOCK_SQL + self.compiled_sql
+            sql = self.NO_LOCK_SQL + sql
 
+        self._log(sql)
         with warnings.catch_warnings():
             # Suppress pandas warning of SQLAlchemy connectable DB support
             warnings.simplefilter("ignore")

--- a/third_party/ibis/ibis_teradata/api.py
+++ b/third_party/ibis/ibis_teradata/api.py
@@ -21,7 +21,7 @@ def teradata_connect(
     password: str = None,
     port: int = 1025,
     logmech: str = "TD2",
-    use_no_lock_tables: bool = False,
+    use_no_lock_tables: str = "False",
 ):
     backend = TeradataBackend()
     backend.do_connect(


### PR DESCRIPTION
Closes #970 
Closes #969

This will require users to specify `--use-no-lock-tables True` to use an access lock instead of a read lock on TD.
If enabled, will append the prefix "LOCKING ROW FOR ACCESS" before query execution.