### PR TITLE
docs: Update connections.md to add supported version of DB2

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -285,7 +285,7 @@ data-validation connections add
 
 
 ## DB2
-DB2 requires the `ibm_db_sa` package.
+DB2 requires the `ibm_db_sa` package. We currently support only IBM DB2 LUW - Universal Database for Linux/Unix/Windows versions 9.7 onwards.
 ```
 data-validation connections add 
     [--secret-manager-type <None|GCP>]                  Secret Manager type (None, GCP)


### PR DESCRIPTION
A recent issue (#1020) brought up to attention again the fact we don't support DB2 z/OS, only DB2 LUW.
Adding this clarification to our documentation.

/gcbrun