### PR TITLE
fix: Fix decimal separator to "." (dot) on Oracle

### DIFF
--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -61,6 +61,8 @@ class Backend(BaseAlchemyBackend):
         def connect(dbapi_connection, connection_record):
             with dbapi_connection.cursor() as cur:
                 cur.execute("ALTER SESSION SET TIME_ZONE='UTC'")
+                # Standardise numeric formatting on en_US (issue 1033).
+                cur.execute("ALTER SESSION SET NLS_NUMERIC_CHARACTERS='.,'")
 
         super().do_connect(engine)
 


### PR DESCRIPTION
Setting `NLS_NUMERIC_CHARACTERS` to `'.,'` when connecting to Oracle to ensure we get `.` as the decimal separator when converting decimals to string. This matches PostgreSQL and BigQuery.

I've been trying to manually test if the same applies on Teradata but cannot figure out how to setup a failure in order to fix it. I suspect we'll have similar issues on other engines in the future but this PR is restricted to Oracle.

I've also been unable to write a test for this. I added a test to `test_oracle.py` that failed without my fix and passed with it but, unfortunately, when I run all tests the new test passed even without the fix. I think this is because `os.environ` is captured when cx-Oracle is imported, when my test ran alone then my manipulation of `os.environ` worked. When my test ran amongst other tests my setup was not effective.

I've captured the test below for posterity but am submitting this PR based on manual testing alone.

```
@mock.patch(
    "data_validation.state_manager.StateManager.get_connection_config",
    new=mock_get_connection_config,
)
def test_row_validation_core_types_to_bigquery_fr_FR():
    """Oracle to BigQuery row comparison-fields where Oracle locale does not use . for decimal separator."""
    parser = cli_tools.configure_arg_parser()
    nls_lang = os.environ.get('NLS_LANG')
    os.environ['NLS_LANG'] = 'FRENCH_FRANCE.AL32UTF8'
    args = parser.parse_args(
        [
            "validate",
            "row",
            "-sc=ora-conn",
            "-tc=bq-conn",
            "-tbls=pso_data_validator.dvt_core_types",
            "--primary-keys=id",
            "--filter-status=fail",
            "--hash=id,col_dec_10_2",
        ]
    )
    config_managers = main.build_config_managers_from_args(args)
    assert len(config_managers) == 1
    config_manager = config_managers[0]
    validator = data_validation.DataValidation(config_manager.config, verbose=False)
    df = validator.execute()
    # Return NLS_LANG to its previous setting.
    if nls_lang:
        os.environ['NLS_LANG'] = nls_lang
    else:
        del os.environ['NLS_LANG']
    # With filter on failures the data frame should be empty.
    assert len(df) == 0
```