### PR TITLE
fix: Support DATE '0001-01-01' comparison fields

### DIFF
--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -579,8 +579,13 @@ def string_to_epoch(ts: str):
     from dateutil.tz import UTC
     from datetime import datetime, timezone
 
-    parsed_ts = isoparse(ts).astimezone(UTC)
-    return (parsed_ts - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()
+    try:
+        parsed_ts = isoparse(ts).astimezone(UTC)
+        return (parsed_ts - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()
+    except ValueError:
+        # Dates that start with 0 cannot be converted to UTC
+        parsed_ts = isoparse(ts)
+        return (parsed_ts - datetime(1970, 1, 1)).total_seconds()
 
 
 @execute_node.register(ops.ExtractEpochSeconds, (datetime.datetime, pd.Series))

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -583,7 +583,7 @@ def string_to_epoch(ts: str):
         parsed_ts = isoparse(ts).astimezone(UTC)
         return (parsed_ts - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()
     except ValueError:
-        # Dates that start with 0 cannot be converted to UTC
+        # Support DATE '0001-01-01' which throws error when converted to UTC
         parsed_ts = isoparse(ts)
         return (parsed_ts - datetime(1970, 1, 1)).total_seconds()
 


### PR DESCRIPTION
Fixes #1193 

Previously dates starting with zero i.e. DATE '0001-01-01' in comparison fields would throw an error when convertin to UTC`isoparse(timestamp).astimezone(UTC)` since it's an invalid UTC timestamp.

This fix implements a fix so date columns can calculate epoch seconds without UTC conversion. The timedelta generated is the same since DATE fields don't support timezones innately. 