### PR TITLE
feat: Add TLS options to PostgreSQL connections add

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -107,6 +107,23 @@ CONNECTION_SOURCE_FIELDS = {
         ["user", "Username to connect to"],
         ["password", "Password for authentication of user"],
         ["database", "Database in PostgreSQL to connect to (default postgres)"],
+        [
+            "hostaddr",
+            "(Optional) May be required to supply an address that differs from the name in the host option",
+        ],
+        [
+            "sslcert",
+            "(Optional) Local path to your client certificate (client-cert.pem) file",
+        ],
+        [
+            "sslkey",
+            "(Optional) Local path to your private client key (client-key.pem) file",
+        ],
+        [
+            "sslrootcert",
+            "(Optional) Local path to your root certificate (server-ca.pem) file",
+        ],
+        ["sslmode", "(Optional) SSL mode"],
     ],
     "Redshift": [
         ["host", "Desired Redshift host."],

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -188,6 +188,22 @@ data-validation connections add
     --user USER                                         Postgres user
     --password PASSWORD                                 Postgres password
     --database DATABASE                                 Postgres database
+    [--hostaddr HOSTADDR]                               May be required to supply an address that differs from the name in the host option
+    [--sslcert SSLCERT]                                 Local path to your client certificate (client-cert.pem) file
+    [--sslkey SSLKEY]                                   Local path to your private client key (client-key.pem) file
+    [--sslrootcert] SSLROOTCERT                         Local path to your root certificate (server-ca.pem) file
+    [--sslmode SSLMODE]                                 SSL mode
+```
+
+### Example TLS connection
+```
+data-validation connections add --connection-name pg_tls_ca Postgres \
+--host=10.1.0.2 --user=dvt_user --password=secret-password-123 \
+--database=appdb \
+--sslcert="/path/to/certs/client-cert.pem" \
+--sslkey=/path/to/certs/client-key.pem \
+--sslrootcert=/path/to/certs/server-ca.pem \
+--sslmode=verify-ca
 ```
 
 ## AlloyDB
@@ -202,6 +218,11 @@ data-validation connections add
     --user USER                                         Postgres user
     --password PASSWORD                                 Postgres password
     --database DATABASE                                 Postgres database
+    [--hostaddr HOSTADDR]                               May be required to supply an address that differs from the name in the host option
+    [--sslcert SSLCERT]                                 Local path to your client certificate (client-cert.pem) file
+    [--sslkey SSLKEY]                                   Local path to your private client key (client-key.pem) file
+    [--sslrootcert] SSLROOTCERT                         Local path to your root certificate (server-ca.pem) file
+    [--sslmode SSLMODE]                                 SSL mode
 ```
 
 ## MySQL

--- a/third_party/ibis/ibis_postgres/client.py
+++ b/third_party/ibis/ibis_postgres/client.py
@@ -32,6 +32,11 @@ def do_connect(
     schema: str = None,
     url: str = None,
     driver: Literal["psycopg2"] = "psycopg2",
+    hostaddr: str = None,
+    sslcert: str = None,
+    sslkey: str = None,
+    sslrootcert: str = None,
+    sslmode: str = None,
 ) -> None:
     # Override do_connect() method to remove DDL queries to CREATE/DROP FUNCTION
     if driver != "psycopg2":
@@ -50,6 +55,16 @@ def do_connect(
     connect_args = {}
     if schema is not None:
         connect_args["options"] = f"-csearch_path={schema}"
+    if hostaddr:
+        connect_args["hostaddr"] = hostaddr
+    if sslcert:
+        connect_args["sslcert"] = sslcert
+    if sslkey:
+        connect_args["sslkey"] = sslkey
+    if sslrootcert:
+        connect_args["sslrootcert"] = sslrootcert
+    if sslmode:
+        connect_args["sslmode"] = sslmode
 
     engine = sa.create_engine(
         alchemy_url, connect_args=connect_args, poolclass=sa.pool.StaticPool


### PR DESCRIPTION
Adds several new options to Postgres `connections add`.

```
[--hostaddr HOSTADDR]        May be required to supply an address that differs from the name in the host option
[--sslcert SSLCERT]          Local path to your client certificate (client-cert.pem) file
[--sslkey SSLKEY]            Local path to your private client key (client-key.pem) file
[--sslrootcert] SSLROOTCERT  Local path to your root certificate (server-ca.pem) file
[--sslmode SSLMODE]          SSL mode
```

`--hostaddr` is one I didn't expect to need but I could only connect via TLS with `--sslmode=verify-full` if I included the real host name in `--host` (which for Cloud SQL was a complex string like "2-ab12ab12-ab12-12a1-1234-1abc12ab12ab.europe-west1.sql.goog") and supplied the IP address via `--hostaddr`. That is why I added that option too.