### PR TITLE
fix: Correctly cater for Oracle FLOAT in custom-query validations

### DIFF
--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -602,6 +602,7 @@ def test_custom_query_row_validation_oracle_to_postgres():
     )
     custom_query_validation_test(
         validation_type="row",
+        tc="pg-conn",
         source_query=f"select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
         target_query=f"select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
         hash="*",

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -600,24 +600,12 @@ def test_custom_query_row_validation_oracle_to_postgres():
             )
         ]
     )
-    parser = cli_tools.configure_arg_parser()
-    args = parser.parse_args(
-        [
-            "validate",
-            "custom-query",
-            "row",
-            "-sc=mock-conn",
-            "-tc=pg-conn",
-            f"--source-query=select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
-            f"--target-query=select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
-            "--primary-keys=id",
-            "--hash=*",
-            "--filter-status=fail",
-        ]
+    custom_query_validation_test(
+        validation_type="row",
+        source_query=f"select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
+        target_query=f"select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
+        hash="*",
     )
-    df = run_test_from_cli_args(args)
-    # With filter on failures the data frame should be populated
-    assert len(df) > 0
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -624,6 +624,57 @@ def test_custom_query_invalid_long_decimal():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_custom_query_row_validation_oracle_to_postgres():
+    # TODO Change hash_cols below to include col_tstz when issue-706 is complete.
+    # TODO col_raw/col_long_raw are blocked by issue-773 (is it even reasonable to expect binary columns to work here?)
+    # TODO Change hash_cols below to include col_nvarchar_30,col_nchar_2 when issue-772 is complete.
+    # TODO Change hash_cols below to include col_interval_ds when issue-1214 is complete.
+    # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
+    # Excluded CLOB/NCLOB/BLOB columns because lob values cannot be concatenated
+    hash_cols = ",".join(
+        [
+            _
+            for _ in ORA2PG_COLUMNS
+            if _
+            not in (
+                "col_blob",
+                "col_clob",
+                "col_nclob",
+                "col_raw",
+                "col_long_raw",
+                "col_float32",
+                "col_float64",
+                "col_tstz",
+                "col_nvarchar_30",
+                "col_nchar_2",
+                "col_interval_ds",
+            )
+        ]
+    )
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=mock-conn",
+            "-tc=pg-conn",
+            f"--source-query=select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
+            f"--target-query=select {hash_cols} from pso_data_validator.dvt_ora2pg_types",
+            "--primary-keys=id",
+            "--hash=*",
+            "--filter-status=fail",
+        ]
+    )
+    df = run_test_from_cli_args(args)
+    # With filter on failures the data frame should be populated
+    assert len(df) > 0
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_find_tables():
     """Oracle to BigQuery test of find-tables command."""
     parser = cli_tools.configure_arg_parser()

--- a/third_party/ibis/ibis_oracle/datatypes.py
+++ b/third_party/ibis/ibis_oracle/datatypes.py
@@ -50,8 +50,8 @@ def _get_type(col: _FieldDescription) -> dt.DataType:
         raise NotImplementedError(f"Oracle type {typename} is not supported")
 
     if typename == cx_Oracle.DB_TYPE_NUMBER:
-        if col[4] == 0 and col[5] == -127:
-            # This will occur if type is NUMBER with no precision/scale
+        if col[5] == -127:
+            # This will occur if type is NUMBER with no precision/scale or if type is FLOAT.
             typ = partial(typ)
         else:
             typ = partial(typ, precision=col[4], scale=col[5])

--- a/third_party/ibis/ibis_postgres/client.py
+++ b/third_party/ibis/ibis_postgres/client.py
@@ -99,7 +99,13 @@ def _get_type(typestr: str) -> dt.DataType:
     else:
         typestr_wo_length = typestr_wob
     typ = _type_mapping.get(typestr_wo_length)
-    if typ is not None:
+    # Added != "numeric" below for issue:
+    #   https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1302
+    # We do not want to map all numerics to decimal(None, None), we want "numeric" to be
+    # passed to the _parse_numeric() function.
+    # An alternative was to remove "numeric" from _type_mapping but that would be yet more monkey
+    # patching, at least this function is already patched.
+    if typ is not None and typestr_wo_length != "numeric":
         return dt.Array(typ) if is_array else typ
     return _parse_numeric(typestr)
 


### PR DESCRIPTION
Fix two issues:

1) Use of Oracle FLOAT in a custom query validation
2) Use of PostgreSQL numeric in a custom query validation

Also adds a test covering both issues.