### PR TITLE
fix: Set `RAND()` as default for DB2's random function

### DIFF
--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -448,7 +448,8 @@ def _literal(t, op):
 
 
 def _random(t, expr):
-    return sa.func.random()
+    # https://stackoverflow.com/a/38297161 
+    return sa.func.random(sa.func.setseed(1))
 
 
 def _day_of_week_index(t, op):

--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -448,8 +448,7 @@ def _literal(t, op):
 
 
 def _random(t, expr):
-    # https://stackoverflow.com/a/38297161 
-    return sa.func.random(sa.func.setseed(1))
+    return sa.func.rand()
 
 
 def _day_of_week_index(t, op):


### PR DESCRIPTION
Fixes #1239 
Fixes #1020

Error was still happening as reported in issue https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1239 even though it is a LUW version that is supported by DVT. 

This PR changes the implementation to be using RAND() as default since the method is always available in all DB2 versions.