### PR TITLE
fix: custom query row validation failing when SQL contains upper cased columns

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -140,7 +140,11 @@ def get_ibis_table(client, schema_name, table_name, database_name=None):
 
 def get_ibis_query(client, query):
     """Return Ibis Table from query expression for Supplied Client."""
-    return client.sql(query)
+    iq = client.sql(query)
+    # Normalise all columns in the query to lower case.
+    # https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/992
+    iq = iq.relabel(dict(zip(iq.columns, [_.lower() for _ in iq.columns])))
+    return iq
 
 
 def get_ibis_table_schema(client, schema_name, table_name):

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -321,20 +321,80 @@ def test_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_custom_query_validation_core_types():
-    """Oracle to Oracle dvt_core_types custom-query validation"""
+def test_custom_query_column_validation_core_types_to_bigquery():
+    """Oracle to BigQuery dvt_core_types custom-query column validation"""
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [
             "validate",
             "custom-query",
             "column",
-            "-sc=mock-conn",
-            "-tc=mock-conn",
+            "-sc=ora-conn",
+            "-tc=bq-conn",
             "--source-query=select * from pso_data_validator.dvt_core_types",
             "--target-query=select * from pso_data_validator.dvt_core_types",
             "--filter-status=fail",
             "--count=*",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_row_validation_core_types_to_bigquery():
+    """Oracle to BigQuery dvt_core_types custom-query row comparison-fields validation"""
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=ora-conn",
+            "-tc=bq-conn",
+            "--source-query=select id,col_int64,COL_VARCHAR_30,col_date from pso_data_validator.dvt_core_types",
+            "--target-query=select id,col_int64,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--comparison-fields=col_int64,col_varchar_30,col_date",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_row_hash_validation_core_types_to_bigquery():
+    """Oracle to BigQuery dvt_core_types custom-query row hash validation"""
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=ora-conn",
+            "-tc=bq-conn",
+            "--source-query=select id,col_int64,COL_VARCHAR_30,col_date from pso_data_validator.dvt_core_types",
+            "--target-query=select id,col_int64,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--hash=col_int64,col_varchar_30,col_date",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -450,20 +450,80 @@ def test_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_custom_query_validation_core_types():
-    """SQL Server to SQL Server dvt_core_types custom-query validation"""
+def test_custom_query_column_validation_core_types_to_bigquery():
+    """Oracle to BigQuery dvt_core_types custom-query column validation"""
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [
             "validate",
             "custom-query",
             "column",
-            "-sc=mock-conn",
-            "-tc=mock-conn",
+            "-sc=sql-conn",
+            "-tc=bq-conn",
             "--source-query=select * from pso_data_validator.dvt_core_types",
             "--target-query=select * from pso_data_validator.dvt_core_types",
             "--filter-status=fail",
             "--count=*",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_row_validation_core_types_to_bigquery():
+    """SQL Server to BigQuery dvt_core_types custom-query row comparison-fields validation"""
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=sql-conn",
+            "-tc=bq-conn",
+            "--source-query=select id,col_int64,COL_VARCHAR_30,col_date from pso_data_validator.dvt_core_types",
+            "--target-query=select id,col_int64,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--comparison-fields=col_int64,col_varchar_30,col_date",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_row_hash_validation_core_types_to_bigquery():
+    """SQL Server to BigQuery dvt_core_types custom-query row hash validation"""
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=sql-conn",
+            "-tc=bq-conn",
+            "--source-query=select id,col_int64,COL_VARCHAR_30,col_date from pso_data_validator.dvt_core_types",
+            "--target-query=select id,col_int64,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--hash=col_int64,col_varchar_30,col_date",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -449,20 +449,80 @@ def test_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_custom_query_validation_core_types():
-    """Teradata to Teradata dvt_core_types custom-query validation"""
+def test_custom_query_column_validation_core_types_to_bigquery():
+    """Teradata to BigQuery dvt_core_types custom-query validation"""
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [
             "validate",
             "custom-query",
             "column",
-            "-sc=mock-conn",
-            "-tc=mock-conn",
+            "-sc=td-conn",
+            "-tc=bq-conn",
             "--source-query=select * from udf.dvt_core_types",
-            "--target-query=select * from udf.dvt_core_types",
+            "--target-query=select * from pso_data_validator.dvt_core_types",
             "--filter-status=fail",
             "--count=*",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_row_validation_core_types_to_bigquery():
+    """Oracle to BigQuery dvt_core_types custom-query row validation"""
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=td-conn",
+            "-tc=bq-conn",
+            "--source-query=select id,col_int64,COL_VARCHAR_30,col_date from udf.dvt_core_types",
+            "--target-query=select id,col_int64,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--comparison-fields=col_int64,col_varchar_30,col_date",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    validator = data_validation.DataValidation(config_manager.config, verbose=False)
+    df = validator.execute()
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_row_hash_validation_core_types_to_bigquery():
+    """Oracle to BigQuery dvt_core_types custom-query row validation"""
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=td-conn",
+            "-tc=bq-conn",
+            "--source-query=select id,col_int64,COL_VARCHAR_30,col_date from udf.dvt_core_types",
+            "--target-query=select id,col_int64,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--filter-status=fail",
+            "--hash=col_int64,col_varchar_30,col_date",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -53,7 +53,7 @@ class Backend(BaseAlchemyBackend):
             )
         else:
             sa_url = sa.engine.url.make_url(url)
-        
+
         self.database_name = sa_url.database
         engine = sa.create_engine(sa_url, poolclass=sa.pool.StaticPool)
 
@@ -61,9 +61,8 @@ class Backend(BaseAlchemyBackend):
         def connect(dbapi_connection, connection_record):
             with dbapi_connection.cursor() as cur:
                 cur.execute("ALTER SESSION SET TIME_ZONE='UTC'")
-    
-        super().do_connect(engine)
 
+        super().do_connect(engine)
 
     def _metadata(self, query)  -> Iterable[Tuple[str, dt.DataType]]:
         if (
@@ -76,6 +75,6 @@ class Backend(BaseAlchemyBackend):
             result = con.exec_driver_sql(f"SELECT * FROM {query} t0 WHERE ROWNUM <= 1")
             cursor = result.cursor
             yield from (
-                (column[0], _get_type(column))
+                (column[0].lower(), _get_type(column))
                 for column in cursor.description
             )

--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -53,7 +53,7 @@ class Backend(BaseAlchemyBackend):
             )
         else:
             sa_url = sa.engine.url.make_url(url)
-
+        
         self.database_name = sa_url.database
         engine = sa.create_engine(sa_url, poolclass=sa.pool.StaticPool)
 
@@ -61,8 +61,9 @@ class Backend(BaseAlchemyBackend):
         def connect(dbapi_connection, connection_record):
             with dbapi_connection.cursor() as cur:
                 cur.execute("ALTER SESSION SET TIME_ZONE='UTC'")
-
+    
         super().do_connect(engine)
+
 
     def _metadata(self, query)  -> Iterable[Tuple[str, dt.DataType]]:
         if (
@@ -75,6 +76,6 @@ class Backend(BaseAlchemyBackend):
             result = con.exec_driver_sql(f"SELECT * FROM {query} t0 WHERE ROWNUM <= 1")
             cursor = result.cursor
             yield from (
-                (column[0].lower(), _get_type(column))
+                (column[0], _get_type(column))
                 for column in cursor.description
             )


### PR DESCRIPTION
We found this issue on Oracle where column default to upper case but it could easily be reproduced on other engines by writing SQL with upper cased columns, the columns in the actual SQL engine were irrelevant, it was just the SQL we pass in.

The problem was only seen for custom query validation using `--comparison-fields`. When using `--hash` the calculated fields resulted in lower case end column names.

I added tests to protect from regressions for Oracle, SQL Server, Teradata vs BigQuery. The fix was global so should wortk on all engines but I was reluctant to add too many tests seeing as integration tests are already pretty slow.

The fix was very minor, in `data_validation/clients.py` I convert the Ibis schema to have lower case columns:
```
-    return client.sql(query)
+    iq = client.sql(query)
+    # Normalise all columns in the query to lower case.
+    # https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/992
+    iq = iq.relabel(dict(zip(iq.columns, [_.lower() for _ in iq.columns])))
+    return iq
```