### PR TITLE
fix: cast count to bigint when generating partitions

### DIFF
--- a/data_validation/query_builder/partition_row_builder.py
+++ b/data_validation/query_builder/partition_row_builder.py
@@ -62,4 +62,4 @@ class PartitionRowBuilder(object):
 
     def get_count(self) -> int:
         """Return a count of rows of primary keys - they should be all distinct"""
-        return self.query[self.primary_keys].count().execute()
+        return self.query[self.primary_keys].count().force_cast("int64").execute()


### PR DESCRIPTION
Closes #1280 

Casts count to BIGINT so that large count values will not throw a NumericOverflow error.