### PR TITLE
fix: Teradata SSLMODE issue fix

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -66,6 +66,7 @@ CONNECTION_SOURCE_FIELDS = {
         ["password", "Password for supplied user"],
         ["logmech", "(Optional) Log on mechanism"],
         ["use_no_lock_tables", "Use an access lock for queries (defaults to False)"],
+        ["json_params", "(Optional) Additional teradatasql JSON string parameters"],
     ],
     "Oracle": [
         ["host", "Desired Oracle host"],

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -124,7 +124,8 @@ data-validation connections add
     --user-name USER                                    Teradata user
     --password PASSWORD                                 Teradata password
     [--logmech LOGMECH]                                 Teradata logmech, defaults to "TD2"
-    [--use-no-lock-tables USE_NO_LOCK_TABLES]           Use access lock for queries, defaults to "False"  
+    [--use-no-lock-tables USE_NO_LOCK_TABLES]           Use access lock for queries, defaults to "False"
+    [--json-params JSON_PARAMS]                         Additional teradatasql JSON string parameters (Optional)
 ```
 
 ## Oracle

--- a/third_party/ibis/ibis_teradata/__init__.py
+++ b/third_party/ibis/ibis_teradata/__init__.py
@@ -14,6 +14,7 @@
 import pandas
 import warnings
 
+import json
 import teradatasql
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
@@ -40,6 +41,7 @@ class Backend(BaseSQLBackend):
         port: int = 1025,
         logmech: str = "TD2",
         use_no_lock_tables: str = "False",
+        json_params: str = None,
     ) -> None:
         self.teradata_config = {
             "host": host,
@@ -48,6 +50,13 @@ class Backend(BaseSQLBackend):
             "dbs_port": port,
             "logmech": logmech,
         }
+
+        if json_params:
+            try:
+                param_dict = json.loads(json_params.replace("'", '"'))
+                self.teradata_config.update(param_dict)
+            except json.JSONDecodeError:
+                print(f"Invalid JSON format in the parameter dictionary string: {json_params}")
 
         self.client = teradatasql.connect(**self.teradata_config)
         self.con = self.client.cursor()

--- a/third_party/ibis/ibis_teradata/api.py
+++ b/third_party/ibis/ibis_teradata/api.py
@@ -22,6 +22,7 @@ def teradata_connect(
     port: int = 1025,
     logmech: str = "TD2",
     use_no_lock_tables: str = "False",
+    json_params: str = None,
 ):
     backend = TeradataBackend()
     backend.do_connect(
@@ -31,5 +32,6 @@ def teradata_connect(
         port=port,
         logmech=logmech,
         use_no_lock_tables=use_no_lock_tables,
+        json_params=json_params,
     )
     return backend


### PR DESCRIPTION
Solves Teradata SSLMODE support - connection timeout issue (#1011) and adds support for additional teradatasql connection options as a JSON string.

Example of usage:
`data-validation connections add -c my_td Teradata --json-params "{'sslmode': 'disable', 'encryptdata': 'true'}"`