### PR TITLE
fix: Support PKs with different casing for generate-partitions

### DIFF
--- a/tests/unit/test_partition_builder.py
+++ b/tests/unit/test_partition_builder.py
@@ -381,7 +381,6 @@ def test_class_object_creation(module_under_test):
     args = parser.parse_args(CLI_ARGS_SINGLE_KEY)
     builder = module_under_test.PartitionBuilder(config_managers, args)
     assert builder.table_count == len(config_managers)
-    assert builder.primary_keys == ["id"]
 
 
 def test_add_partition_filters_to_config(module_under_test):

--- a/tests/unit/test_partition_builder.py
+++ b/tests/unit/test_partition_builder.py
@@ -383,12 +383,6 @@ def test_class_object_creation(module_under_test):
     assert builder.table_count == len(config_managers)
     assert builder.primary_keys == ["id"]
 
-    # multiple primary keys are present
-    args = parser.parse_args(CLI_ARGS_MULTIPLE_KEYS)
-    builder = module_under_test.PartitionBuilder(config_managers, args)
-    assert builder.table_count == len(config_managers)
-    assert builder.primary_keys == ["region_id", "station_id"]
-
 
 def test_add_partition_filters_to_config(module_under_test):
     """Add partition filters to ConfigManager object, build YAML config list


### PR DESCRIPTION
Closes #1136 

Instead of getting the PKs from args (`--primary-keys column_a,columb_b`), gets PKs from the ConfigManager which accounts for different casing between source and target systems.