### PR TITLE
feat: Adding exclude_columns flag for row validation hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ data-validation (--verbose or -v) (--log-level or -ll) validate row
   --hash COLUMNS        Comma separated list of columns to hash or * for all columns
   --concat COLUMNS      Comma separated list of columns to concatenate or * for all columns (use if a common hash function is not available between databases)
   [--exclude-columns or -ec]
-                        Flag to indicate the list of columns provided should be excluded and not included.
+                        Flag to indicate the list of columns provided should be excluded from hash or concat instead of included.
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
@@ -409,7 +409,7 @@ data-validation (--verbose or -v) (--log-level or -ll) validate custom-query row
   --primary-key or -pk JOIN_KEY
                        Common column between source and target tables for join
   [--exclude-columns or -ec]
-                        Flag to indicate the list of columns provided should be excluded and not included.
+                        Flag to indicate the list of columns provided should be excluded from hash or concat instead of included.
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ data-validation (--verbose or -v) (--log-level or -ll) validate row
                         See: *Calculated Fields* section for details
   --hash COLUMNS        Comma separated list of columns to hash or * for all columns
   --concat COLUMNS      Comma separated list of columns to concatenate or * for all columns (use if a common hash function is not available between databases)
+  [--exclude-columns or -ec]
+                        Flag to indicate the list of columns provided should be excluded and not included.
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
@@ -406,6 +408,8 @@ data-validation (--verbose or -v) (--log-level or -ll) validate custom-query row
                         (use if a common hash function is not available between databases)
   --primary-key or -pk JOIN_KEY
                        Common column between source and target tables for join
+  [--exclude-columns or -ec]
+                        Flag to indicate the list of columns provided should be excluded and not included.
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -174,14 +174,18 @@ def get_calculated_config(args, config_manager: ConfigManager) -> List[dict]:
             if config_manager.hash == "*"
             else cli_tools.get_arg_list(config_manager.hash)
         )
-        fields = config_manager.build_dependent_aliases("hash", col_list)
+        fields = config_manager.build_dependent_aliases(
+            "hash", col_list, args.exclude_columns
+        )
     elif config_manager.concat:
         col_list = (
             None
             if config_manager.concat == "*"
             else cli_tools.get_arg_list(config_manager.concat)
         )
