### PR TITLE
fix: Add table names to report results when source and/or target dataframes are empty

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -92,7 +92,7 @@ def generate_report(
     joined = _join_pivots(
         con.tables.source, con.tables.target, con.tables.differences, join_on_fields
     )
-    
+
     documented = _add_metadata(joined, run_metadata)
 
     if verbose:
@@ -104,9 +104,15 @@ def generate_report(
 
     key = next(iter(run_metadata.validations))
     # get the first validation metadata object to fill source or target empty table names
-    result_df.source_table_name.fillna(run_metadata.validations[key].get_table_name(consts.RESULT_TYPE_SOURCE), inplace=True)
-    result_df.target_table_name.fillna(run_metadata.validations[key].get_table_name(consts.RESULT_TYPE_TARGET), inplace=True)
-    
+    result_df.source_table_name.fillna(
+        run_metadata.validations[key].get_table_name(consts.RESULT_TYPE_SOURCE),
+        inplace=True,
+    )
+    result_df.target_table_name.fillna(
+        run_metadata.validations[key].get_table_name(consts.RESULT_TYPE_TARGET),
+        inplace=True,
+    )
+
     return result_df
 
 

--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -348,11 +348,11 @@ def _join_pivots(source, target, differences, join_on_fields):
         source_difference["aggregation_type"]
         .fillna(target["aggregation_type"])
         .name("aggregation_type"),
-        source_difference["table_name"].name("source_table_name"),
-        source_difference["column_name"].name("source_column_name"),
+        source_difference["table_name"].fillna(source["table_name"]).name("source_table_name"),
+        source_difference["column_name"].fillna(source["column_name"]).name("source_column_name"),
         source_difference["agg_value"].name("source_agg_value"),
-        target["table_name"].name("target_table_name"),
-        target["column_name"].name("target_column_name"),
+        target["table_name"].fillna("LALALA").name("target_table_name"),
+        target["column_name"].fillna("LALALA").name("target_column_name"),
         target["agg_value"].name("target_agg_value"),
         group_by_columns,
         source_difference["primary_keys"],
@@ -362,6 +362,24 @@ def _join_pivots(source, target, differences, join_on_fields):
         source_difference["pct_threshold"],
         source_difference["validation_status"],
     ]
+    # joined_fillna_source = joined.join(source, join_keys, how="outer")[
+    #     joined["validation_name"],
+    #     joined["validation_type"],
+    #     joined["aggregation_type"],
+    #     joined["source_table_name"].fillna(source["table_name"]).name("source_table_name"),
+    #     joined["column_name"].fillna(source["column_name"]).name("source_column_name"),
+    #     joined["source_agg_value"],
+    #     joined["table_name"],
+    #     joined["target_column_name"],
+    #     joined["target_agg_value"],
+    #     group_by_columns,
+    #     joined["primary_keys"],
+    #     joined["num_random_rows"],
+    #     joined["difference"],
+    #     joined["pct_difference"],
+    #     joined["pct_threshold"],
+    #     joined["validation_status"],
+    # ]
     return joined
 
 

--- a/data_validation/metadata.py
+++ b/data_validation/metadata.py
@@ -37,7 +37,7 @@ class ValidationMetadata(object):
     num_random_rows: int
     threshold: float
 
-    def get_table_name(self, result_type):
+    def get_table_name(self, result_type: str) -> str:
         if result_type == consts.RESULT_TYPE_SOURCE:
             return (
                 self.source_table_schema + "." + self.source_table_name
@@ -53,7 +53,7 @@ class ValidationMetadata(object):
         else:
             raise ValueError(f"Unexpected result_type: {result_type}")
 
-    def get_column_name(self, result_type):
+    def get_column_name(self, result_type: str) -> str:
         if result_type == consts.RESULT_TYPE_SOURCE:
             return self.source_column_name
         elif result_type == consts.RESULT_TYPE_TARGET:

--- a/tests/unit/test_combiner.py
+++ b/tests/unit/test_combiner.py
@@ -567,23 +567,9 @@ def test_generate_report_without_group_by(
                         )
                     ]
                     * 6,
-                    "source_table_name": [
-                        "bq-public.source_dataset.test_source",
-                        "bq-public.source_dataset.test_source",
-                        _NAN,
-                        _NAN,
-                        "bq-public.source_dataset.test_source",
-                        "bq-public.source_dataset.test_source",
-                    ],
+                    "source_table_name": ["bq-public.source_dataset.test_source"] * 6,
                     "source_column_name": [None] * 6,
-                    "target_table_name": [
-                        "bq-public.target_dataset.test_target",
-                        "bq-public.target_dataset.test_target",
-                        "bq-public.target_dataset.test_target",
-                        "bq-public.target_dataset.test_target",
-                        _NAN,
-                        _NAN,
-                    ],
+                    "target_table_name": ["bq-public.target_dataset.test_target"] * 6,
                     "target_column_name": [None] * 6,
                     "validation_type": ["Column"] * 6,
                     "aggregation_type": ["count"] * 6,


### PR DESCRIPTION
Closes #1098 

Partially fixing the issue, we still need to figure how to get the column names and most important, if we'll do this change

/gcbrun