### PR TITLE
fix: --dry-run for SQLAlchemy clients with valid raw SQL

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -468,16 +468,37 @@ def run_validation(config_manager, dry_run=False, verbose=False):
         result_handler=None,
         verbose=verbose,
     )
+
     if dry_run:
+        sql_alchemy_clients = [
+            "mysql",
+            "oracle",
+            "postgres",
+            "db2",
+            "mssql",
+            "redshift",
+            "snowflake",
+        ]
+
+        source_query = validator.validation_builder.get_source_query().compile()
+        if config_manager.source_client.name in sql_alchemy_clients:
+            source_query = source_query.compile(
+                config_manager.source_client.con.engine,
+                compile_kwargs={"literal_binds": True},
+            )
+
+        target_query = validator.validation_builder.get_target_query().compile()
+        if config_manager.target_client.name in sql_alchemy_clients:
+            target_query = target_query.compile(
+                config_manager.target_client.con.engine,
+                compile_kwargs={"literal_binds": True},
+            )
+
         print(
             json.dumps(
                 {
-                    "source_query": str(
-                        validator.validation_builder.get_source_query().compile()
-                    ),
-                    "target_query": str(
-                        validator.validation_builder.get_target_query().compile()
-                    ),
+                    "source_query": str(source_query),
+                    "target_query": str(target_query),
                 },
                 indent=4,
             )

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from unittest import mock
 
@@ -1131,6 +1132,35 @@ def test_bigquery_generate_table_partitions(mock_conn):
         len(partition_filters[0][0]) == partition_builder.args.partition_num
     )  # assume no of table rows > partition_num
     assert partition_filters[0][0] == EXPECTED_PARTITION_FILTER
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
+def test_bigquery_dry_run(mock_conn, capsys):
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "row",
+            "-sc=mock-conn",
+            "-tc=mock-conn",
+            "-tbls=pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--hash=col_string",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    main.run_validation(config_manager, dry_run=True)
+    out, err = capsys.readouterr()
+    dry_run = json.loads(out)
+    assert (
+        dry_run["source_query"]
+        == f"WITH t0 AS (\n  SELECT t6.*, t6.`col_string` AS `cast__col_string`\n  FROM `{PROJECT_ID}.pso_data_validator.dvt_core_types` t6\n),\nt1 AS (\n  SELECT t0.*,\n         IFNULL(t0.`cast__col_string`, 'DEFAULT_REPLACEMENT_STRING') AS `ifnull__cast__col_string`\n  FROM t0\n),\nt2 AS (\n  SELECT t1.*,\n         rtrim(t1.`ifnull__cast__col_string`) AS `rstrip__ifnull__cast__col_string`\n  FROM t1\n),\nt3 AS (\n  SELECT t2.*,\n         upper(t2.`rstrip__ifnull__cast__col_string`) AS `upper__rstrip__ifnull__cast__col_string`\n  FROM t2\n),\nt4 AS (\n  SELECT t3.*,\n         ARRAY_TO_STRING([t3.`upper__rstrip__ifnull__cast__col_string`], '') AS `concat__all`\n  FROM t3\n)\nSELECT t5.`hash__all`, t5.`id`\nFROM (\n  SELECT t4.*, TO_HEX(SHA256(t4.`concat__all`)) AS `hash__all`\n  FROM t4\n) t5"
+    )
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -1153,9 +1153,9 @@ def test_bigquery_dry_run(mock_conn, capsys):
     )
     config_managers = main.build_config_managers_from_args(args)
     assert len(config_managers) == 1
-    config_manager = config_managers[0]
-    main.run_validation(config_manager, dry_run=True)
+    main.run_validation(config_managers[0], dry_run=True)
     out, err = capsys.readouterr()
+    assert err == ""
     dry_run = json.loads(out)
     assert (
         dry_run["source_query"]

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from unittest import mock
 
@@ -121,6 +122,37 @@ def test_mysql_generate_table_partitions():
         len(partition_filters[0][0]) == partition_builder.args.partition_num
     )  # assume no of table rows > partition_num
     assert partition_filters[0][0] == EXPECTED_PARTITION_FILTER
