### PR TITLE
feat: set default oracle sql alchemy arraysize to 500

### DIFF
--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -25,6 +25,9 @@ class Backend(BaseAlchemyBackend):
     name = "oracle"
     compiler = OracleCompiler
 
+    def __init__(self, arraysize: int = 500):
+        self.arraysize = arraysize
+
     def do_connect(
         self,
         host: str = "localhost",
@@ -55,7 +58,7 @@ class Backend(BaseAlchemyBackend):
             sa_url = sa.engine.url.make_url(url)
 
         self.database_name = sa_url.database
-        engine = sa.create_engine(sa_url, poolclass=sa.pool.StaticPool)
+        engine = sa.create_engine(sa_url, poolclass=sa.pool.StaticPool, arraysize=self.arraysize)
 
         @sa.event.listens_for(engine, "connect")
         def connect(dbapi_connection, connection_record):

--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -26,6 +26,7 @@ class Backend(BaseAlchemyBackend):
     compiler = OracleCompiler
 
     def __init__(self, arraysize: int = 500):
+        super().__init__()
         self.arraysize = arraysize
 
     def do_connect(
@@ -58,7 +59,9 @@ class Backend(BaseAlchemyBackend):
             sa_url = sa.engine.url.make_url(url)
 
         self.database_name = sa_url.database
-        engine = sa.create_engine(sa_url, poolclass=sa.pool.StaticPool, arraysize=self.arraysize)
+        engine = sa.create_engine(
+            sa_url, poolclass=sa.pool.StaticPool, arraysize=self.arraysize
+        )
 
         @sa.event.listens_for(engine, "connect")
         def connect(dbapi_connection, connection_record):


### PR DESCRIPTION
#1086  - update default oracle sql alchemy arraysize to 500 via init method. Default is now set to 500 but can be updated to new value upon new instance of Backend() class. 

Gives a little more flexibility when calling the class but does not break existing instances of the class.

@nj1973 