### PR TITLE
feat: Include date columns for min/max/sum validations

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -94,7 +94,7 @@ def generate_report(
 
 def _calculate_difference(field_differences, datatype, validation, is_value_comparison):
     pct_threshold = ibis.literal(validation.threshold)
-    if isinstance(datatype, ibis.expr.datatypes.Timestamp):
+    if isinstance(datatype, (ibis.expr.datatypes.Timestamp, ibis.expr.datatypes.Date)):
         source_value = field_differences["differences_source_value"].epoch_seconds()
         target_value = field_differences["differences_target_value"].epoch_seconds()
     elif isinstance(datatype, ibis.expr.datatypes.Decimal) or isinstance(

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -680,7 +680,14 @@ class ConfigManager(object):
             arg_value = [x.casefold() for x in arg_value]
             if supported_types:
                 # This mutates external supported_types, making it local as part of adding more values.
-                supported_types = supported_types + ["string", "!string", "timestamp", "!timestamp", "date", "!date"]
+                supported_types = supported_types + [
+                    "string",
+                    "!string",
+                    "timestamp",
+                    "!timestamp",
+                    "date",
+                    "!date",
+                ]
 
         allowlist_columns = arg_value or casefold_source_columns
         for column_position, column in enumerate(casefold_source_columns):

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -598,7 +598,7 @@ class ConfigManager(object):
         if column_type == "string":
             calc_func = "length"
 
-        elif column_type == "timestamp" or column_type == "!timestamp":
+        elif column_type in ["timestamp", "!timestamp", "date", "!date"]:
             if (
                 self.source_client.name == "bigquery"
                 or self.target_client.name == "bigquery"
@@ -679,7 +679,8 @@ class ConfigManager(object):
         if arg_value:
             arg_value = [x.casefold() for x in arg_value]
             if supported_types:
-                supported_types.extend(["string", "!string", "timestamp", "!timestamp"])
+                # This mutates external supported_types, making it local as part of adding more values.
+                supported_types = supported_types + ["string", "!string", "timestamp", "!timestamp", "date", "!date"]
 
         allowlist_columns = arg_value or casefold_source_columns
         for column_position, column in enumerate(casefold_source_columns):
@@ -714,7 +715,7 @@ class ConfigManager(object):
                     and (column_type == "int32" or column_type == "!int32")
                 )
                 or (
-                    (column_type == "timestamp" or column_type == "!timestamp")
+                    column_type in ["timestamp", "!timestamp", "date", "!date"]
                     and agg_type
                     in (
                         "sum",

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -1172,9 +1172,9 @@ def test_column_validation_core_types(mock_conn):
             "-tc=mock-conn",
             "-tbls=pso_data_validator.dvt_core_types",
             "--filter-status=fail",
-            "--sum=*",
-            "--min=*",
-            "--max=*",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -218,9 +218,9 @@ def test_column_validation_core_types():
             "-tc=mock-conn",
             "-tbls=pso_data_validator.dvt_core_types",
             "--filter-status=fail",
-            "--sum=*",
-            "--min=*",
-            "--max=*",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -625,9 +625,9 @@ def test_column_validation_core_types():
             "-tc=mock-conn",
             "-tbls=pso_data_validator.dvt_core_types",
             "--filter-status=fail",
-            "--sum=*",
-            "--min=*",
-            "--max=*",
+            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -296,8 +296,8 @@ def test_column_validation_core_types():
             "-tbls=udf.dvt_core_types",
             "--filter-status=fail",
             "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
-            "--min=*",
-            "--max=*",
+            "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/third_party/ibis/ibis_teradata/__init__.py
+++ b/third_party/ibis/ibis_teradata/__init__.py
@@ -51,13 +51,15 @@ class Backend(BaseSQLBackend):
 
         self.client = teradatasql.connect(**self.teradata_config)
         self.con = self.client.cursor()
-        self.use_no_lock_tables = True if use_no_lock_tables.casefold() == "True".casefold() else False
+        self.use_no_lock_tables = (
+            True if use_no_lock_tables.casefold() == "True".casefold() else False
+        )
 
     def close(self):
         """Close the connection."""
         self.con.close()
 
-    def __del__ (self):
+    def __del__(self):
         self.con.close()
 
     @property

--- a/third_party/ibis/ibis_teradata/__init__.py
+++ b/third_party/ibis/ibis_teradata/__init__.py
@@ -56,7 +56,7 @@ class Backend(BaseSQLBackend):
     def close(self):
         """Close the connection."""
         self.con.close()
-    
+
     def __del__ (self):
         self.con.close()
 
@@ -216,10 +216,15 @@ class Backend(BaseSQLBackend):
             sql = self.NO_LOCK_SQL + sql
 
         self._log(sql)
+
+        schema = self.ast_schema(query_ast, **kwargs)
+        # Date columns are in the Dataframe as "object", using parse_dates to ensure they have a better data type.
+        date_columns = [_ for _ in schema.names if schema.fields[_].is_date()]
+
         with warnings.catch_warnings():
             # Suppress pandas warning of SQLAlchemy connectable DB support
             warnings.simplefilter("ignore")
-            df = pandas.read_sql(sql, self.client)
+            df = pandas.read_sql(sql, self.client, parse_dates=date_columns)
         return df
 
     # Methods we need to implement for BaseSQLBackend

--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -228,13 +228,14 @@ def _string_join(translator, op):
 
 def _extract_epoch(translator, op):
     arg = translator.translate(op.arg)
-    utc_expression = "AT TIME ZONE 'GMT'" if op.arg.output_dtype.timezone else ""
-    
+    utc_expression = "AT TIME ZONE 'GMT'" if getattr(op.arg.output_dtype, 'timezone', None) else ""
+    extract_arg = f"CAST({arg} AS TIMESTAMP)" if op.arg.output_dtype.is_date() else arg
+
     return (
         f"(CAST ({arg} AS DATE {utc_expression}) - DATE '1970-01-01') * 86400 + "
-        f"(EXTRACT(HOUR FROM {arg} {utc_expression}) * 3600) + "
-        f"(EXTRACT(MINUTE FROM {arg} {utc_expression}) * 60) + "
-        f"(EXTRACT(SECOND FROM {arg} {utc_expression}))"
+        f"(EXTRACT(HOUR FROM {extract_arg} {utc_expression}) * 3600) + "
+        f"(EXTRACT(MINUTE FROM {extract_arg} {utc_expression}) * 60) + "
+        f"(EXTRACT(SECOND FROM {extract_arg} {utc_expression}))"
     )
 
 

--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -228,7 +228,9 @@ def _string_join(translator, op):
 
 def _extract_epoch(translator, op):
     arg = translator.translate(op.arg)
-    utc_expression = "AT TIME ZONE 'GMT'" if getattr(op.arg.output_dtype, 'timezone', None) else ""
+    utc_expression = (
+        "AT TIME ZONE 'GMT'" if getattr(op.arg.output_dtype, "timezone", None) else ""
+    )
     extract_arg = f"CAST({arg} AS TIMESTAMP)" if op.arg.output_dtype.is_date() else arg
 
     return (


### PR DESCRIPTION
This change includes Ibis `Date` columns in min/max/sum column validations. Prior to these changes they were excluded, only `Timestamp` columns were processed.

Most engines worked out of the box for min/max/sum. In my testing only Teradata needed changes, both to implement `epoch_seconds` for sum support and convert `Date` columns in the Pandas Dataframe to be a date rather than `object` list.