### PR TITLE
fix: Update Teradata rtrim() to account for tabs and other whitespace

### DIFF
--- a/tests/resources/bigquery_test_tables.sql
+++ b/tests/resources/bigquery_test_tables.sql
@@ -122,10 +122,10 @@ CREATE TABLE `pso_data_validator`.`dvt_char_id`
 ,   other_data  STRING(100)
 ) OPTIONS (description='Integration test table used to test CHAR pk matching.');
 INSERT INTO `pso_data_validator`.`dvt_char_id` VALUES
-('DVT1  ', 'Row 1'),
-('DVT2  ', 'Row 2'),
-('DVT3  ', 'Row 3'),
-('DVT4  ', 'Row 4'),
+('DVT1  ', 'Row 1	  '),
+('DVT2  ', 'Row 2  	'),
+('DVT3  ', 'Row 3  '),
+('DVT4  ', 'Row 4  	  '),
 ('DVT5  ', 'Row 5');
 
 DROP TABLE `pso_data_validator`.`dvt_time_table`;

--- a/tests/resources/teradata_test_tables.sql
+++ b/tests/resources/teradata_test_tables.sql
@@ -132,13 +132,13 @@ INSERT INTO udf.dvt_time_Table VALUES (3, '04:01:07-04:00');
 DROP TABLE udf.dvt_char_id;
 CREATE TABLE udf.dvt_char_id
 (   id          CHAR(6) NOT NULL PRIMARY KEY
-,   other_data  VARCHAR(100)
+,   other_data  CHAR(100)
 );
 COMMENT ON TABLE udf.dvt_char_id IS 'Integration test table used to test CHAR pk matching.';
-INSERT INTO udf.dvt_char_id VALUES ('DVT1', 'Row 1');
-INSERT INTO udf.dvt_char_id VALUES ('DVT2', 'Row 2');
-INSERT INTO udf.dvt_char_id VALUES ('DVT3', 'Row 3');
-INSERT INTO udf.dvt_char_id VALUES ('DVT4', 'Row 4');
+INSERT INTO udf.dvt_char_id VALUES ('DVT1', 'Row 1	  ');
+INSERT INTO udf.dvt_char_id VALUES ('DVT2', 'Row 2  	');
+INSERT INTO udf.dvt_char_id VALUES ('DVT3', 'Row 3  ');
+INSERT INTO udf.dvt_char_id VALUES ('DVT4', 'Row 4  	  ');
 INSERT INTO udf.dvt_char_id VALUES ('DVT5', 'Row 5');
 
 DROP TABLE udf.test_generate_partitions;

--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -290,6 +290,12 @@ def _extract_epoch(translator, op):
     )
 
 
+def _rstrip(translator, op):
+    arg = translator.translate(op.arg)
+    # Use regexp_replace to account for trailing tabs and spaces as per #1272
+    return f"REGEXP_REPLACE({arg}, '[ \\t]+$', '')"
+
+
 """ Add New Customizations to Operations registry """
 _operation_registry.update(
     {
@@ -299,5 +305,6 @@ _operation_registry.update(
         ops.IfNull: fixed_arity("NVL", 2),
         ops.StringJoin: _string_join,
         ops.ExtractEpochSeconds: _extract_epoch,
+        ops.RStrip: _rstrip,
     }
 )

--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -292,8 +292,8 @@ def _extract_epoch(translator, op):
 
 def _rstrip(translator, op):
     arg = translator.translate(op.arg)
-    # Use regexp_replace to account for trailing tabs and spaces as per #1272
-    return f"REGEXP_REPLACE({arg}, '[ \\t]+$', '')"
+    # Rtrim parameter accounts for ' \t\x0b\n\r\x0c' as per #1272
+    return f"RTRIM({arg}, _latin '20090B0A0D0C'XCV)"
 
 
 """ Add New Customizations to Operations registry """


### PR DESCRIPTION
Closes #1272 

This updates the default `RTRIM(column, " ")` for Teradata so that it also accounts for tabs, newlines, and other whitespace characters.