### PR TITLE
fix: Support char comparison fields in Teradata

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -160,7 +160,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
     return aggregate_configs
 
 
-def get_calculated_config(args, config_manager):
+def get_calculated_config(args, config_manager) -> List[dict]:
     """Return list of formatted calculated objects.
 
     Args:
@@ -290,9 +290,26 @@ def build_config_from_args(args: Namespace, config_manager: ConfigManager):
             comparison_fields = cli_tools.get_arg_list(
                 args.comparison_fields, default_value=[]
             )
-            config_manager.append_comparison_fields(
-                config_manager.build_config_comparison_fields(comparison_fields)
-            )
+
+            if (
+                config_manager.source_client.name == "teradata"
+                or config_manager.target_client.name == "teradata"
+            ):
+
+                full_comp_fields = config_manager._add_rstrip_for_td_str_comp_fields(
+                    comparison_fields
+                )
+                print(full_comp_fields)
+                comp_config = config_manager.build_config_comparison_fields(
+                    full_comp_fields
+                )
+                print(comp_config)
+                config_manager.append_comparison_fields(comp_config)
+
+            else:
+                config_manager.append_comparison_fields(
+                    config_manager.build_config_comparison_fields(comparison_fields)
+                )
 
         # Append primary_keys
         primary_keys = cli_tools.get_arg_list(args.primary_keys)

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -291,25 +291,19 @@ def build_config_from_args(args: Namespace, config_manager: ConfigManager):
                 args.comparison_fields, default_value=[]
             )
 
+            # As per #1190, add rstrip for Teradata string comparison fields
             if (
                 config_manager.source_client.name == "teradata"
                 or config_manager.target_client.name == "teradata"
             ):
 
-                full_comp_fields = config_manager._add_rstrip_for_td_str_comp_fields(
+                comparison_fields = config_manager.add_rstrip_to_comp_fields(
                     comparison_fields
                 )
-                print(full_comp_fields)
-                comp_config = config_manager.build_config_comparison_fields(
-                    full_comp_fields
-                )
-                print(comp_config)
-                config_manager.append_comparison_fields(comp_config)
 
-            else:
-                config_manager.append_comparison_fields(
-                    config_manager.build_config_comparison_fields(comparison_fields)
-                )
+            config_manager.append_comparison_fields(
+                config_manager.build_config_comparison_fields(comparison_fields)
+            )
 
         # Append primary_keys
         primary_keys = cli_tools.get_arg_list(args.primary_keys)

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -508,48 +508,54 @@ class ConfigManager(object):
             verbose=verbose,
         )
 
-    def _add_rstrip_for_td_str_comp_fields(self, comparison_fields: List[str]):
+    def add_rstrip_to_comp_fields(self, comparison_fields: List[str]) -> List[str]:
+        """As per #1190, add an rstrip calculated field for Teradata string comparison fields.
+
+        Parameters:
+            comparison_fields: List[str] of comparison field columns
+        Returns:
+            comp_fields_with_aliases: List[str] of comparison field columns with rstrip aliases
+        """
+        logging.info(
+            "Adding rtrim() to string comparison fields due to Teradata CHAR padding."
+        )
         source_table = self.get_source_ibis_calculated_table()
         target_table = self.get_target_ibis_calculated_table()
         casefold_source_columns = {x.casefold(): str(x) for x in source_table.columns}
         casefold_target_columns = {x.casefold(): str(x) for x in target_table.columns}
 
-        string_comp_fields = []
-        full_comp_fields = []
+        comp_fields_with_aliases = []
         calculated_configs = []
-        for comparison_field in comparison_fields:
-            if comparison_field.casefold() not in casefold_source_columns:
-                raise ValueError(f"Column DNE in source: {comparison_field}")
-            if comparison_field.casefold() not in casefold_target_columns:
-                raise ValueError(f"Column DNE in target: {comparison_field}")
+        for field in comparison_fields:
+            if field.casefold() not in casefold_source_columns:
+                raise ValueError(f"Column DNE in source: {field}")
+            if field.casefold() not in casefold_target_columns:
+                raise ValueError(f"Column DNE in target: {field}")
 
             source_ibis_type = source_table[
-                casefold_source_columns[comparison_field.casefold()]
+                casefold_source_columns[field.casefold()]
             ].type()
             target_ibis_type = target_table[
-                casefold_target_columns[comparison_field.casefold()]
+                casefold_target_columns[field.casefold()]
             ].type()
 
             if source_ibis_type.is_string() or target_ibis_type.is_string():
-                string_comp_fields.append(comparison_field.casefold())
-                full_comp_fields.append(f"rstrip__{comparison_field.casefold()}")
-            else:
-                full_comp_fields.append(comparison_field)
-
-        for field in string_comp_fields:
-            calculated_configs.append(
-                self.build_config_calculated_fields(
-                    [casefold_source_columns[field]],
-                    [casefold_target_columns[field]],
-                    "rstrip",
-                    f"rstrip__{field}",
-                    0,
+                alias = f"rstrip__{field.casefold()}"
+                calculated_configs.append(
+                    self.build_config_calculated_fields(
+                        [casefold_source_columns[field.casefold()]],
+                        [casefold_target_columns[field.casefold()]],
+                        "rstrip",
+                        alias,
+                        0,
+                    )
                 )
-            )
+                comp_fields_with_aliases.append(alias)
+            else:
+                comp_fields_with_aliases.append(field)
 
-        print(calculated_configs)
         self.append_calculated_fields(calculated_configs)
-        return full_comp_fields
+        return comp_fields_with_aliases
 
     def build_config_comparison_fields(self, fields, depth=None):
         """Return list of field config objects."""
@@ -641,7 +647,7 @@ class ConfigManager(object):
         cast_type=None,
         depth=0,
     ):
-        """Create calculated field config used as a pre-aggregation step. Appends to calulated fields if does not already exist and returns created config."""
+        """Create calculated field config used as a pre-aggregation step. Appends to calculated fields if does not already exist and returns created config."""
         calculated_config = {
             consts.CONFIG_CALCULATED_SOURCE_COLUMNS: [source_column],
             consts.CONFIG_CALCULATED_TARGET_COLUMNS: [target_column],

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -527,6 +527,30 @@ def test_row_validation_char_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_char_comp_field_to_bigquery():
+    """Teradata to BigQuery char comparison field validation.
+    Due to a Teradata client "quirk" comparison fields should add an rstrip()
+    """
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "row",
+            "-sc=td-conn",
+            "-tc=bq-conn",
+            "-tbls=udf.dvt_core_types=pso_data_validator.dvt_core_types",
+            "--primary-keys=id",
+            "-comp-fields=col_char_2",
+        ]
+    )
+    df = run_test_from_cli_args(args)
+    id_type_test_assertions(df)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_row_validation_pangrams_to_bigquery():
     """Teradata to BigQuery dvt_pangrams row validation.
     This is testing comparisons across a wider set of characters than standard test data.

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -540,11 +540,11 @@ def test_row_validation_char_comp_field_to_bigquery():
             "-tc=bq-conn",
             "-tbls=udf.dvt_core_types=pso_data_validator.dvt_core_types",
             "--primary-keys=id",
-            "-comp-fields=col_char_2",
+            "-comp-fields=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
         ]
     )
     df = run_test_from_cli_args(args)
-    id_type_test_assertions(df)
+    id_type_test_assertions(df, expected_rows=45)
 
 
 @mock.patch(


### PR DESCRIPTION
Closes #1190 

Due to a Teradata client "quirk" extra padding is added to CHAR data types. This adds an rtrim() when doing comparison field row validations. It affects all string comparison fields when Teradata is a source or target system.