### PR TITLE
Fix: Issue with GoogleSQL regarding dates before 1000CE

### DIFF
--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -187,9 +187,9 @@ def strftime_bigquery(translator, op):
             arg_formatted,
             arg_type.timezone if arg_type.timezone is not None else "UTC",
         )
-    # Deal with issue 1181 which appears to be due a GoogleSQL bug with dates before 1000 CE 
-    if format_str.value == '%Y-%m-%d' :
-        fmt_string="'%4Y-%m-%d'"
+    # Deal with issue 1181 which appears to be due a GoogleSQL bug with dates before 1000 CE
+    if format_str.value == "%Y-%m-%d":
+        fmt_string = "'%4Y-%m-%d'"
     return "FORMAT_{}({}, {})".format(
         strftime_format_func_name, fmt_string, arg_formatted
     )

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -180,7 +180,7 @@ def strftime_bigquery(translator, op):
     fmt_string = translator.translate(format_str)
     # Deal with issue 1181 due a GoogleSQL bug with dates before 1000 CE affects both date and timestamp types
     if format_str.value.startswith("%Y"):
-        fmt_string = fmt_string.replace("%Y", "%4Y", 1)
+        fmt_string = fmt_string.replace("%Y", "%E4Y", 1)
     arg_formatted = translator.translate(arg)
     if isinstance(arg_type, dt.Timestamp):
         return "FORMAT_{}({}, {}({}), {!r})".format(

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -187,6 +187,9 @@ def strftime_bigquery(translator, op):
             arg_formatted,
             arg_type.timezone if arg_type.timezone is not None else "UTC",
         )
+    # Deal with issue 1181 which appears to be due a GoogleSQL bug with dates before 1000 CE 
+    if format_str.value == '%Y-%m-%d' :
+        fmt_string="'%4Y-%m-%d'"
     return "FORMAT_{}({}, {})".format(
         strftime_format_func_name, fmt_string, arg_formatted
     )
@@ -658,6 +661,7 @@ if Db2ExprTranslator:
     Db2ExprTranslator._registry[BinaryLength] = sa_format_binary_length
 
 SpannerExprTranslator._registry[RawSQL] = format_raw_sql
+SpannerExprTranslator._registry[Strftime] = strftime_bigquery
 SpannerExprTranslator._registry[HashBytes] = format_hashbytes_bigquery
 SpannerExprTranslator._registry[BinaryLength] = sa_format_binary_length
 

--- a/third_party/ibis/ibis_cloud_spanner/registry.py
+++ b/third_party/ibis/ibis_cloud_spanner/registry.py
@@ -33,7 +33,7 @@ def _compiles_strftime(translator, op):
     fmt_string = translator.translate(format_str)
     # Deal with issue 1181 due a GoogleSQL bug with dates before 1000 CE affects both date and timestamp types
     if format_str.value.startswith("%Y"):
-        fmt_string = fmt_string.replace("%Y", "%4Y", 1)
+        fmt_string = fmt_string.replace("%Y", "%E4Y", 1)
     arg_formatted = translator.translate(arg)
     if isinstance(arg_type, dt.Timestamp) and arg_type.timezone is None:
         # As per issue-767, fixes issue in Spanner where TIMESTAMP() function

--- a/third_party/ibis/ibis_cloud_spanner/registry.py
+++ b/third_party/ibis/ibis_cloud_spanner/registry.py
@@ -31,6 +31,9 @@ def _compiles_strftime(translator, op):
     arg_type = arg.output_dtype
     strftime_format_func_name = STRFTIME_FORMAT_FUNCTIONS[arg_type]
     fmt_string = translator.translate(format_str)
+    # Deal with issue 1181 due a GoogleSQL bug with dates before 1000 CE affects both date and timestamp types
+    if format_str.value.startswith("%Y"):
+        fmt_string = fmt_string.replace("%Y", "%4Y", 1)
     arg_formatted = translator.translate(arg)
     if isinstance(arg_type, dt.Timestamp) and arg_type.timezone is None:
         # As per issue-767, fixes issue in Spanner where TIMESTAMP() function


### PR DESCRIPTION
GoogleSQL when presented with dates before 1000CE does not print a four digit date. This fix changes the format string used to force a 4 digit date for BigQuery and Spanner backends.

Closes #1181 
 