### PR TITLE
fix: Oracle cast(decimal to string) caters for non-zero values <1

### DIFF
--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -378,7 +378,10 @@ def sa_cast_decimal_when_scale_padded_fmt_fm(t, op):
         #     return (sa.cast(sa.func.trim_scale(arg), typ))
         precision = arg_dtype.precision or 38
         fmt = (
-            "FM" + ("9" * (precision - arg_dtype.scale)) + "." + ("9" * arg_dtype.scale)
+            "FM"
+            + ("9" * (precision - arg_dtype.scale - 1))
+            + "0."
+            + ("9" * arg_dtype.scale)
         )
         return sa.func.rtrim(sa.func.to_char(sa_arg, fmt), ".")
     return None

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -480,23 +480,6 @@ def sa_cast_mysql(t, op):
     return sa_fixed_cast(t, op)
 
 
-def sa_cast_oracle(t, op):
-    arg = op.arg
-    typ = op.to
-    arg_dtype = arg.output_dtype
-
-    sa_arg = t.translate(arg)
-    if arg_dtype.is_binary() and typ.is_string():
-        # Binary to string cast is a "to hex" conversion for DVT.
-        return sa.func.lower(sa.func.rawtohex(sa_arg))
-    elif arg_dtype.is_string() and typ.is_binary():
-        # Binary from string cast is a "from hex" conversion for DVT.
-        return sa.func.hextoraw(sa_arg)
-
-    # Follow the original Ibis code path.
-    return sa_fixed_cast(t, op)
-
-
 def sa_cast_snowflake(t, op):
     custom_cast = sa_cast_decimal_when_scale_padded_fmt_fm(t, op)
     if custom_cast is not None:
@@ -624,7 +607,6 @@ ImpalaExprTranslator._registry[Strftime] = strftime_impala
 ImpalaExprTranslator._registry[BinaryLength] = sa_format_binary_length
 
 if OracleExprTranslator:
-    OracleExprTranslator._registry[Cast] = sa_cast_oracle
     OracleExprTranslator._registry[RawSQL] = sa_format_raw_sql
     OracleExprTranslator._registry[HashBytes] = sa_format_hashbytes_oracle
     OracleExprTranslator._registry[ToChar] = sa_format_to_char

--- a/third_party/ibis/ibis_oracle/registry.py
+++ b/third_party/ibis/ibis_oracle/registry.py
@@ -105,8 +105,12 @@ def _cast(t, op):
     arg_dtype = arg.output_dtype
 
     sa_arg = t.translate(arg)
-    if arg_dtype.is_decimal() and typ.is_string():
-        # Specialize going from decimal type to a string.
+    if (
+        arg_dtype.is_decimal()
+        and typ.is_string()
+        and (arg_dtype.scale is None or arg_dtype.scale > 0)
+    ):
+        # Specialize going from fractional decimal type to a string.
         # Oracle has an edge case that non-zero values <1 are converted to a string without a leading zero.
         # For example 0.5 becomes ".5", -0.5 becomes "-.5". This does not match most supported engines.
         # When we have precision/scale we can use a TO_CHAR format but Oracle supports NUMBER(*) - without precision/scale.


### PR DESCRIPTION
This PR fixes two issues:

1) Oracle non-zero NUMBERs < 1 (or > -1) were missing a leading zero when cast to string.
2) PostgreSQL non-zero DECIMALs < 1 (or > -1) were missing a leading zero when cast to string, but only if they had precision/scale.

My test plan is to:

1) Change row 1 in dvt_core_types.col_dec_10_2 to contain a value < 1. This is testing a column with a precision and scale. It will weed out any issues with other engines. Other issues that are identified will result in new issues and disabled tests.
2) Change row 1 in dvt_ora2pg_types.col_num to contain a negative value > -1. This will test columns that have no precision/scale which I believe applies to Oracle and PostgreSQL only. It also tests a negative value.

Because our test tables are not version controlled I need to time this correctly and after merging this PR, merge `develop` into other feature branches.