### PR TITLE
fix: Adding credentials as parameter for Spanner 

### DIFF
--- a/third_party/ibis/ibis_cloud_spanner/__init__.py
+++ b/third_party/ibis/ibis_cloud_spanner/__init__.py
@@ -38,10 +38,12 @@ class Backend(BaseSQLBackend):
         instance_id: str,
         database_id: str = None,
         project_id: str = None,
-        credentials = None,
+        credentials=None,
     ) -> None:
 
-        self.spanner_client = spanner.Client(project=project_id, credentials=credentials)
+        self.spanner_client = spanner.Client(
+            project=project_id, credentials=credentials
+        )
         self.instance = self.spanner_client.instance(instance_id)
         self.database_name = self.instance.database(database_id)
         (

--- a/third_party/ibis/ibis_cloud_spanner/__init__.py
+++ b/third_party/ibis/ibis_cloud_spanner/__init__.py
@@ -38,9 +38,10 @@ class Backend(BaseSQLBackend):
         instance_id: str,
         database_id: str = None,
         project_id: str = None,
+        credentials = None,
     ) -> None:
 
-        self.spanner_client = spanner.Client(project=project_id)
+        self.spanner_client = spanner.Client(project=project_id, credentials=credentials)
         self.instance = self.spanner_client.instance(instance_id)
         self.database_name = self.instance.database(database_id)
         (

--- a/third_party/ibis/ibis_cloud_spanner/api.py
+++ b/third_party/ibis/ibis_cloud_spanner/api.py
@@ -21,6 +21,7 @@ def spanner_connect(
     instance_id,
     database_id,
     project_id=None,
+    credentials=None,
 ):
     """Create a Cloud Spanner Backend for use with Ibis.
 
@@ -38,5 +39,6 @@ def spanner_connect(
         instance_id=instance_id,
         database_id=database_id,
         project_id=project_id,
+        credentials=credentials,
     )
     return backend


### PR DESCRIPTION
* This fix adds a credential parameter in connect function for spanner.
* The credentials consist of service account key required to access the DB. 