### PR TITLE
fix: big query run id message

### DIFF
--- a/data_validation/result_handlers/bigquery.py
+++ b/data_validation/result_handlers/bigquery.py
@@ -107,7 +107,7 @@ class BigQueryResultHandler(object):
             logging.info("No results to write to BigQuery")
         else:
             logging.info(
-                f'Results written to BigQuery, run id: {result_df["run_id"][0]}'
+                f'Results written to BigQuery, run id: {result_df.iloc[0]["run_id"]}'
             )
 
         # Handler also logs results after saving to BigQuery.

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -853,7 +853,7 @@ def test_console_data_shown_for_matching_validation_with_result_written_to_bq_in
     # Then...
     # 0 failures returned
     assert len(result_df) == 0
-    # The "Results written" message happens + "Empty DataFrame" because there are no failures to display
+    # The "No results" message happens + "Empty DataFrame" because there are no failures to display
     assert len(caplog.records) == 2
     assert caplog.records[0].message == "No results to write to BigQuery"
     assert caplog.records[1].message.startswith("Empty DataFrame")

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -401,10 +401,10 @@ SAMPLE_ROW_CONFIG_BQ_FAILURES = {
         },
     ],
     consts.CONFIG_RESULT_HANDLER: {
-            consts.CONFIG_TYPE: "BigQuery",
-            consts.PROJECT_ID: "my-project",
-            consts.TABLE_ID: "dataset.table_name",
-        },
+        consts.CONFIG_TYPE: "BigQuery",
+        consts.PROJECT_ID: "my-project",
+        consts.TABLE_ID: "dataset.table_name",
+    },
     consts.CONFIG_FORMAT: "text",
     consts.CONFIG_FILTER_STATUS: ["fail"],
 }
@@ -751,7 +751,9 @@ def test_bad_join_row_level_validation(module_under_test, fs):
     assert len(comparison_df) == 202
 
 
-def test_no_console_data_shown_for_validation_with_result_written_to_bq_in_info_mode(module_under_test, fs, caplog, monkeypatch):
+def test_no_console_data_shown_for_validation_with_result_written_to_bq_in_info_mode(
+    module_under_test, fs, caplog, monkeypatch
+):
     # Mock the big query client
     mock_bq_client = mock.create_autospec(bigquery.Client)
     monkeypatch.setattr(bigquery, "Client", value=mock_bq_client)
@@ -770,18 +772,18 @@ def test_no_console_data_shown_for_validation_with_result_written_to_bq_in_info_
     # Then...
     # 2 failures returned
     assert len(result_df) == 2
-    fail_df = result_df[
-        result_df["validation_status"] == consts.VALIDATION_STATUS_FAIL
-    ]
+    fail_df = result_df[result_df["validation_status"] == consts.VALIDATION_STATUS_FAIL]
     assert len(fail_df) == 2
     # Only the "Results written" message happens
     # Important because the results could include sensitive data, which some users need to exclude
     assert len(caplog.records) == 1
     run_id = result_df.iloc[0]["run_id"]
-    assert caplog.records[0].message == f'Results written to BigQuery, run id: {run_id}'
+    assert caplog.records[0].message == f"Results written to BigQuery, run id: {run_id}"
 
 
-def test_no_console_data_shown_for_matching_validation_with_result_written_to_bq_in_info_mode(module_under_test, fs, caplog, monkeypatch):
+def test_no_console_data_shown_for_matching_validation_with_result_written_to_bq_in_info_mode(
+    module_under_test, fs, caplog, monkeypatch
+):
     # Mock the big query client
     mock_bq_client = mock.create_autospec(bigquery.Client)
     monkeypatch.setattr(bigquery, "Client", value=mock_bq_client)
@@ -804,7 +806,9 @@ def test_no_console_data_shown_for_matching_validation_with_result_written_to_bq
     assert caplog.records[0].message == "No results to write to BigQuery"
 
 
-def test_console_data_shown_for_validation_with_result_written_to_bq_in_debug_mode(module_under_test, fs, caplog, monkeypatch):
+def test_console_data_shown_for_validation_with_result_written_to_bq_in_debug_mode(
+    module_under_test, fs, caplog, monkeypatch
+):
     # Mock the big query client
     mock_bq_client = mock.create_autospec(bigquery.Client)
     monkeypatch.setattr(bigquery, "Client", value=mock_bq_client)
@@ -823,19 +827,22 @@ def test_console_data_shown_for_validation_with_result_written_to_bq_in_debug_mo
     # Then...
     # 2 failures returned
     assert len(result_df) == 2
-    fail_df = result_df[
-        result_df["validation_status"] == consts.VALIDATION_STATUS_FAIL
-    ]
+    fail_df = result_df[result_df["validation_status"] == consts.VALIDATION_STATUS_FAIL]
     assert len(fail_df) == 2
     # The "Results written" message happens + info about the failed data
     assert len(caplog.records) == 2
     run_id = result_df.iloc[0]["run_id"]
-    assert caplog.records[0].message == f'Results written to BigQuery, run id: {run_id}'
-    assert "validation_name validation_type source_table_name source_column_name source_agg_value target_agg_value pct_difference validation_status" in caplog.records[1].message
-    assert f'fail {run_id}' in caplog.records[1].message
+    assert caplog.records[0].message == f"Results written to BigQuery, run id: {run_id}"
+    assert (
+        "validation_name validation_type source_table_name source_column_name source_agg_value target_agg_value pct_difference validation_status"
+        in caplog.records[1].message
+    )
+    assert f"fail {run_id}" in caplog.records[1].message
 
 
-def test_console_data_shown_for_matching_validation_with_result_written_to_bq_in_debug_mode(module_under_test, fs, caplog, monkeypatch):
+def test_console_data_shown_for_matching_validation_with_result_written_to_bq_in_debug_mode(
+    module_under_test, fs, caplog, monkeypatch
+):
     # Mock the big query client
     mock_bq_client = mock.create_autospec(bigquery.Client)
     monkeypatch.setattr(bigquery, "Client", value=mock_bq_client)


### PR DESCRIPTION
I started out on this PR by trying to add additional unit test scenarios around running row level validations where I'm writing results to BQ.

In particular these scenarios...

1. log level = INFO + some results returned with filter_status = fail -> Does not write results to console + we get the run id message
2. log level = INFO + no results returned with filter_status = fail -> Does not write results to console + we get the "No results" message
3. log level = DEBUG + some results returned with filter_status = fail -> Does write results to console + we get the run id message
4. log level = DEBUG + no results returned with filter_status = fail -> Does not write results to console (because there are none) + we get the "No results" message

I care about this stuff because I don't want to write sensitive info to the console and I want to keep track of the run IDs (or lack of one where there is no row validation failure)

I found that I was getting an exception when I was setting filter_status = fail.
Once I looked into it, I found that `result_df["run_id"][0]` was looking for a key = 0, which did not exist in my test case.
`result_df.iloc[0]["run_id"]` returns the run id for the first item in the DF so should get around this bug.

Related PR -> https://github.com/GoogleCloudPlatform/professional-services-data-validator/pull/1240

