### PR TITLE
fix: Teradata's TypeError after large timestamp epoch second handling

### DIFF
--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -501,6 +501,7 @@ def execute_epoch_seconds_new(op, data, **kwargs):
         epoch_series = series.map(string_to_epoch)
         return epoch_series
 
+
 execute_epoch_seconds = execute_epoch_seconds_new
 
 BinaryValue.byte_length = compile_binary_length


### PR DESCRIPTION
Fixes #1120 

/gcbrun