### PR TITLE
fix: Numeric Overflow for Teradata COUNT column validation

### DIFF
--- a/data_validation/query_builder/query_builder.py
+++ b/data_validation/query_builder/query_builder.py
@@ -112,7 +112,7 @@ class AggregateField(object):
             agg_field = self.expr(ibis_table)
 
         if self.cast:
-            agg_field = agg_field.cast(self.cast)
+            agg_field = agg_field.force_cast(self.cast)
 
         if self.alias:
             agg_field = agg_field.name(self.alias)


### PR DESCRIPTION
Closes #1023 

This fix will allow users to CAST count at the outer level like so to avoid numeric overflow error:
```
- aggregates:
  - field_alias: count
    source_column: null
    target_column: null
    type: count
    cast: int64
```

with the SQL generated:
`SELECT CAST(count(1) AS BIGINT) AS "count" FROM dataset.table`