### PR TITLE
fix: Using datetime constants in filters

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1065,7 +1065,7 @@ def get_labels(arg_labels):
     return labels
 
 
-def get_filters(filter_value: str) -> list[dict]:
+def get_filters(filter_value: str) -> List[Dict]:
     """Returns filters for source and target from --filters argument.
     A filter is the condition that is used in a SQL WHERE clause.
     If only one filter is specified, it applies to both source and target

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -52,6 +52,7 @@ import sys
 import uuid
 import os
 import math
+import re
 from argparse import Namespace
 from typing import Dict, List, Optional
 from yaml import Dumper, Loader, dump, load
@@ -1064,26 +1065,33 @@ def get_labels(arg_labels):
     return labels
 
 
-def get_filters(filter_value):
-    """Returns parsed JSON from filter file. Backwards compatible for JSON input.
-
-    filter_value (str): Filter argument specified.
+def get_filters(filter_value: str) -> list[dict]:
+    """Returns filters for source and target from --filters argument.
+    A filter is the condition that is used in a SQL WHERE clause.
+    If only one filter is specified, it applies to both source and target
+    For a doc on regular expression for filters see docs/internal/filters_regex.md
     """
+
+    single_filter = r"([^':]*('[^']*')*)*"
+    double_filter = (
+        r"(?P<source>" + single_filter + r"):(?P<target>" + single_filter + r")"
+    )
     filter_config = []
-    filter_vals = filter_value.split(":")
-    if len(filter_vals) == 1:
+    if result := re.fullmatch(single_filter, filter_value):
+        if result.group(0) == "":
+            raise ValueError("Empty string not allowed in filter")
         filter_dict = {
             "type": "custom",
-            "source": filter_vals[0],
-            "target": filter_vals[0],
+            "source": result.group(0),
+            "target": result.group(0),
         }
-    elif len(filter_vals) == 2:
-        if not filter_vals[1]:
-            raise ValueError("Please provide valid target filter.")
+    elif result := re.fullmatch(double_filter, filter_value):
+        if result.group("source") == "" or result.group("target") == "":
+            raise ValueError("Empty string not allowed in filter")
         filter_dict = {
             "type": "custom",
-            "source": filter_vals[0],
-            "target": filter_vals[1],
+            "source": result.group("source"),
+            "target": result.group("target"),
         }
     else:
         raise ValueError("Unable to parse filter arguments.")

--- a/docs/internal/filters_regex.md
+++ b/docs/internal/filters_regex.md
@@ -1,0 +1,14 @@
+# Regular Expressions for filters
+
+## Background
+
+Filters can be a single SQL expression that evaluates to Boolean or two SQL expressions separated by a ':'. The initial implementation used `filters.split(':')`. This works for cases such as `cost > 2` and `cost >2:initial_cost >3`. When the SQL expression contains embedded ':' in timestamp strings, it does not work. A more sophisticated parsing of the SQL expression is needed. 
+
+## Derive the regular expression
+
+* A ':' does not occur in SQL expressions across the different database engines except in the context of bind variables, host variable and variable assignment. '::' was used in Postgres for casting and ':' can occur in column names in Salesforce. These uses are not allowed in DVT filters.
+* DVT does not need to parse the filter to ensure that it is a valid SQL expression. A filter such as '“column_name > 4' is not a valid SQL expression - since the '“”' around column_name needs to be closed. There is no SQL standard for quoting column names, Oracle uses '"', while BigQuery uses '`'.  When DVT generates code, the backends quote column names correctly. Parsing SQL expressions is too complicated and not necessary. DVT will pass the SQL expression to the database. If there is an error the database will detect and report it.
+* The definition for quoted strings in SQL is straightforward - a sequence of characters enclosed in “'“ (single quotes). If a single quote is part of a string, it needs to be doubled. A single quote cannot be escaped with an escape character.
+* A regular expression (re) for a sequence of zero or more characters not containing “'“ or “:” is `[^':]*`
+* An re for a strings - a sequence of zero of more characters not containing a “‘“ is `'[^']*'`
+* An re for a single_filter is `([^':]*('[^']*')*)*`. If separate filters are specified for source and target, the re is `([^':]*('[^']*')*)*:([^':]*('[^']*')*)*`. To extract the source and target filters, the re can be specified as `(?P<source>([^':]*('[^']*')*)*):(?P<target>([^':]*('[^']*')*)*)`.

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -416,21 +416,51 @@ def test_get_result_handler(test_input, expected):
     "test_input,expected",
     [
         (
-            "source:target",
-            [{"type": "custom", "source": "source", "target": "target"}],
+            "id < 5:row_id <5",
+            [{"type": "custom", "source": "id < 5", "target": "row_id <5"}],
         ),
-        ("source", [{"type": "custom", "source": "source", "target": "source"}]),
+        ("id < 5", [{"type": "custom", "source": "id < 5", "target": "id < 5"}]),
+        (
+            "name != 'John'",
+            [
+                {
+                    "type": "custom",
+                    "source": "name != 'John'",
+                    "target": "name != 'John'",
+                }
+            ],
+        ),
+        (
+            "name != 'St. John''s'",
+            [
+                {
+                    "type": "custom",
+                    "source": "name != 'St. John''s'",
+                    "target": "name != 'St. John''s'",
+                }
+            ],
+        ),
+        (
+            "mod_timestamp >= '2024-04-01 16:00:00 UTC':mod_timestamp >= '2020-04-01 16:00:00 UTC'",
+            [
+                {
+                    "type": "custom",
+                    "source": "mod_timestamp >= '2024-04-01 16:00:00 UTC'",
+                    "target": "mod_timestamp >= '2020-04-01 16:00:00 UTC'",
+                }
+            ],
+        ),
     ],
 )
 def test_get_filters(test_input, expected):
-    """Test get filters from file function."""
+    """Test get filters."""
     res = cli_tools.get_filters(test_input)
     assert res == expected
 
 
 @pytest.mark.parametrize(
     "test_input",
-    [("source:"), ("invalid:filter:count")],
+    [(""), ("source:"), ("invalid:filter:count")],
 )
 def test_get_filters_err(test_input):
     """Test get filters function returns error."""


### PR DESCRIPTION
Correctly parses `--filters` to handle datetime constants or other string literals that could have embedded ':'

Closes [1255](https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1255)