### PR TITLE
chore: Remove redundant code from build_config_calculated_fields()

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -914,34 +914,9 @@ class ConfigManager(object):
         calc_type: str,
         alias: str,
         depth: int,
-        supported_types=None,
-        arg_value=None,
         custom_params: Optional[dict] = None,
     ) -> dict:
         """Returns list of calculated fields"""
-        source_table = self.get_source_ibis_calculated_table(depth=depth)
-        target_table = self.get_target_ibis_calculated_table(depth=depth)
-
-        casefold_source_columns = {x.casefold(): str(x) for x in source_table.columns}
-        casefold_target_columns = {x.casefold(): str(x) for x in target_table.columns}
-
-        allowlist_columns = arg_value or casefold_source_columns
-        for column in casefold_source_columns:
-            column_type_str = str(source_table[casefold_source_columns[column]].type())
-            column_type = column_type_str.split("(")[0]
-            if column not in allowlist_columns:
-                continue
-            elif column not in casefold_target_columns:
-                logging.info(
-                    f"Skipping {calc_type} on {column} as column is not present in target table"
-                )
-                continue
-            elif supported_types and column_type not in supported_types:
-                if self.verbose:
-                    msg = f"Skipping {calc_type} on {column} due to data type: {column_type}"
-                    logging.info(msg)
-                continue
-
         calculated_config = {
             consts.CONFIG_CALCULATED_SOURCE_COLUMNS: source_reference,
             consts.CONFIG_CALCULATED_TARGET_COLUMNS: target_reference,


### PR DESCRIPTION
There is code in `build_config_calculated_fields()` which can burn a lot of CPU for tables with many columns but serves no purpose.

We never pass in values for the `supported_types` and `arg_value` parameters. This means the loop in the method will never reach either logger call and therefore serves no purpose at all. After removing the loop the casefold variables become redundant and then the calls to `self.get_source_ibis_calculated_table`/`self.get_target_ibis_calculated_table` also become redundant.

I've compared these changes to develop and there's only a marginal improvement because all of our current test tables are narrow.

- Branch `develop`: 50m18s
- Branch: `config-mgr-performance`: 44m48s


For a 400 column table manual test, only writing to Yaml not actually running the validation, I saw more dramatic improvements:

Branch `develop`:
```
$ time data-validation  validate row -sc=ora -tc=ora \
-tbls=pso_data_validator.dvt_many_cols --primary-keys=id \
--hash='*' --filter-status=fail --config-file=/tmp/many-feat.yaml

08/20/2024 04:10:48 PM-INFO: Success! Config output written to /tmp/many-feat.yaml

real	0m21.274s
user	0m20.447s
sys	0m1.262s
```

Branch `config-mgr-performance`:
```
$ time data-validation  validate row -sc=ora -tc=ora \
-tbls=pso_data_validator.dvt_many_cols --primary-keys=id \
--hash='*' --filter-status=fail --config-file=/tmp/many-feat.yaml
08/20/2024 04:11:27 PM-INFO: Success! Config output written to /tmp/many-feat.yaml

real	0m3.718s
user	0m3.104s
sys	0m1.163s
```

21s down to 4s.

And for `custom-query` even more dramatic:

Branch `develop`:
```
$ time data-validation -v validate custom-query row -sc=ora -tc=ora \
-sqf=/tmp/many.sql -tqf=/tmp/many.sql --primary-keys=id \
--hash='*' --config-file=/tmp/many-custom-q.yaml

08/20/2024 04:13:10 PM-INFO: Success! Config output written to /tmp/many-custom-q.yaml

real	1m3.395s
user	1m2.689s
sys	0m1.390s
```

Branch `config-mgr-performance`:
```
$ time data-validation -v validate custom-query row -sc=ora -tc=ora \
-sqf=/tmp/many.sql -tqf=/tmp/many.sql --primary-keys=id \
--hash='*' --config-file=/tmp/many-custom-q2.yaml

08/20/2024 04:13:28 PM-INFO: Success! Config output written to /tmp/many-custom-q.yaml

real	0m3.949s
user	0m3.391s
sys	0m0.978s
```

1m3s down to 4s.