### PR TITLE
feat: Enhance --tables-list to support schema.* shorthand for find-tables command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ over all columns ('*') will only run over numeric columns, unless the
 `--wildcard-include-string-len` or `--wildcard-include-timestamp` flags are present.
 
 ```
-data-validation  
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
@@ -100,7 +100,7 @@ data-validation
                         Target connection details
                         See: *Connections* section for each data source
   --tables-list or -tbls SOURCE_SCHEMA.SOURCE_TABLE=TARGET_SCHEMA.TARGET_TABLE
-                        Comma separated list of tables in the form schema.table=target_schema.target_table
+                        Comma separated list of tables in the form schema.table=target_schema.target_table. Or shorthand schema.* for all tables.
                         Target schema name and table name are optional.
                         i.e 'bigquery-public-data.new_york_citibike.citibike_trips'
   [--grouped-columns or -gc GROUPED_COLUMNS]
@@ -172,7 +172,7 @@ Under the hood, row validation uses
 apply functions such as IFNULL() or RTRIM(). These can be edited in the YAML or JSON config file to customize your row validation.
 
 ```
-data-validation 
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
@@ -224,7 +224,7 @@ data-validation
   [--trim-string-pks, -tsp]
                         Trims string based primary key values, intended for use when one engine uses padded string semantics (e.g. CHAR(n)) and the other does not (e.g. VARCHAR(n)).
   [--case-insensitive-match, -cim]
-                        Performs a case insensitive match by adding an UPPER() before comparison.                
+                        Performs a case insensitive match by adding an UPPER() before comparison.
 ```
 #### Generate Table Partitions for Large Table Row Validations
 
@@ -235,7 +235,7 @@ The command generates and stores multiple YAML validations each representing a c
 The command takes the same parameters as required for `Row Validation` *plus* a few parameters to support partitioning. Single and multiple primary keys are supported and keys can be of any indexable type, except for date and timestamp type. A parameter used in earlier versions, ```partition-key``` is no longer supported.
 
 ```
-data-validation 
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
@@ -262,7 +262,7 @@ data-validation
                         Directory Path to store YAML Config Files
                         GCS: Provide a full gs:// path of the target directory. Eg: `gs://<BUCKET>/partitions_dir`
                         Local: Provide a relative path of the target directory. Eg: `partitions_dir`
-  --partition-num INT, -pn INT 
+  --partition-num INT, -pn INT
                         Number of partitions into which the table should be split, e.g. 1000 or 10000
                         In case this value exceeds the row count of the source/target table, it will be decreased to max(source_row_count, target_row_count)
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
@@ -270,7 +270,7 @@ data-validation
                         See: *Validation Reports* section
   [--service-account or -sa PATH_TO_SA_KEY]
                         Service account to use for BigQuery result handler output.
-  [--parts-per-file INT], [-ppf INT] 
+  [--parts-per-file INT], [-ppf INT]
                         Number of partitions in a yaml file, default value 1.
   [--filters SOURCE_FILTER:TARGET_FILTER]
                         Colon separated string values of source and target filters.
@@ -285,7 +285,7 @@ data-validation
   [--trim-string-pks, -tsp]
                         Trims string based primary key values, intended for use when one engine uses padded string semantics (e.g. CHAR(n)) and the other does not (e.g. VARCHAR(n)).
   [--case-insensitive-match, -cim]
-                        Performs a case insensitive match by adding an UPPER() before comparison.     
+                        Performs a case insensitive match by adding an UPPER() before comparison.
 ```
 #### Schema Validations
 
@@ -295,7 +295,7 @@ types between source and target.
 Note: An exclamation point before a data type (`!string`) signifies the column is non-nullable or required.
 
 ```
-data-validation 
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
@@ -308,7 +308,7 @@ data-validation
                         Target connection details
                         See: *Connections* section for each data source
   --tables-list or -tbls SOURCE_SCHEMA.SOURCE_TABLE=TARGET_SCHEMA.TARGET_TABLE
