### PR TITLE
fix: Apply RTRIM on string column when generating partitions with `-tsp`

### DIFF
--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -252,9 +252,6 @@ class PartitionBuilder:
                 )
             )
 
-            print(source_where_list)
-            print(target_where_list)
-
             for i in range(1, first_elements.shape[0] - 1):
                 filter_source_clause = geq_value(
                     source_table,


### PR DESCRIPTION
Closes Issue #1179

Applies RTRIM on string PKs when generating partitions with the `--trim-string-pks` flag. With this, the YAML configs will have trimmed whitespace from the string value in the WHERE clause. i.e

```yaml
  filters:
  - source: ' ( "name" < ''Bob'' ) OR ( ( "name" = ''Bob'' ) AND ( "id" < 2 ) )'
    target: ' ( `name` < ''Bob'' ) OR ( ( `name` = ''Bob'' ) AND ( `id` < 2 ) )'
```