### PR TITLE
feat: Support query parameter for MSSQL connection

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -81,6 +81,8 @@ CONNECTION_SOURCE_FIELDS = {
         ["user", "User used to connect"],
         ["password", "Password for supplied user"],
         ["database", "Database to connect to (default master)"],
+        ["query", "Connection query parameters"],
+        ["url", "SQL Server SQLAlchemy connection URL"],
     ],
     "MySQL": [
         ["host", "Desired MySQL host (default localhost)"],

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -151,6 +151,7 @@ data-validation connections add
 
 ## MSSQL Server
 MSSQL Server connections require [pyodbc](https://pypi.org/project/pyodbc/) as the driver: `pip install pyodbc`.
+For connection query parameter options, see https://docs.sqlalchemy.org/en/20/dialects/mssql.html#hostname-connections.
 
 ```
 data-validation connections add 
@@ -162,6 +163,8 @@ data-validation connections add
     --user USER                                         MSSQL user
     --password PASSWORD                                 MSSQL password
     --database DATABASE                                 MSSQL database
+    [--url URL]                                         SQLAlchemy connection URL
+    [--query QUERY]                                     Connection query parameters i.e. '{"TrustServerCertificate": "yes"}'
 ```
 
 ## Postgres

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -21,6 +21,7 @@ from ibis.backends.mssql.compiler import MsSqlCompiler
 from ibis.backends.mssql.datatypes import _type_from_result_set_info
 
 import third_party.ibis.ibis_mssql.datatypes
+import json
 
 
 # The MSSQL backend uses the Ibis MSSQL compiler, but overrides
@@ -42,12 +43,18 @@ class Backend(BaseAlchemyBackend):
         url: str = None,
         driver: Literal["pyodbc"] = "pyodbc",
         odbc_driver: str = "ODBC Driver 17 for SQL Server",
+        query: str = None,
     ) -> None:
         if url is None:
             if driver != "pyodbc":
                 raise NotImplementedError(
                     "pyodbc is currently the only supported driver"
                 )
+
+            if query:
+                query = json.loads(query)
+            else:
+                query = {"driver": odbc_driver}
 
             alchemy_url = sa.engine.url.URL.create(
                 f"mssql+{driver}",
@@ -56,7 +63,7 @@ class Backend(BaseAlchemyBackend):
                 username=user,
                 password=password,
                 database=database,
-                query={"driver": odbc_driver},
+                query=query,
             )
         else:
             alchemy_url = sa.engine.url.make_url(url)

--- a/third_party/ibis/ibis_mssql/api.py
+++ b/third_party/ibis/ibis_mssql/api.py
@@ -25,6 +25,7 @@ def mssql_connect(
     url: str = None,
     driver: Literal["pyodbc"] = "pyodbc",
     odbc_driver: str = "ODBC Driver 17 for SQL Server",
+    query: str = None,
 ):
     backend = MsSqlBackend()
     backend.do_connect(
@@ -36,5 +37,6 @@ def mssql_connect(
         url=url,
         driver=driver,
         odbc_driver=odbc_driver,
+        query=query,
     )
     return backend


### PR DESCRIPTION
Closes #1025 

This supports user-provided query parameter for the MSSQL connection URL:
`data-validation connections add -c mssqltest MSSQL --host 127.0.0.1 --port 1433 --user sqlserver --password passwrod --database guestbook --query '{"driver": "ODBC Driver 17 for SQL Server", "TrustServerCertificate": "yes", "authentication": "ActiveDirectoryIntegrated"}' `

This also supports a user-provided connection URL:
`data-validation connections add -c mssqltest MSSQL --url "mssql+pyodbc://user:pass@127.0.0.1:1433/database?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes&authentication=ActiveDirectoryIntegrated" `