### PR TITLE
fix: Increase upper limit on number of columns that can be validated

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -74,13 +74,25 @@ def generate_report(
     differences_pivot = _calculate_differences(
         source, target, join_on_fields, run_metadata.validations, is_value_comparison
     )
+    differences_df = client.execute(differences_pivot)
+
     source_pivot = _pivot_result(
         source, join_on_fields, run_metadata.validations, consts.RESULT_TYPE_SOURCE
     )
+    source_df = client.execute(source_pivot)
+
     target_pivot = _pivot_result(
         target, join_on_fields, run_metadata.validations, consts.RESULT_TYPE_TARGET
     )
-    joined = _join_pivots(source_pivot, target_pivot, differences_pivot, join_on_fields)
+    target_df = client.execute(target_pivot)
+
+    con = ibis.pandas.connect(
+        {"source": source_df, "differences": differences_df, "target": target_df}
+    )
+    joined = _join_pivots(
+        con.tables.source, con.tables.target, con.tables.differences, join_on_fields
+    )
+
     documented = _add_metadata(joined, run_metadata)
 
     if verbose:


### PR DESCRIPTION
Closes #897 

This fix addresses the 'RecursionError' that can be hit when validating a large number of columns (upwards of 140 typically). This will increase the upper limit, but not completely remove it. This is a pandas limitation also discussed in the Ibis repo here: https://github.com/ibis-project/ibis/issues/7124

The newer version of Ibis should also increase the limit further.