### PR TITLE
docs: Update Cloud Functions sample to support Cloud Scheduler job triggering

### DIFF
--- a/samples/cloud_functions/main.py
+++ b/samples/cloud_functions/main.py
@@ -33,8 +33,10 @@ def main(request):
 
     request (flask.Request): HTTP request object.
     """
+    request = request.get_data()
     try:
-        config = request.json["config"]
+        request_json = json.loads(request.decode())
+        config = request_json.get("config")
         validator = DataValidation(config)
         df = validator.execute()
 


### PR DESCRIPTION
Suggested modification to improve support for Cloud Scheduler job triggering. With the original approach, DVT jobs triggered via Cloud Scheduler are getting hung up on line #37 where configs are processed. 

I followed the pattern used with https://github.com/GoogleCloudPlatform/community/blob/master/archived/using-scheduler-invoke-private-functions-oidc/index.md

Using this pattern, I confirmed that (1) users can trigger DVT jobs with the cloud scheduler AND (2) jobs triggered using the curl test command continue to trigger as expected.