### PR TITLE
feat: Add support for -comp-fields=*, which also adds support for --exclude-columns

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -160,7 +160,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
     return aggregate_configs
 
 
-def get_calculated_config(args, config_manager: ConfigManager) -> List[dict]:
+def _get_calculated_config(args, config_manager: ConfigManager) -> List[dict]:
     """Return list of formatted calculated objects.
 
     Args:
@@ -217,6 +217,33 @@ def get_calculated_config(args, config_manager: ConfigManager) -> List[dict]:
     return calculated_configs
 
 
+def _get_comparison_config(args, config_manager: ConfigManager) -> List[dict]:
+    col_list = (
+        None
+        if config_manager.comparison_fields == "*"
+        else cli_tools.get_arg_list(config_manager.comparison_fields)
+    )
+    comparison_fields = config_manager.build_comp_fields(
+        col_list,
+        args.exclude_columns,
+    )
+    # We can't have the PK columns in the comparison SQL twice therefore filter them out here if included.
+    comparison_fields = [
+        _
+        for _ in comparison_fields
+        if _ not in cli_tools.get_arg_list(args.primary_keys.casefold())
+    ]
+
+    # As per #1190, add rstrip for Teradata string comparison fields
+    if (
+        config_manager.source_client.name == "teradata"
+        or config_manager.target_client.name == "teradata"
+    ):
+        comparison_fields = config_manager.add_rstrip_to_comp_fields(comparison_fields)
+
+    return config_manager.build_config_comparison_fields(comparison_fields)
+
+
 def build_config_from_args(args: Namespace, config_manager: ConfigManager):
     """Append build configs to ConfigManager object.
 
@@ -260,26 +287,13 @@ def build_config_from_args(args: Namespace, config_manager: ConfigManager):
         if args.custom_query_type == consts.ROW_VALIDATION.lower():
             # Append Comparison fields
             if args.comparison_fields is not None:
-                comparison_fields = cli_tools.get_arg_list(
-                    args.comparison_fields, default_value=[]
-                )
-
-                # As per #1190, add rstrip for Teradata string comparison fields
-                if (
-                    config_manager.source_client.name == "teradata"
-                    or config_manager.target_client.name == "teradata"
-                ):
-                    comparison_fields = config_manager.add_rstrip_to_comp_fields(
-                        comparison_fields
-                    )
-
                 config_manager.append_comparison_fields(
-                    config_manager.build_config_comparison_fields(comparison_fields)
+                    _get_comparison_config(args, config_manager)
                 )
 
             # Append calculated fields: --hash/--concat
             config_manager.append_calculated_fields(
-                get_calculated_config(args, config_manager)
+                _get_calculated_config(args, config_manager)
             )
 
             # Append primary_keys
@@ -301,26 +315,13 @@ def build_config_from_args(args: Namespace, config_manager: ConfigManager):
     if config_manager.validation_type == consts.ROW_VALIDATION:
         # Append calculated fields: --hash/--concat
         config_manager.append_calculated_fields(
-            get_calculated_config(args, config_manager)
+            _get_calculated_config(args, config_manager)
         )
 
         # Append Comparison fields
         if args.comparison_fields is not None:
-            comparison_fields = cli_tools.get_arg_list(
-                args.comparison_fields, default_value=[]
-            )
-
-            # As per #1190, add rstrip for Teradata string comparison fields
-            if (
-                config_manager.source_client.name == "teradata"
-                or config_manager.target_client.name == "teradata"
-            ):
-                comparison_fields = config_manager.add_rstrip_to_comp_fields(
-                    comparison_fields
-                )
-
             config_manager.append_comparison_fields(
-                config_manager.build_config_comparison_fields(comparison_fields)
+                _get_comparison_config(args, config_manager)
             )
 
         # Append primary_keys

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1069,6 +1069,27 @@ class ConfigManager(object):
 
         return order_of_operations
 
+    def _filter_columns_by_column_list(
+        self, casefold_columns: list, col_list: list, exclude_cols: bool
+    ) -> list:
+        if col_list:
+            filter_list = [_.casefold() for _ in col_list]
+            if exclude_cols:
+                # Exclude columns based on col_list if provided
+                casefold_columns = {
+                    k: v for (k, v) in casefold_columns.items() if k not in filter_list
+                }
+            else:
+                # Include columns based on col_list if provided
+                casefold_columns = {
+                    k: v for (k, v) in casefold_columns.items() if k in filter_list
+                }
+        elif exclude_cols:
+            raise ValueError(
+                "Exclude columns flag cannot be present with column list '*'"
+            )
+        return casefold_columns
+
     def build_dependent_aliases(
         self, calc_type: str, col_list=None, exclude_cols=False
     ) -> List[Dict]:
@@ -1079,36 +1100,12 @@ class ConfigManager(object):
         casefold_source_columns = {x.casefold(): str(x) for x in source_table.columns}
         casefold_target_columns = {x.casefold(): str(x) for x in target_table.columns}
 
