### PR TITLE
fix: Better casts to string for binary floats/doubles

### DIFF
--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -312,7 +312,7 @@ def disabled_test_row_validation_core_types():
 )
 def test_row_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
-    # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
+    # col_float64 is excluded below because there is no way to control the format when casting to string.
     args = parser.parse_args(
         [
             "validate",
@@ -322,7 +322,7 @@ def test_row_validation_core_types_to_bigquery():
             "-tbls=pso_data_validator.dvt_core_types",
             "--primary-keys=id",
             "--filter-status=fail",
-            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
+            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -394,7 +394,7 @@ def test_row_validation_core_types():
 )
 def test_row_validation_core_types_to_bigquery():
     """Oracle to BigQuery dvt_core_types row validation"""
-    # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
+    # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(
         [
@@ -423,9 +423,9 @@ def test_row_validation_core_types_to_bigquery():
 )
 def test_row_validation_oracle_to_postgres():
     # TODO Change hash_cols below to include col_tstz when issue-706 is complete.
-    # TODO Change hash_cols below to include col_float32,col_float64 when issue-841 is complete.
     # TODO col_raw is blocked by issue-773 (is it even reasonable to expect binary columns to work here?)
     # TODO Change hash_cols below to include col_nvarchar_30,col_nchar_2 when issue-772 is complete.
+    # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
     # Excluded CLOB/NCLOB/BLOB columns because lob values cannot be concatenated
     hash_cols = ",".join(
         [

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -425,7 +425,6 @@ def test_row_validation_core_types_to_bigquery():
     parser = cli_tools.configure_arg_parser()
     # TODO When issue-834 is complete add col_string to --hash string below.
     # TODO Change --hash string below to include col_tstz when issue-929 is complete.
-    # TODO Change --hash string below to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [
             "validate",
@@ -435,7 +434,7 @@ def test_row_validation_core_types_to_bigquery():
             "-tbls=pso_data_validator.dvt_core_types",
             "--primary-keys=id",
             "--filter-status=fail",
-            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_varchar_30,col_char_2,col_date,col_datetime",
+            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_date,col_datetime",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -424,7 +424,6 @@ def test_row_validation_core_types_to_bigquery():
     # Excluded col_string because LONG VARCHAR column causes exception regardless of column contents:
     # [Error 3798] A column or character expression is larger than the max size.
     # TODO Change --hash option to include col_tstz when issue-929 is complete.
-    # TODO Change --hash option to include col_float32,col_float64 when issue-841 is complete.
     args = parser.parse_args(
         [
             "validate",
@@ -434,7 +433,7 @@ def test_row_validation_core_types_to_bigquery():
             "-tbls=udf.dvt_core_types=pso_data_validator.dvt_core_types",
             "--primary-keys=id",
             "--filter-status=fail",
-            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_varchar_30,col_char_2,col_date,col_datetime",
+            "--hash=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_date,col_datetime",
         ]
     )
     config_managers = main.build_config_managers_from_args(args)

--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -54,6 +54,14 @@ def _cast(t, op):
     arg, target_type = op.args
     arg_formatted = t.translate(arg)
     input_dtype = arg.output_dtype
+
+    # Specialize going from a binary float type to a string.
+    # Trying to avoid scientific notation.
+    if (input_dtype.is_float32() or input_dtype.is_float64()) and op.to.is_string():
+        # Cannot return sa.func.to_char because t (TeradataExprTranslator) returns
+        # a string containing the column and not a SQLAlchemy Column object.
+        return f"TO_CHAR({arg_formatted},'TM9')"
+
     return teradata_cast(arg_formatted, input_dtype, target_type)
 
 


### PR DESCRIPTION
This PR is to work around problems validating floating point values where some engines return all digits and others return scientific notation, for example:
```
1.23456781E+007         │ 12345678.1
```

Changes in the PR:

- Use SQL Server FORMAT() instead of CAST() for real/float columns. In my tests that ensures we do not end up with scientific notation
- Use Teradata TO_CHAR('TM9') instead of CAST() for binary_float/double columns. In my tests that ensures we do not end up with scientific notation
- Use Oracle TO_CHAR('TM9') instead of CAST() for binary_float/double columns. In my tests that ensures we do not end up with scientific notation but we still get some unpredicatable values due to the lossy nature of binary floats. For this reason the column remain excluded from Oracle integration tests
- Reduces code duplication by importing the original Ibis `_cast()` function and calling that when not in one of our workarounds

Problems not fixed by this PR:

- Hive float and double remain problematic
- Oracle binary_float/double remain problematic