### PR TITLE
fix: Pass default seed value when using DB2's `RAND()` function

### DIFF
--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -448,8 +448,7 @@ def _literal(t, op):
 
 
 def _random(t, expr):
-    sa.func.setseed(1)
-    return sa.func.rand()
+    return sa.func.rand(1)
 
 
 def _day_of_week_index(t, op):

--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -448,6 +448,7 @@ def _literal(t, op):
 
 
 def _random(t, expr):
+    sa.func.setseed(1)
     return sa.func.rand()
 
 

--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -448,7 +448,8 @@ def _literal(t, op):
 
 
 def _random(t, expr):
-    return sa.func.rand(1)
+    # https://www.zobristinc.com/blog/db2-sql-error-sqlcode-418-sqlstate-42610/
+    return sa.func.rand(sa.cast(1, sa.INTEGER))
 
 
 def _day_of_week_index(t, op):


### PR DESCRIPTION
Fixes #1239