-        if col_list:
-            casefold_col_list = [x.casefold() for x in col_list]
-            if exclude_cols:
-                # Exclude columns based on col_list if provided
-                casefold_source_columns = {
-                    k: v
-                    for (k, v) in casefold_source_columns.items()
-                    if k not in casefold_col_list
-                }
-                casefold_target_columns = {
-                    k: v
-                    for (k, v) in casefold_target_columns.items()
-                    if k not in casefold_col_list
-                }
-            else:
-                # Include columns based on col_list if provided
-                casefold_source_columns = {
-                    k: v
-                    for (k, v) in casefold_source_columns.items()
-                    if k in casefold_col_list
-                }
-                casefold_target_columns = {
-                    k: v
-                    for (k, v) in casefold_target_columns.items()
-                    if k in casefold_col_list
-                }
-        elif exclude_cols:
-            raise ValueError(
-                "Exclude columns flag cannot be present with column list '*'"
-            )
+        casefold_source_columns = self._filter_columns_by_column_list(
+            casefold_source_columns, col_list, exclude_cols
+        )
+        casefold_target_columns = self._filter_columns_by_column_list(
+            casefold_target_columns, col_list, exclude_cols
+        )
 
         column_aliases = {}
         col_names = []
@@ -1158,3 +1155,14 @@ class ConfigManager(object):
                     column_aliases[name] = i
                     col_names.append(col)
         return col_names
+
+    def build_comp_fields(self, col_list: list, exclude_cols: bool = False) -> list:
+        """This is a utility function processing comp-fields values like we do for hash/concat."""
+        source_table = self.get_source_ibis_calculated_table()
+        casefold_source_columns = {_.casefold(): str(_) for _ in source_table.columns}
+
+        casefold_source_columns = self._filter_columns_by_column_list(
+            casefold_source_columns, col_list, exclude_cols
+        )
+
+        return casefold_source_columns

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -342,6 +342,19 @@ def test_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_core_types():
+    """Oracle to Oracle dvt_core_types row validation with --comp-fields"""
+    row_validation_test(
+        tables="pso_data_validator.dvt_core_types",
+        tc="mock-conn",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_row_validation_oracle_to_postgres():
     # TODO Change hash_cols below to include col_tstz when issue-706 is complete.
     # TODO col_raw/col_long_raw are blocked by issue-773 (is it even reasonable to expect binary columns to work here?)
@@ -734,22 +747,12 @@ def test_row_validation_identifiers():
     pytest.skip(
         "Skipping test_row_validation_identifiers because concat_all expression does not enquote identifier names, issue-1271."
     )
-    parser = cli_tools.configure_arg_parser()
-    args = parser.parse_args(
-        [
-            "validate",
-            "row",
-            "-sc=mock-conn",
-            "-tc=mock-conn",
-            "-tbls=pso_data_validator.dvt-identifier$_#",
-            "--primary-keys=id",
-            "--filter-status=fail",
-            "--hash=*",
-        ]
+    row_validation_test(
+        tables="pso_data_validator.dvt-identifier$_#",
+        tc="mock-conn",
+        hash="*",
+        filters="id>0 AND col_int8>0",
     )
-    df = run_test_from_cli_args(args)
-    # With filter on failures the data frame should be empty
-    assert len(df) == 0
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -36,6 +36,7 @@ from tests.system.data_sources.common_functions import (
     run_test_from_cli_args,
     partition_table_test,
     partition_query_test,
+    row_validation_test,
     schema_validation_test,
 )
 from tests.system.data_sources.test_bigquery import BQ_CONN
@@ -690,23 +691,25 @@ def test_row_validation_pg_types():
     This used to use the dvt_core_types table but that is covered by subsequent BigQuery
     testing therefore this test can cover off an extended list of data types.
     """
-    parser = cli_tools.configure_arg_parser()
-    args = parser.parse_args(
-        [
-            "validate",
-            "row",
-            "-sc=mock-conn",
-            "-tc=mock-conn",
-            "-tbls=pso_data_validator.dvt_pg_types",
-            "--filters=id>0 AND col_int8>0",
-            "--primary-keys=id",
-            "--filter-status=fail",
-            "--hash=*",
-        ]
+    row_validation_test(
+        tables="pso_data_validator.dvt_pg_types",
+        tc="mock-conn",
+        hash="*",
+        filters="id>0 AND col_int8>0",
     )
-    df = run_test_from_cli_args(args)
-    # With filter on failures the data frame should be empty
-    assert len(df) == 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_comp_fields_pg_types():
+    """PostgreSQL to PostgreSQL dvt_core_types row validation with --comp-fields"""
+    row_validation_test(
+        tables="pso_data_validator.dvt_pg_types",
+        tc="mock-conn",
+        comp_fields="*",
+    )
 
 
 @mock.patch(


### PR DESCRIPTION
This PR adds support for `-comp-fields=*`, which also adds support for `--exclude-columns`.

Tests added in Oracle and PostgreSQL test sets. We could (should?) add more but the asterisk change is not engine specific and tests are slow enough as it is.