### PR TITLE
chore: bumping jellyfish version to 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dependencies = [
     "google-cloud-bigquery-storage==2.20.0",
     "google-cloud-spanner==3.36.0",
     "google-cloud-storage==2.10.0",
-    "jellyfish==1.0.0",
+    "jellyfish==1.1.0",
     "tabulate==0.9.0",
     "Flask==2.3.2",
     "parsy==2.1",


### PR DESCRIPTION
This morning I was trying to understand how to contribute and I spotted that the latest version of the jellyfish package is not being used. So, I've bumped it to 1.1.0 as an excuse to learn about how to contribute.

Jellyfish changelog -> https://github.com/jamesturk/jellyfish/blob/main/docs/changelog.md