### PR TITLE
fix: yaml validation files in gcs

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1062,14 +1062,16 @@ def get_validation(validation_name, config_dir=None):
         mgr = state_manager.StateManager(file_system_root_path=config_dir)
         return mgr.get_validation_config(validation_name, config_dir)
     else:
-       if validation_name.startswith("gs://"):
-           obj_depth = len(validation_name.split("/"))
-           gcs_prefix = '/'.join(validation_name.split('/')[:obj_depth-1])
-           mgr = state_manager.StateManager(file_system_root_path=gcs_prefix)
-           return mgr.get_validation_config(validation_name.split('/')[obj_depth-1],gcs_prefix)
-       else: 
-           mgr = state_manager.StateManager()
-           return mgr.get_validation_config(validation_name)
+        if validation_name.startswith("gs://"):
+            obj_depth = len(validation_name.split("/"))
+            gcs_prefix = "/".join(validation_name.split("/")[: obj_depth - 1])
+            mgr = state_manager.StateManager(file_system_root_path=gcs_prefix)
+            return mgr.get_validation_config(
+                validation_name.split("/")[obj_depth - 1], gcs_prefix
+            )
+        else:
+            mgr = state_manager.StateManager()
+            return mgr.get_validation_config(validation_name)
 
 
 def list_validations():

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1062,8 +1062,14 @@ def get_validation(validation_name, config_dir=None):
         mgr = state_manager.StateManager(file_system_root_path=config_dir)
         return mgr.get_validation_config(validation_name, config_dir)
     else:
-        mgr = state_manager.StateManager()
-        return mgr.get_validation_config(validation_name)
+       if validation_name.startswith("gs://"):
+           obj_depth = len(validation_name.split("/"))
+           gcs_prefix = '/'.join(validation_name.split('/')[:obj_depth-1])
+           mgr = state_manager.StateManager(file_system_root_path=gcs_prefix)
+           return mgr.get_validation_config(validation_name.split('/')[obj_depth-1],gcs_prefix)
+       else: 
+           mgr = state_manager.StateManager()
+           return mgr.get_validation_config(validation_name)
 
 
 def list_validations():


### PR DESCRIPTION
This change fixes [972](https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/972). When using `data-validation configs run -c gs://mudu-plex-pri-myb/db6rows/public.iowa_27rows/0001.yaml` was throwing an error.

This fix does not have a test cases. We don't have any GCS based test cases in unit tests. Do the unit tests have access to a GCS bucket ? I tested the fix manually and it works. It would be nice for this to be tested in the test suite

Sundar Mudupalli