-        fields = config_manager.build_dependent_aliases("concat", col_list)
+        fields = config_manager.build_dependent_aliases(
+            "concat", col_list, args.exclude_columns
+        )
 
     if len(fields) > 0:
         max_depth = max([x["depth"] for x in fields])

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -444,6 +444,12 @@ def _configure_row_parser(
         help="Float max threshold for percent difference",
     )
     optional_arguments.add_argument(
+        "--exclude-columns",
+        "-ec",
+        action="store_true",
+        help="Flag to indicate the list of columns should be excluded from hash or concat instead of included.",
+    )
+    optional_arguments.add_argument(
         "--filters",
         "-filters",
         help="Filters in the format source_filter:target_filter",

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1021,7 +1021,9 @@ class ConfigManager(object):
 
         return order_of_operations
 
-    def build_dependent_aliases(self, calc_type: str, col_list=None) -> List[Dict]:
+    def build_dependent_aliases(
+        self, calc_type: str, col_list=None, exclude_cols=False
+    ) -> List[Dict]:
         """This is a utility function for determining the required depth of all fields"""
         source_table = self.get_source_ibis_calculated_table()
         target_table = self.get_target_ibis_calculated_table()
@@ -1031,17 +1033,35 @@ class ConfigManager(object):
 
         if col_list:
             casefold_col_list = [x.casefold() for x in col_list]
-            # Filter columns based on col_list if provided
-            casefold_source_columns = {
-                k: v
-                for (k, v) in casefold_source_columns.items()
-                if k in casefold_col_list
-            }
-            casefold_target_columns = {
-                k: v
-                for (k, v) in casefold_target_columns.items()
-                if k in casefold_col_list
-            }
+            if exclude_cols:
+                # Filter columns based on col_list if provided
+                casefold_source_columns = {
+                    k: v
+                    for (k, v) in casefold_source_columns.items()
+                    if k not in casefold_col_list
+                }
+                casefold_target_columns = {
+                    k: v
+                    for (k, v) in casefold_target_columns.items()
+                    if k not in casefold_col_list
+                }
+            else:
+                # Filter columns based on col_list if provided
+                casefold_source_columns = {
+                    k: v
+                    for (k, v) in casefold_source_columns.items()
+                    if k in casefold_col_list
+                }
+                casefold_target_columns = {
+                    k: v
+                    for (k, v) in casefold_target_columns.items()
+                    if k in casefold_col_list
+                }
+        else:
+            if exclude_cols:
+                raise ValueError(
+                    "Exclude columns flag cannot be present with column list '*'"
+                )
 
         column_aliases = {}
         col_names = []

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1034,7 +1034,7 @@ class ConfigManager(object):
         if col_list:
             casefold_col_list = [x.casefold() for x in col_list]
             if exclude_cols:
-                # Filter columns based on col_list if provided
+                # Exclude columns based on col_list if provided
                 casefold_source_columns = {
                     k: v
                     for (k, v) in casefold_source_columns.items()
@@ -1046,7 +1046,7 @@ class ConfigManager(object):
                     if k not in casefold_col_list
                 }
             else:
-                # Filter columns based on col_list if provided
+                # Include columns based on col_list if provided
                 casefold_source_columns = {
                     k: v
                     for (k, v) in casefold_source_columns.items()
@@ -1057,11 +1057,10 @@ class ConfigManager(object):
                     for (k, v) in casefold_target_columns.items()
                     if k in casefold_col_list
                 }
-        else:
-            if exclude_cols:
-                raise ValueError(
-                    "Exclude columns flag cannot be present with column list '*'"
-                )
+        elif exclude_cols:
+            raise ValueError(
+                "Exclude columns flag cannot be present with column list '*'"
+            )
 
         column_aliases = {}
         col_names = []

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -520,3 +520,40 @@ def test__decimal_column_too_big_for_pandas(module_under_test):
     c1 = dt.Decimal(38, 10)
     c2 = dt.Decimal(38, 10)
     assert config_manager._decimal_column_too_big_for_pandas(c1, c2)
+
+
+# def test_build_dependent_aliases(module_under_test):
+#    config_manager = module_under_test.ConfigManager(
+#        copy.copy(SAMPLE_CONFIG), MockIbisClient(), MockIbisClient(), verbose=False
+#    )
+#
+#    #Only including col a
+#    aggregate_configs = config_manager.build_dependent_aliases(
+#        "hash", ["a"], False
+#    )
+#    assert TBD
+
+
+# def test_build_dependent_aliases_ec(module_under_test):
+#    config_manager = module_under_test.ConfigManager(
+#        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+#    )
+#
+#    #Excluding col a, should hash b,c and d.
+#    aggregate_configs = config_manager.build_dependent_aliases(
+#            "hash", ["a"] , True
+#        )
+#    assert TBD
+
+
+def test_build_dependent_aliases_exception(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        config_manager.build_dependent_aliases("hash", None, True)
+    assert (
+        str(excinfo.value)
+        == "Exclude columns flag cannot be present with column list '*'"
+    )

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -62,6 +62,20 @@ SAMPLE_ROW_CONFIG = {
     consts.CONFIG_CALCULATED_FIELDS: ["name", "station_id"],
 }
 
+SAMPLE_ROW_CONFIG_DEP_ALIASES = {
+    # BigQuery Specific Connection Config
+    consts.CONFIG_SOURCE_CONN: {"type": "DNE connection"},
+    consts.CONFIG_TARGET_CONN: {"type": "DNE connection"},
+    # Validation Type
+    consts.CONFIG_TYPE: "Row",
+    # Configuration Required Depending on Validator Type
+    consts.CONFIG_SCHEMA_NAME: "bigquery-public-data.new_york_citibike",
+    consts.CONFIG_TABLE_NAME: "citibike_trips",
+    consts.CONFIG_GROUPED_COLUMNS: [],
+    consts.CONFIG_THRESHOLD: 0.0,
+    consts.CONFIG_PRIMARY_KEYS: [{"source_column": "c", "target_column": "c"}],
+}
+
 AGGREGATE_CONFIG_A = {
     consts.CONFIG_SOURCE_COLUMN: "a",
     consts.CONFIG_TARGET_COLUMN: "a",
@@ -141,6 +155,7 @@ class MockIbisClient(object):
 class MockIbisTable(object):
     def __init__(self):
         self.columns = ["a", "b", "c", "d"]
+        self.schema = MockIbisSchema()
 
     def __getitem__(self, key):
         return MockIbisColumn(key)
@@ -148,6 +163,20 @@ class MockIbisTable(object):
     def mutate(self, fields):
         self.columns = self.columns + fields
         return self
+
+
+class MockIbisSchema(object):
+    def __init__(self):
+        self.schema = {
+            "a": "int64",
+            "b": "int64",
+            "c": "!string",
+            "d": "int64",
+            "e": "int64",
+        }
+
+    def __call__(self):
+        return self.schema
 
 
 class MockIbisColumn(object):
@@ -522,33 +551,41 @@ def test__decimal_column_too_big_for_pandas(module_under_test):
     assert config_manager._decimal_column_too_big_for_pandas(c1, c2)
 
 
-# def test_build_dependent_aliases(module_under_test):
-#    config_manager = module_under_test.ConfigManager(
-#        copy.copy(SAMPLE_CONFIG), MockIbisClient(), MockIbisClient(), verbose=False
-#    )
-#
-#    #Only including col a
-#    aggregate_configs = config_manager.build_dependent_aliases(
-#        "hash", ["a"], False
-#    )
-#    assert TBD
+def test_build_dependent_aliases(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_ROW_CONFIG_DEP_ALIASES, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+
+    # Hash includes col a
+    dependent_aliases = config_manager.build_dependent_aliases(
+        "hash", ["a"], exclude_cols=False
+    )
+    concat_config = dependent_aliases[-2]
+    assert concat_config["source_reference"] == [
+        "rstrip__ifnull__cast__a",
+    ]
 
 
-# def test_build_dependent_aliases_ec(module_under_test):
-#    config_manager = module_under_test.ConfigManager(
-#        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
-#    )
-#
-#    #Excluding col a, should hash b,c and d.
-#    aggregate_configs = config_manager.build_dependent_aliases(
-#            "hash", ["a"] , True
-#        )
-#    assert TBD
+def test_build_dependent_aliases_exclude_columns(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_ROW_CONFIG_DEP_ALIASES, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+
+    # Hash excludes col a
+    dependent_aliases = config_manager.build_dependent_aliases(
+        "hash", ["a"], exclude_cols=True
+    )
+    concat_config = dependent_aliases[-2]
+    assert concat_config["source_reference"] == [
+        "rstrip__ifnull__cast__b",
+        "rstrip__ifnull__cast__c",
+        "rstrip__ifnull__cast__d",
+    ]
 
 
 def test_build_dependent_aliases_exception(module_under_test):
     config_manager = module_under_test.ConfigManager(
-        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+        SAMPLE_ROW_CONFIG_DEP_ALIASES, MockIbisClient(), MockIbisClient(), verbose=False
     )
 
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
Closes issue https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/880

Added parameter --exclude-columns or -ec  as a flag that identifies the column list as an exclusion, and not an inclusion when calculating hash operations in row validation and custom query row.
Updated Read Me with new parameter.