### PR TITLE
fix: Ensure Teradata OutofBound dates don't affect other date columns

### DIFF
--- a/tests/local_check.sh
+++ b/tests/local_check.sh
@@ -17,6 +17,9 @@
 # Step 1: After finishing your development, activate your virtual environment
 # Step 2: Execute this script only after the virtual env activation
 
+# install/update all necessary libraries
+pip install pytest pytest-cov pyfakefs==4.6.2 freezegun black==22.3.0 flake8 
+
 # check unit tests and coverage
 echo "Start TEST COVERAGE"
 pytest --quiet --cov=data_validation --cov=tests.unit --cov-append --cov-config=.coveragerc --cov-report=term tests/unit

--- a/third_party/ibis/ibis_teradata/__init__.py
+++ b/third_party/ibis/ibis_teradata/__init__.py
@@ -236,7 +236,7 @@ class Backend(BaseSQLBackend):
             # Suppress pandas warning of SQLAlchemy connectable DB support
             warnings.simplefilter("ignore")
             df = pandas.read_sql(sql, self.client)
-                
+
             for col in schema.names:
                 if schema.fields[col].is_date():
                     # Cast date cols as datetime64. Large timestamps i.e. '9999-12-31'

--- a/third_party/ibis/ibis_teradata/__init__.py
+++ b/third_party/ibis/ibis_teradata/__init__.py
@@ -231,22 +231,21 @@ class Backend(BaseSQLBackend):
         self._log(sql)
 
         schema = self.ast_schema(query_ast, **kwargs)
-        # Date columns are in the Dataframe as "object", using parse_dates to ensure they have a better data type.
-        date_cols = {
-            _: "datetime64[ns]" for _ in schema.names if schema.fields[_].is_date()
-        }
 
         with warnings.catch_warnings():
             # Suppress pandas warning of SQLAlchemy connectable DB support
             warnings.simplefilter("ignore")
             df = pandas.read_sql(sql, self.client)
-
-            try:
-                # Cast date_cols as datetime64. Large timestamps i.e. '9999-12-31'
-                # will throw OutOfBoundsDatetime so keep those as 'object' data type.
-                df = df.astype(date_cols)
-            except pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime as e:
-                pass
+                
+            for col in schema.names:
+                if schema.fields[col].is_date():
+                    # Cast date cols as datetime64. Large timestamps i.e. '9999-12-31'
+                    # will throw OutOfBoundsDatetime so keep those as 'object' data type.
+                    dtype_mapping = {col: "datetime64[ns]"}
+                    try:
+                        df = df.astype(dtype_mapping)
+                    except pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime as e:
+                        pass
 
         if df.empty:
             # Empty df infers an 'object' data type, update to float64 and datetime64.


### PR DESCRIPTION
Closes #1218 

Previously, if one date column was OutOfBounds (large timestamps '9999-12-31' or dates starting with 0 '0001-01-01'), all date fields would be converted to an 'object' data type in the pandas schema. This causes issues when comparing to the standard 'datetime64[ns]' dates in BQ or other DBs.

This PR fixes it so that only OutOfBounds date columns get converted to 'object' data types.