-                        Comma separated list of tables in the form schema.table=target_schema.target_table
+                        Comma separated list of tables in the form schema.table=target_schema.target_table. Or shorthand schema.* for all tables.
                         Target schema name and table name are optional.
                         e.g.: 'bigquery-public-data.new_york_citibike.citibike_trips'
   [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
@@ -341,7 +341,7 @@ data-validation
 Below is the command syntax for custom query column validations.
 
 ```
-data-validation 
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
@@ -408,7 +408,7 @@ in the SELECT statement of both source_query.sql and target_query.sql.  See *Pri
 Below is the command syntax for custom query row validations.
 
 ```
-data-validation 
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
@@ -459,7 +459,7 @@ data-validation
   [--trim-string-pks, -tsp]
                         Trims string based primary key values, intended for use when one engine uses padded string semantics (e.g. CHAR(n)) and the other does not (e.g. VARCHAR(n)).
   [--case-insensitive-match, -cim]
-                        Performs a case insensitive match by adding an UPPER() before comparison.                    
+                        Performs a case insensitive match by adding an UPPER() before comparison.
 ```
 
 The [Examples](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/docs/examples.md)
@@ -471,7 +471,7 @@ The `validate` command takes a `--dry-run` command line flag that prints source
 and target SQL to stdout as JSON in lieu of performing a validation:
 
 ```
-data-validation 
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
@@ -507,11 +507,11 @@ GCS and local paths.
 You can use the `data-validation configs` command to run and view YAMLs.
 
 ```
-data-validation 
+data-validation
   [--verbose or -v ]
                         Verbose logging
   [--log-level or -ll]
-                        Log Level to be assigned. Supported levels are (DEBUG,INFO,WARNING,ERROR,CRITICAL). Defaults to INFO.    
+                        Log Level to be assigned. Supported levels are (DEBUG,INFO,WARNING,ERROR,CRITICAL). Defaults to INFO.
   configs run
   [--config-file or -c CONFIG_FILE]
                         Path to YAML config file to run. Supports local and GCS paths.
@@ -520,7 +520,7 @@ data-validation
   [--dry-run or -dr]    If this flag is present, prints the source and target SQL generated in lieu of running the validation.
   [--kube-completions or -kc]
                         Flag to indicate usage in Kubernetes index completion mode.
-                        See *Scaling DVT* section                   
+                        See *Scaling DVT* section
 ```
 
 ```

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -24,11 +24,11 @@ from data_validation import (
     cli_tools,
     clients,
     consts,
-    jellyfish_distance,
     state_manager,
 )
 from data_validation.config_manager import ConfigManager
 from data_validation.data_validation import DataValidation
+from data_validation.find_tables import find_tables_using_string_matching
 from data_validation.partition_builder import PartitionBuilder
 
 # by default yaml dumps lists as pointers. This disables that feature
@@ -432,71 +432,6 @@ def build_config_managers_from_yaml(args, config_file_path):
         config_managers.append(config_manager)
 
     return config_managers
-
-
-def _compare_match_tables(source_table_map, target_table_map, score_cutoff=0.8):
-    """Return dict config object from matching tables."""
-    # TODO(dhercher): evaluate if improved comparison and score cutoffs should be used.
-    table_configs = []
-
-    target_keys = target_table_map.keys()
-    for source_key in source_table_map:
-        target_key = jellyfish_distance.extract_closest_match(
-            source_key, target_keys, score_cutoff=score_cutoff
-        )
-        if target_key is None:
-            continue
-
-        table_config = {
-            consts.CONFIG_SCHEMA_NAME: source_table_map[source_key][
-                consts.CONFIG_SCHEMA_NAME
-            ],
-            consts.CONFIG_TABLE_NAME: source_table_map[source_key][
-                consts.CONFIG_TABLE_NAME
-            ],
-            consts.CONFIG_TARGET_SCHEMA_NAME: target_table_map[target_key][
-                consts.CONFIG_SCHEMA_NAME
-            ],
-            consts.CONFIG_TARGET_TABLE_NAME: target_table_map[target_key][
-                consts.CONFIG_TABLE_NAME
-            ],
-        }
-        table_configs.append(table_config)
-
-    return table_configs
-
-
-def get_table_map(client, allowed_schemas=None):
-    """Return dict with searchable keys for table matching."""
-    table_map = {}
-    table_objs = clients.get_all_tables(client, allowed_schemas=allowed_schemas)
-
-    for table_obj in table_objs:
-        table_key = ".".join([t for t in table_obj if t])
-        table_map[table_key] = {
-            consts.CONFIG_SCHEMA_NAME: table_obj[0],
-            consts.CONFIG_TABLE_NAME: table_obj[1],
-        }
-
-    return table_map
-
-
-def find_tables_using_string_matching(args):
-    """Return JSON String with matched tables for use in validations."""
-    score_cutoff = args.score_cutoff or 1
-
-    mgr = state_manager.StateManager()
-    source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
-    target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
-
-    allowed_schemas = cli_tools.get_arg_list(args.allowed_schemas)
-    source_table_map = get_table_map(source_client, allowed_schemas=allowed_schemas)
-    target_table_map = get_table_map(target_client)
-
-    table_configs = _compare_match_tables(
-        source_table_map, target_table_map, score_cutoff=score_cutoff
-    )
-    return json.dumps(table_configs)
 
 
 def run_raw_query_against_connection(args):

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1397,9 +1397,10 @@ def get_pre_build_configs(args: Namespace, validate_cmd: str) -> List[Dict]:
         filter_status = None
 
     pre_build_configs_list = []
-    tables_list = find_tables.expand_tables_of_asterisk(
-        tables_list, source_client, target_client
-    )
+    if config_type != consts.CUSTOM_QUERY:
+        tables_list = find_tables.expand_tables_of_asterisk(
+            tables_list, source_client, target_client
+        )
     for table_obj in tables_list:
         pre_build_configs = {
             "config_type": config_type,

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -116,7 +116,7 @@ def expand_tables_of_asterisk(
 
     We can be very specific in this function, we only expand arguments that are:
       {"schema_name": (str), "table_name": "*"}.
-    No partital wildcards or args that include target_schema/table_name are expanded.
+    No partial wildcards or args that include target_schema/table_name are expanded.
 
     Args:
         tables_list (list[dict]): List of schema/table name dicts.
@@ -132,8 +132,9 @@ def expand_tables_of_asterisk(
             mapping
             and mapping[consts.CONFIG_SCHEMA_NAME]
             and mapping[consts.CONFIG_TABLE_NAME] == "*"
-            and consts.CONFIG_TARGET_SCHEMA_NAME not in mapping
-            and consts.CONFIG_TARGET_TABLE_NAME not in mapping
+            # Looking for schema.* without a target side qualifier.
+            and not mapping.get(consts.CONFIG_TARGET_SCHEMA_NAME, None)
+            and not mapping.get(consts.CONFIG_TARGET_TABLE_NAME, None)
         ):
             # Expand the "*" to all tables in the schema.
             expanded_tables = get_mapped_table_configs(

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -1,0 +1,146 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+from typing import TYPE_CHECKING
+
+from data_validation import (
+    cli_tools,
+    clients,
+    consts,
+    jellyfish_distance,
+    state_manager,
+)
+
+if TYPE_CHECKING:
+    import ibis
+
+
+def _compare_match_tables(source_table_map, target_table_map, score_cutoff=0.8) -> list:
+    """Return dict config object from matching tables."""
+    # TODO(dhercher): evaluate if improved comparison and score cutoffs should be used.
+    table_configs = []
+
+    target_keys = target_table_map.keys()
+    for source_key in source_table_map:
+        target_key = jellyfish_distance.extract_closest_match(
+            source_key, target_keys, score_cutoff=score_cutoff
+        )
+        if target_key is None:
+            continue
+
+        table_config = {
+            consts.CONFIG_SCHEMA_NAME: source_table_map[source_key][
+                consts.CONFIG_SCHEMA_NAME
+            ],
+            consts.CONFIG_TABLE_NAME: source_table_map[source_key][
+                consts.CONFIG_TABLE_NAME
+            ],
+            consts.CONFIG_TARGET_SCHEMA_NAME: target_table_map[target_key][
+                consts.CONFIG_SCHEMA_NAME
+            ],
+            consts.CONFIG_TARGET_TABLE_NAME: target_table_map[target_key][
+                consts.CONFIG_TABLE_NAME
+            ],
+        }
+        table_configs.append(table_config)
+
+    return table_configs
+
+
+def _get_table_map(client: "ibis.backends.base.BaseBackend", allowed_schemas=None):
+    """Return dict with searchable keys for table matching."""
+    table_map = {}
+    table_objs = clients.get_all_tables(client, allowed_schemas=allowed_schemas)
+
+    for table_obj in table_objs:
+        table_key = ".".join([t for t in table_obj if t])
+        table_map[table_key] = {
+            consts.CONFIG_SCHEMA_NAME: table_obj[0],
+            consts.CONFIG_TABLE_NAME: table_obj[1],
+        }
+
+    return table_map
+
+
+def get_mapped_table_configs(
+    source_client: "ibis.backends.base.BaseBackend",
+    target_client: "ibis.backends.base.BaseBackend",
+    allowed_schemas: list = None,
+    score_cutoff: int = 1,
+) -> list:
+    """Get table list from each client and match them together into a single list of dicts."""
+    source_table_map = _get_table_map(source_client, allowed_schemas=allowed_schemas)
+    target_table_map = _get_table_map(target_client)
+    return _compare_match_tables(
+        source_table_map, target_table_map, score_cutoff=score_cutoff
+    )
+
+
+def find_tables_using_string_matching(args) -> str:
+    """Return JSON String with matched tables for use in validations."""
+    score_cutoff = args.score_cutoff or 1
+
+    mgr = state_manager.StateManager()
+    source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
+    target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
+
+    allowed_schemas = cli_tools.get_arg_list(args.allowed_schemas)
+    table_configs = get_mapped_table_configs(
+        source_client,
+        target_client,
+        allowed_schemas=allowed_schemas,
+        score_cutoff=score_cutoff,
+    )
+    return json.dumps(table_configs)
+
+
+def expand_tables_of_asterisk(
+    tables_list: list,
+    source_client: "ibis.backends.base.BaseBackend",
+    target_client: "ibis.backends.base.BaseBackend",
+) -> list:
+    """Pre-processes tables_mapping expanding any entries that are "schema.*". A shorthand for "find-tables" command.
+
+    We can be very specific in this function, we only expand arguments that are:
+      {"schema_name": (str), "table_name": "*"}.
+    No partital wildcards or args that include target_schema/table_name are expanded.
+
+    Args:
+        tables_list (list[dict]): List of schema/table name dicts.
+        source_client: Ibis client we can use to get a table list.
+        target_client: Ibis client we can use to get a table list.
+
+    Returns:
+        list: New version of tables_list with expanded "table_name": "*" entries.
+    """
+    new_list = []
+    for mapping in tables_list:
+        if (
+            mapping[consts.CONFIG_SCHEMA_NAME]
+            and mapping[consts.CONFIG_TABLE_NAME] == "*"
+            and consts.CONFIG_TARGET_SCHEMA_NAME not in mapping
+            and consts.CONFIG_TARGET_TABLE_NAME not in mapping
+        ):
+            # Expand the "*" to all tables in the schema.
+            expanded_tables = get_mapped_table_configs(
+                source_client,
+                target_client,
+                allowed_schemas=[mapping[consts.CONFIG_SCHEMA_NAME]],
+            )
+            new_list.extend(expanded_tables)
+        else:
+            new_list.append(mapping)
+    return new_list

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -129,7 +129,8 @@ def expand_tables_of_asterisk(
     new_list = []
     for mapping in tables_list:
         if (
-            mapping[consts.CONFIG_SCHEMA_NAME]
+            mapping
+            and mapping[consts.CONFIG_SCHEMA_NAME]
             and mapping[consts.CONFIG_TABLE_NAME] == "*"
             and consts.CONFIG_TARGET_SCHEMA_NAME not in mapping
             and consts.CONFIG_TARGET_TABLE_NAME not in mapping

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -161,7 +161,7 @@ def find_tables_assertions(command_output: str):
     assert "dvt_core_types" in [_["target_table_name"] for _ in output_dict]
 
 
-def column_validation_test(
+def column_validation_test_args(
     tables="pso_data_validator.dvt_core_types",
     tc="bq-conn",
     count_cols=None,
@@ -170,7 +170,6 @@ def column_validation_test(
     max_cols=None,
     filters=None,
     grouped_columns=None,
-    expected_config_managers: int = 1,
 ):
     parser = cli_tools.configure_arg_parser()
     cli_arg_list = [
@@ -194,12 +193,59 @@ def column_validation_test(
     if grouped_columns:
         cli_arg_list.append(f"--grouped-columns={grouped_columns}")
 
-    args = parser.parse_args(cli_arg_list)
-    for df in run_tests_from_cli_args(
-        args, expected_config_managers=expected_config_managers
-    ):
-        # With filter on failures the data frame should be empty
-        assert len(df) == 0
+    return parser.parse_args(cli_arg_list)
+
+
+def column_validation_test(
+    tables="pso_data_validator.dvt_core_types",
+    tc="bq-conn",
+    count_cols=None,
+    sum_cols=None,
+    min_cols=None,
+    max_cols=None,
+    filters=None,
+    grouped_columns=None,
+):
+    """Generic column validation test.
+
+    All tests expect an empty dataframe as the assertion.
+    """
+    args = column_validation_test_args(
+        tables=tables,
+        tc=tc,
+        count_cols=count_cols,
+        sum_cols=sum_cols,
+        min_cols=min_cols,
+        max_cols=max_cols,
+        filters=filters,
+        grouped_columns=grouped_columns,
+    )
+    df = run_test_from_cli_args(args)
+    # With filter on failures the data frame should be empty
+    assert len(df) == 0
+
+
+def column_validation_test_config_managers(
+    tables="pso_data_validator.dvt_core_types",
+    tc="bq-conn",
+    count_cols=None,
+    sum_cols=None,
+    min_cols=None,
+    max_cols=None,
+    filters=None,
+    grouped_columns=None,
+) -> list:
+    args = column_validation_test_args(
+        tables=tables,
+        tc=tc,
+        count_cols=count_cols,
+        sum_cols=sum_cols,
+        min_cols=min_cols,
+        max_cols=max_cols,
+        filters=filters,
+        grouped_columns=grouped_columns,
+    )
+    return main.build_config_managers_from_args(args)
 
 
 def row_validation_test(

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -22,6 +22,7 @@ from data_validation import (
     clients,
     consts,
     data_validation,
+    find_tables,
     gcs_helper,
 )
 from data_validation.query_builder import random_row_builder
@@ -692,7 +693,7 @@ def test_cli_find_tables():
 
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(CLI_FIND_TABLES_ARGS)
-    tables_json = main.find_tables_using_string_matching(args)
+    tables_json = find_tables.find_tables_using_string_matching(args)
     assert isinstance(tables_json, str)
     assert STRING_MATCH_RESULT in tables_json
 

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -19,6 +19,7 @@ from data_validation import cli_tools, data_validation, consts, find_tables
 from tests.system.data_sources.common_functions import (
     binary_key_assertions,
     column_validation_test,
+    column_validation_test_config_managers,
     find_tables_assertions,
     id_type_test_assertions,
     null_not_null_assertions,
@@ -696,24 +697,35 @@ def test_custom_query_row_validation_many_columns():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_column_multi_table_validation():
-    """Oracle to BigQuery test of multi-table validation command."""
-    column_validation_test(
+def test_column_multi_table_config_managers():
+    """Oracle to BigQuery test of multi-table validation command.
+
+    No need to actually execute the validations to confirm we get the correct number of config managers.
+    """
+    config_managers = column_validation_test_config_managers(
         tables="pso_data_validator.dvt_core_types,pso_data_validator.dvt_large_decimals",
         count_cols="*",
-        expected_config_managers=2,
     )
+    assert len(config_managers) == 2
+    assert "dvt_core_types" in [_.source_table.lower() for _ in config_managers]
+    assert "dvt_large_decimals" in [_.source_table.lower() for _ in config_managers]
 
 
 @mock.patch(
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_column_schema_validation():
-    """Oracle to PostgreSQL test of schema level validation command."""
-    column_validation_test(
+def test_column_multi_table_all_config_managers():
+    """Oracle to PostgreSQL test of multi-table schema.* validation command.
+
+    No need to actually execute the validations to confirm we get the correct number of config managers.
+    """
+    config_managers = column_validation_test_config_managers(
         tc="pg-conn",
         tables="pso_data_validator.*",
         count_cols="*",
-        expected_config_managers=6,
     )
+    assert len(config_managers) > 2
+    assert "dvt_core_types" in [_.source_table.lower() for _ in config_managers]
+    assert "dvt_large_decimals" in [_.source_table.lower() for _ in config_managers]
+    assert "dvt_pangrams" in [_.source_table.lower() for _ in config_managers]

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -15,7 +15,7 @@
 import os
 from unittest import mock
 
-from data_validation import cli_tools, data_validation, consts, __main__ as main
+from data_validation import cli_tools, data_validation, consts, find_tables
 from tests.system.data_sources.common_functions import (
     binary_key_assertions,
     find_tables_assertions,
@@ -689,7 +689,7 @@ def test_find_tables():
             "--allowed-schemas=pso_data_validator",
         ]
     )
-    output = main.find_tables_using_string_matching(args)
+    output = find_tables.find_tables_using_string_matching(args)
     find_tables_assertions(output)
 
 

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -18,6 +18,7 @@ from unittest import mock
 from data_validation import cli_tools, data_validation, consts, find_tables
 from tests.system.data_sources.common_functions import (
     binary_key_assertions,
+    column_validation_test,
     find_tables_assertions,
     id_type_test_assertions,
     null_not_null_assertions,
@@ -245,25 +246,17 @@ def test_schema_validation_oracle_to_postgres():
 )
 def test_column_validation_core_types():
     """Oracle to Oracle dvt_core_types column validation"""
-    parser = cli_tools.configure_arg_parser()
-    args = parser.parse_args(
-        [
-            "validate",
-            "column",
-            "-sc=mock-conn",
-            "-tc=mock-conn",
-            "-tbls=pso_data_validator.dvt_core_types",
-            "--filters=id>0 AND col_int8>0",
-            "--filter-status=fail",
-            "--grouped-columns=col_varchar_30",
-            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
-            "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
-            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
-        ]
+    cols = "col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz"
+    column_validation_test(
+        tc="mock-conn",
+        tables="pso_data_validator.dvt_core_types",
+        count_cols=cols,
+        sum_cols=cols,
+        min_cols=cols,
+        max_cols=cols,
+        filters="id>0 AND col_int8>0",
+        grouped_columns="col_varchar_30",
     )
-    df = run_test_from_cli_args(args)
-    # With filter on failures the data frame should be empty
-    assert len(df) == 0
 
 
 @mock.patch(
@@ -271,24 +264,16 @@ def test_column_validation_core_types():
     new=mock_get_connection_config,
 )
 def test_column_validation_core_types_to_bigquery():
-    parser = cli_tools.configure_arg_parser()
-    # We've excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
-    args = parser.parse_args(
-        [
-            "validate",
-            "column",
-            "-sc=ora-conn",
-            "-tc=bq-conn",
-            "-tbls=pso_data_validator.dvt_core_types",
-            "--filter-status=fail",
-            "--sum=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
-            "--min=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
-            "--max=col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz",
-        ]
+    # Excluded col_float32 because BigQuery does not have an exact same type and
+    # float32/64 are lossy and cannot be compared.
+    cols = "col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz"
+    column_validation_test(
+        tc="bq-conn",
+        tables="pso_data_validator.dvt_core_types",
+        sum_cols=cols,
+        min_cols=cols,
+        max_cols=cols,
     )
-    df = run_test_from_cli_args(args)
-    # With filter on failures the data frame should be empty
-    assert len(df) == 0
 
 
 @mock.patch(
@@ -296,7 +281,6 @@ def test_column_validation_core_types_to_bigquery():
     new=mock_get_connection_config,
 )
 def test_column_validation_oracle_to_postgres():
-    parser = cli_tools.configure_arg_parser()
     count_cols = ",".join([_ for _ in ORA2PG_COLUMNS if _ not in ("col_long_raw")])
     # TODO Change sum_cols and min_cols to include col_char_2,col_nchar_2 when issue-842 is complete.
     # TODO Change sum_cols to include col_num_18 when issue-1007 is complete.
@@ -314,23 +298,14 @@ def test_column_validation_oracle_to_postgres():
             if _ not in ("col_char_2", "col_nchar_2", "col_long_raw")
         ]
     )
-    args = parser.parse_args(
-        [
-            "validate",
-            "column",
-            "-sc=ora-conn",
-            "-tc=pg-conn",
-            "-tbls=pso_data_validator.dvt_ora2pg_types",
-            "--filter-status=fail",
-            f"--count={count_cols}",
-            f"--sum={sum_cols}",
-            f"--min={min_cols}",
-            f"--max={min_cols}",
-        ]
+    column_validation_test(
+        tc="pg-conn",
+        tables="pso_data_validator.dvt_ora2pg_types",
+        count_cols=count_cols,
+        sum_cols=sum_cols,
+        min_cols=min_cols,
+        max_cols=min_cols,
     )
-    df = run_test_from_cli_args(args)
-    # With filter on failures the data frame should be empty
-    assert len(df) == 0
 
 
 @mock.patch(
@@ -714,4 +689,31 @@ def test_custom_query_row_validation_many_columns():
     """
     row_validation_many_columns_test(
         validation_type="custom-query", expected_config_managers=4
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_multi_table_validation():
+    """Oracle to BigQuery test of multi-table validation command."""
+    column_validation_test(
+        tables="pso_data_validator.dvt_core_types,pso_data_validator.dvt_large_decimals",
+        count_cols="*",
+        expected_config_managers=2,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_schema_validation():
+    """Oracle to PostgreSQL test of schema level validation command."""
+    column_validation_test(
+        tc="pg-conn",
+        tables="pso_data_validator.*",
+        count_cols="*",
+        expected_config_managers=6,
     )

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -17,7 +17,13 @@ from unittest import mock
 
 import pytest
 
-from data_validation import cli_tools, data_validation, consts, __main__ as main
+from data_validation import (
+    cli_tools,
+    data_validation,
+    consts,
+    find_tables,
+    __main__ as main,
+)
 from tests.system.data_sources.deploy_cloudsql.cloudsql_resource_manager import (
     CloudSQLResourceManager,
 )
@@ -863,7 +869,7 @@ def test_find_tables():
             "--allowed-schemas=pso_data_validator",
         ]
     )
-    output = main.find_tables_using_string_matching(args)
+    output = find_tables.find_tables_using_string_matching(args)
     find_tables_assertions(output)
 
 

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -19,8 +19,7 @@ from unittest import mock
 
 import pytest
 
-from data_validation import cli_tools, consts, data_validation
-from data_validation import __main__ as main
+from data_validation import cli_tools, consts, data_validation, find_tables
 from tests.system.data_sources.common_functions import (
     binary_key_assertions,
     row_validation_many_columns_test,
@@ -199,7 +198,7 @@ def test_grouped_count_validator(grouped_config):
 def test_cli_find_tables():
     parser = cli_tools.configure_arg_parser()
     args = parser.parse_args(CLI_FIND_TABLES_ARGS)
-    tables_json = main.find_tables_using_string_matching(args)
+    tables_json = find_tables.find_tables_using_string_matching(args)
     tables = json.loads(tables_json)
     assert isinstance(tables_json, str)
     assert {

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -20,7 +20,7 @@ import pytest
 from tests.system.data_sources.deploy_cloudsql.cloudsql_resource_manager import (
     CloudSQLResourceManager,
 )
-from data_validation import cli_tools, data_validation, consts, __main__ as main
+from data_validation import cli_tools, data_validation, consts, find_tables
 from tests.system.data_sources.common_functions import (
     binary_key_assertions,
     find_tables_assertions,
@@ -593,7 +593,7 @@ def test_find_tables():
             "--allowed-schemas=pso_data_validator",
         ]
     )
-    output = main.find_tables_using_string_matching(args)
+    output = find_tables.find_tables_using_string_matching(args)
     find_tables_assertions(output)
 
 

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -17,7 +17,7 @@ import logging
 import os
 from unittest import mock
 
-from data_validation import cli_tools, consts
+from data_validation import cli_tools
 from data_validation import __main__ as main
 
 
@@ -33,30 +33,6 @@ CLI_ARGS = {
     "config_file": "example_test.yaml",
     "verbose": True,
 }
-
-SCHEMA_TABLE_OBJ = {
-    consts.CONFIG_SCHEMA_NAME: "schema",
-    consts.CONFIG_TABLE_NAME: "table",
-}
-OTHER_SCHEMA_TABLE_OBJ = {
-    consts.CONFIG_SCHEMA_NAME: "schema",
-    consts.CONFIG_TABLE_NAME: "other_table",
-}
-SOURCE_TABLE_MAP = {
-    "schema_table": SCHEMA_TABLE_OBJ,
-}
-TARGET_TABLE_MAP = {
-    "schema_table": SCHEMA_TABLE_OBJ,
-    "schema_other_table": OTHER_SCHEMA_TABLE_OBJ,
-}
-RESULT_TABLE_CONFIGS = [
-    {
-        "schema_name": "schema",
-        "table_name": "table",
-        "target_schema_name": "schema",
-        "target_table_name": "table",
-    }
-]
 
 CONFIG_RUNNER_ARGS_1 = {
     "verbose": False,
@@ -98,13 +74,6 @@ def test_configure_arg_parser(mock_args):
     file_path = main._get_arg_config_file(args)
 
     assert file_path == "example_test.yaml"
-
-
-def test__compare_match_tables():
-    """Test matching tables from source and target."""
-    table_configs = main._compare_match_tables(SOURCE_TABLE_MAP, TARGET_TABLE_MAP)
-
-    assert table_configs == RESULT_TABLE_CONFIGS
 
 
 @mock.patch("data_validation.__main__.run_validations")
@@ -149,7 +118,6 @@ def test_config_runner_1(mock_args, mock_build, mock_run, caplog):
     return_value=argparse.Namespace(**CONFIG_RUNNER_ARGS_2),
 )
 def test_config_runner_2(mock_args, mock_build, mock_run, caplog):
-
     """Second test - run validation on a directory - and provide the -kc argument,
     but not running in a Kubernetes Completion Configuration. Expected result
     1. Multiple (3) config manager created for validation

--- a/tests/unit/test_find_tables.py
+++ b/tests/unit/test_find_tables.py
@@ -114,7 +114,7 @@ def test__compare_match_tables(module_under_test):
                 },
             ],
         ),
-        # Test that asterisk mixed woth other characters is not expanded
+        # Test that asterisk mixed with other characters is not expanded
         (
             [
                 {"schema_name": "s1", "table_name": "t*"},

--- a/tests/unit/test_find_tables.py
+++ b/tests/unit/test_find_tables.py
@@ -1,0 +1,106 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from unittest import mock
+
+
+S1_TABLES = [
+    ("s1", "t1"),
+    ("s1", "t2"),
+    ("s1", "t3"),
+]
+
+
+@pytest.fixture
+def module_under_test():
+    from data_validation import find_tables
+
+    return find_tables
+
+
+@pytest.mark.parametrize(
+    ("tables_list,expected_result"),
+    (
+        # Test that lone asterisk is expanded.
+        (
+            [
+                {"schema_name": "s1", "table_name": "*"},
+            ],
+            [
+                {
+                    "schema_name": _[0],
+                    "table_name": _[1],
+                    "target_schema_name": _[0],
+                    "target_table_name": _[1],
+                }
+                for _ in S1_TABLES
+            ],
+        ),
+        # Test that arg format s1.t1=s2.t1 is not expanded.
+        (
+            [
+                {
+                    "schema_name": "s1",
+                    "table_name": "t1",
+                    "target_schema_name": "s2",
+                    "target_table_name": "t1",
+                },
+            ],
+            [
+                {
+                    "schema_name": "s1",
+                    "table_name": "t1",
+                    "target_schema_name": "s2",
+                    "target_table_name": "t1",
+                },
+            ],
+        ),
+        # Test that arg format s1.t1 is not expanded.
+        (
+            [
+                {"schema_name": "s1", "table_name": "t1"},
+            ],
+            [
+                {
+                    "schema_name": "s1",
+                    "table_name": "t1",
+                },
+            ],
+        ),
+        # Test that asterisk mixed woth other characters is not expanded
+        (
+            [
+                {"schema_name": "s1", "table_name": "t*"},
+            ],
+            [
+                {
+                    "schema_name": "s1",
+                    "table_name": "t*",
+                },
+            ],
+        ),
+    ),
+)
+def test_expand_tables_of_asterisk(
+    module_under_test, tables_list: list, expected_result: list
+):
+    with mock.patch(
+        "data_validation.clients.get_all_tables",
+        return_value=S1_TABLES,
+    ) as _:
+        result = module_under_test.expand_tables_of_asterisk(
+            tables_list, mock.Mock(), mock.Mock()
+        )
+        assert result == expected_result

--- a/tests/unit/test_find_tables.py
+++ b/tests/unit/test_find_tables.py
@@ -126,6 +126,25 @@ def test__compare_match_tables(module_under_test):
                 },
             ],
         ),
+        # Test that arg format s1.*=s2.t1 is not expanded.
+        (
+            [
+                {
+                    "schema_name": "s1",
+                    "table_name": "*",
+                    "target_schema_name": "s2",
+                    "target_table_name": "t1",
+                },
+            ],
+            [
+                {
+                    "schema_name": "s1",
+                    "table_name": "*",
+                    "target_schema_name": "s2",
+                    "target_table_name": "t1",
+                },
+            ],
+        ),
     ),
 )
 def test_expand_tables_of_asterisk(

--- a/tests/unit/test_find_tables.py
+++ b/tests/unit/test_find_tables.py
@@ -15,11 +15,37 @@
 import pytest
 from unittest import mock
 
+from data_validation import consts
+
 
 S1_TABLES = [
     ("s1", "t1"),
     ("s1", "t2"),
     ("s1", "t3"),
+]
+
+SCHEMA_TABLE_OBJ = {
+    consts.CONFIG_SCHEMA_NAME: "schema",
+    consts.CONFIG_TABLE_NAME: "table",
+}
+OTHER_SCHEMA_TABLE_OBJ = {
+    consts.CONFIG_SCHEMA_NAME: "schema",
+    consts.CONFIG_TABLE_NAME: "other_table",
+}
+SOURCE_TABLE_MAP = {
+    "schema_table": SCHEMA_TABLE_OBJ,
+}
+TARGET_TABLE_MAP = {
+    "schema_table": SCHEMA_TABLE_OBJ,
+    "schema_other_table": OTHER_SCHEMA_TABLE_OBJ,
+}
+RESULT_TABLE_CONFIGS = [
+    {
+        "schema_name": "schema",
+        "table_name": "table",
+        "target_schema_name": "schema",
+        "target_table_name": "table",
+    }
 ]
 
 
@@ -28,6 +54,15 @@ def module_under_test():
     from data_validation import find_tables
 
     return find_tables
+
+
+def test__compare_match_tables(module_under_test):
+    """Test matching tables from source and target."""
+    table_configs = module_under_test._compare_match_tables(
+        SOURCE_TABLE_MAP, TARGET_TABLE_MAP
+    )
+
+    assert table_configs == RESULT_TABLE_CONFIGS
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Two recent projects for different customers have demonstrated the need for this. In both projects the end user wanted to run column validation across the whole schema. They ended up using `find-tables` to pull a list of tables and then feed that into validation commands. The output of find tables can quickly exceed BASH shell limits.

This PR adds a shortcut for validation of all tables in a schema by supplying an asterisk for the table name, for example:

```
data-validation validate column --source-conn=ora --target-conn=bq  \
--tables-list="pso_data_validator.*" --min="*" --count="*"
```

When we see a table name of "str.*" we run the same code that the `find-tables` command runs to get the same output, but without the need for the user to run multiple commands. Because we are using the same code we cannot match partial wildcards, for example `"pso_data_validator.dvt_c*"` matches no tables.

This shortcut is active for all validation types but is only really useful for column and schema validations. I couldn't see a reason to block it for row validations but it isn't useful because of the need for individual primary key values. It is also active when generating config files.

I did consider adding a `--tables-list-exclude` option to allow the user to skip certain tables but didn't because I think that is an independent requirement and not part of this change. Happy to raise an issue for that if others agree it is needed.
 
I only added tests to `test_oracle.py` because I don't think the logic differs across SQL engines, I have tests for Oracle vs BigQuery and Oracle vs PostgreSQL.

Other test changes:
- I added a test for supplying two tables on the command line, not really relevant to this PR but I felt we should have it.
- Initially I was executing validations and refactored how column tests are executed so I could share code. I then moved away from that as I don't need to execute the tests to test these changes. I left the new `column_validation_test` function 
in `common_functions.py` as I think we can roll it out across all test files. I'll create a new issue for this after merging this PR.

