### PR TITLE
fix: Removing t0 alias from column name, while getting schema from query. Adding Integration test for Hive Custom-Query

### DIFF
--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -339,3 +339,28 @@ def test_row_validation_binary_pk_to_bigquery():
     )
     df = run_test_from_cli_args(args)
     binary_key_assertions(df)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_validation_core_types():
+    """Hive to Hive dvt_core_types custom-query validation"""
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "column",
+            "-sc=mock-conn",
+            "-tc=mock-conn",
+            "--source-query=select * from pso_data_validator.dvt_core_types",
+            "--target-query=select * from pso_data_validator.dvt_core_types",
+            "--filter-status=fail",
+            "--count=*",
+        ]
+    )
+    df = run_test_from_cli_args(args)
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0

--- a/third_party/ibis/ibis_impala/api.py
+++ b/third_party/ibis/ibis_impala/api.py
@@ -197,6 +197,7 @@ def _get_schema_using_query(self, query):
     # Removing LIMIT 0 around query since it returns no results in Hive
     cur = self.raw_sql(f"SELECT * FROM ({query}) t0 LIMIT 1")
     cur.fetchall()
+    cur.description = [(description[0].replace('t0.', '', 1), *description[1:]) for description in cur.description]
     ibis_fields = self._adapt_types(cur.description)
     cur.release()
 

--- a/third_party/ibis/ibis_impala/api.py
+++ b/third_party/ibis/ibis_impala/api.py
@@ -197,7 +197,10 @@ def _get_schema_using_query(self, query):
     # Removing LIMIT 0 around query since it returns no results in Hive
     cur = self.raw_sql(f"SELECT * FROM ({query}) t0 LIMIT 1")
     cur.fetchall()
-    cur.description = [(description[0].replace('t0.', '', 1), *description[1:]) for description in cur.description]
+    cur.description = [
+        (description[0].replace("t0.", "", 1), *description[1:])
+        for description in cur.description
+    ]
     ibis_fields = self._adapt_types(cur.description)
     cur.release()
 


### PR DESCRIPTION
This PR does following: 

- Adding integration test for Hive Custom-Query validation. 
- Fixes the t0 alias issue, while generating schema from custom query, issue pointed in #1162 

Closes #1162 