+
+
+mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+
+
+def test_mysql_dry_run(mock_conn, capsys):
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "row",
+            "-sc=mock-conn",
+            "-tc=mock-conn",
+            "-tbls=pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "--hash=col_string",
+        ]
+    )
+    config_managers = main.build_config_managers_from_args(args)
+    assert len(config_managers) == 1
+    config_manager = config_managers[0]
+    main.run_validation(config_manager, dry_run=True)
+    out, err = capsys.readouterr()
+    dry_run = json.loads(out)
+    assert (
+        dry_run["source_query"]
+        == "SELECT t0.hash__all, t0.id \nFROM (SELECT t1.id AS id, t1.col_int8 AS col_int8, t1.col_int16 AS col_int16, t1.col_int32 AS col_int32, t1.col_int64 AS col_int64, t1.col_dec_20 AS col_dec_20, t1.col_dec_38 AS col_dec_38, t1.col_dec_10_2 AS col_dec_10_2, t1.col_float32 AS col_float32, t1.col_float64 AS col_float64, t1.col_varchar_30 AS col_varchar_30, t1.col_char_2 AS col_char_2, t1.col_string AS col_string, t1.col_date AS col_date, t1.col_datetime AS col_datetime, t1.col_tstz AS col_tstz, t1.cast__col_string AS cast__col_string, t1.ifnull__cast__col_string AS ifnull__cast__col_string, t1.rstrip__ifnull__cast__col_string AS rstrip__ifnull__cast__col_string, t1.upper__rstrip__ifnull__cast__col_string AS upper__rstrip__ifnull__cast__col_string, t1.concat__all AS concat__all, sha2(t1.concat__all, '256') AS hash__all \nFROM (SELECT t2.id AS id, t2.col_int8 AS col_int8, t2.col_int16 AS col_int16, t2.col_int32 AS col_int32, t2.col_int64 AS col_int64, t2.col_dec_20 AS col_dec_20, t2.col_dec_38 AS col_dec_38, t2.col_dec_10_2 AS col_dec_10_2, t2.col_float32 AS col_float32, t2.col_float64 AS col_float64, t2.col_varchar_30 AS col_varchar_30, t2.col_char_2 AS col_char_2, t2.col_string AS col_string, t2.col_date AS col_date, t2.col_datetime AS col_datetime, t2.col_tstz AS col_tstz, t2.cast__col_string AS cast__col_string, t2.ifnull__cast__col_string AS ifnull__cast__col_string, t2.rstrip__ifnull__cast__col_string AS rstrip__ifnull__cast__col_string, t2.upper__rstrip__ifnull__cast__col_string AS upper__rstrip__ifnull__cast__col_string, concat_ws('', t2.upper__rstrip__ifnull__cast__col_string) AS concat__all \nFROM (SELECT t3.id AS id, t3.col_int8 AS col_int8, t3.col_int16 AS col_int16, t3.col_int32 AS col_int32, t3.col_int64 AS col_int64, t3.col_dec_20 AS col_dec_20, t3.col_dec_38 AS col_dec_38, t3.col_dec_10_2 AS col_dec_10_2, t3.col_float32 AS col_float32, t3.col_float64 AS col_float64, t3.col_varchar_30 AS col_varchar_30, t3.col_char_2 AS col_char_2, t3.col_string AS col_string, t3.col_date AS col_date, t3.col_datetime AS col_datetime, t3.col_tstz AS col_tstz, t3.cast__col_string AS cast__col_string, t3.ifnull__cast__col_string AS ifnull__cast__col_string, t3.rstrip__ifnull__cast__col_string AS rstrip__ifnull__cast__col_string, upper(t3.rstrip__ifnull__cast__col_string) AS upper__rstrip__ifnull__cast__col_string \nFROM (SELECT t4.id AS id, t4.col_int8 AS col_int8, t4.col_int16 AS col_int16, t4.col_int32 AS col_int32, t4.col_int64 AS col_int64, t4.col_dec_20 AS col_dec_20, t4.col_dec_38 AS col_dec_38, t4.col_dec_10_2 AS col_dec_10_2, t4.col_float32 AS col_float32, t4.col_float64 AS col_float64, t4.col_varchar_30 AS col_varchar_30, t4.col_char_2 AS col_char_2, t4.col_string AS col_string, t4.col_date AS col_date, t4.col_datetime AS col_datetime, t4.col_tstz AS col_tstz, t4.cast__col_string AS cast__col_string, t4.ifnull__cast__col_string AS ifnull__cast__col_string, TRIM(TRAILING '\f' FROM TRIM(TRAILING '\u000b' FROM TRIM(TRAILING '\r' FROM TRIM(TRAILING '\n' FROM TRIM(TRAILING '\t' FROM TRIM(TRAILING ' ' FROM (t4.ifnull__cast__col_string))))))) AS rstrip__ifnull__cast__col_string \nFROM (SELECT t5.id AS id, t5.col_int8 AS col_int8, t5.col_int16 AS col_int16, t5.col_int32 AS col_int32, t5.col_int64 AS col_int64, t5.col_dec_20 AS col_dec_20, t5.col_dec_38 AS col_dec_38, t5.col_dec_10_2 AS col_dec_10_2, t5.col_float32 AS col_float32, t5.col_float64 AS col_float64, t5.col_varchar_30 AS col_varchar_30, t5.col_char_2 AS col_char_2, t5.col_string AS col_string, t5.col_date AS col_date, t5.col_datetime AS col_datetime, t5.col_tstz AS col_tstz, t5.cast__col_string AS cast__col_string, coalesce(t5.cast__col_string, 'DEFAULT_REPLACEMENT_STRING') AS ifnull__cast__col_string \nFROM (SELECT t6.id AS id, t6.col_int8 AS col_int8, t6.col_int16 AS col_int16, t6.col_int32 AS col_int32, t6.col_int64 AS col_int64, t6.col_dec_20 AS col_dec_20, t6.col_dec_38 AS col_dec_38, t6.col_dec_10_2 AS col_dec_10_2, t6.col_float32 AS col_float32, t6.col_float64 AS col_float64, t6.col_varchar_30 AS col_varchar_30, t6.col_char_2 AS col_char_2, t6.col_string AS col_string, t6.col_date AS col_date, t6.col_datetime AS col_datetime, t6.col_tstz AS col_tstz, t6.col_string AS cast__col_string \nFROM dvt_core_types AS t6) AS t5) AS t4) AS t3) AS t2) AS t1) AS t0"
+    )
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -143,9 +143,9 @@ def test_mysql_dry_run(capsys):
     )
     config_managers = main.build_config_managers_from_args(args)
     assert len(config_managers) == 1
-    config_manager = config_managers[0]
-    main.run_validation(config_manager, dry_run=True)
+    main.run_validation(config_managers[0], dry_run=True)
     out, err = capsys.readouterr()
+    assert err == ""
     dry_run = json.loads(out)
     assert (
         dry_run["source_query"]

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -124,13 +124,11 @@ def test_mysql_generate_table_partitions():
     assert partition_filters[0][0] == EXPECTED_PARTITION_FILTER
 
 
-mock.patch(
+@mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-
-
-def test_mysql_dry_run(mock_conn, capsys):
+def test_mysql_dry_run(capsys):
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [


### PR DESCRIPTION
Previously, the `--dry-run` flag, similar to the `--verbose` flag, didn't print the exact raw query w/client specific rendering for SQLAlchemy clients. This PR corrects that and adds tests for one non-SQLAlchemy backend (BigQuery) and one SQLAlchemy backend (MySQL).

This prevents rendering of `:param1` parameters and invalid quotes or backticks when printing a dry run.
This PR does not affect the current `-verbose` functionality since that flag should only be used for debugging purposes. 