### PR TITLE
chore: Builds are failing with a pip install cache error

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def _setup_session_requirements(session, extra_packages=[]):
     """Install requirements for nox tests."""
 
     session.install("--upgrade", "pip", "pytest", "pytest-cov", "wheel")
-    session.install("-e", ".")
+    session.install("--no-cache-dir", "-e", ".")
 
     if extra_packages:
         session.install(*extra_packages)


### PR DESCRIPTION
There's a pip bug causing our builds to fail, the workaround is to use `--no-cache-dir` when installing dependencies.

In the words of the ever wise @nehanene15:
"_we probably won't need the flag once the pip bug is fixed in a newer version, but since we're spinning up separate containers we don't need packages to be cached anyways_"