### PR TITLE
fix: Add not-null string to accepted date types in append_pre_agg_calc_field()

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -595,10 +595,10 @@ class ConfigManager(object):
     ) -> dict:
         """Append calculated field for length(string) or epoch_seconds(timestamp) for preprocessing before column validation aggregation."""
         depth, cast_type = 0, None
-        if column_type == "string":
+        if column_type in ["string", "!string"]:
             calc_func = "length"
 
-        elif column_type == "timestamp" or column_type == "!timestamp":
+        elif column_type in ["timestamp", "!timestamp"]:
             if (
                 self.source_client.name == "bigquery"
                 or self.target_client.name == "bigquery"
@@ -708,13 +708,10 @@ class ConfigManager(object):
             ].type()
 
             if (
-                (column_type == "string" or column_type == "!string")
+                column_type in ["string", "!string"]
+                or (cast_to_bigint and column_type in ["int32", "!int32"])
                 or (
-                    cast_to_bigint
-                    and (column_type == "int32" or column_type == "!int32")
-                )
-                or (
-                    (column_type == "timestamp" or column_type == "!timestamp")
+                    column_type in ["timestamp", "!timestamp"]
                     and agg_type
                     in (
                         "sum",

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import pytest
 
 from data_validation import consts
@@ -285,7 +286,7 @@ def test_build_column_configs(module_under_test):
 
 def test_build_config_aggregates(module_under_test):
     config_manager = module_under_test.ConfigManager(
-        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+        copy.copy(SAMPLE_CONFIG), MockIbisClient(), MockIbisClient(), verbose=False
     )
 
     aggregate_configs = config_manager.build_config_column_aggregates("sum", ["a"], [])
@@ -297,7 +298,7 @@ def test_build_config_aggregates(module_under_test):
 
 def test_build_config_aggregates_no_match(module_under_test):
     config_manager = module_under_test.ConfigManager(
-        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+        copy.copy(SAMPLE_CONFIG), MockIbisClient(), MockIbisClient(), verbose=False
     )
 
     aggregate_configs = config_manager.build_config_column_aggregates(
@@ -308,7 +309,7 @@ def test_build_config_aggregates_no_match(module_under_test):
 
 def test_build_config_count_aggregate(module_under_test):
     config_manager = module_under_test.ConfigManager(
-        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+        copy.copy(SAMPLE_CONFIG), MockIbisClient(), MockIbisClient(), verbose=False
     )
 
     agg = config_manager.build_config_count_aggregate()

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -72,6 +72,13 @@ GROUPED_COLUMN_CONFIG_A = {
     consts.CONFIG_CAST: None,
 }
 
+AGGREGATE_CONFIG_C = {
+    consts.CONFIG_SOURCE_COLUMN: "length__c",
+    consts.CONFIG_TARGET_COLUMN: "length__c",
+    consts.CONFIG_FIELD_ALIAS: "min__length__c",
+    consts.CONFIG_TYPE: "min",
+}
+
 CUSTOM_QUERY_VALIDATION_CONFIG = {
     # BigQuery Specific Connection Config
     "source_conn": None,
@@ -118,14 +125,22 @@ class MockIbisTable(object):
         self.columns = ["a", "b", "c"]
 
     def __getitem__(self, key):
-        return self
-
-    def type(self):
-        return "int64"
+        return MockIbisColumn(key)
 
     def mutate(self, fields):
         self.columns = self.columns + fields
         return self
+
+
+class MockIbisColumn(object):
+    def __init__(self, column):
+        self.column = column
+
+    def type(self):
+        if self.column == "c":
+            return "!string"
+        else:
+            return "int64"
 
 
 @pytest.fixture
@@ -275,6 +290,9 @@ def test_build_config_aggregates(module_under_test):
 
     aggregate_configs = config_manager.build_config_column_aggregates("sum", ["a"], [])
     assert aggregate_configs[0] == AGGREGATE_CONFIG_A
+
+    aggregate_configs = config_manager.build_config_column_aggregates("min", ["c"], [])
+    assert aggregate_configs[0] == AGGREGATE_CONFIG_C
 
 
 def test_build_config_aggregates_no_match(module_under_test):


### PR DESCRIPTION
We were getting an exception from column validation when attempting a min or max validation on a non-null string column:

```
ValueError: Unsupported column type: !string
```

I've added a test for this to `test_config_manager.py`. I needed to add a new mock class `MockIbisColumn` so I could control the returned data type for a specific column.

I've also changed `data_validation/config_manager.py` to treat `!string` in the same way as `string`.