### PR TITLE
fix: Fix --comp-fields bug losing option value before validation

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -220,8 +220,8 @@ def _get_calculated_config(args, config_manager: ConfigManager) -> List[dict]:
 def _get_comparison_config(args, config_manager: ConfigManager) -> List[dict]:
     col_list = (
         None
-        if config_manager.comparison_fields == "*"
-        else cli_tools.get_arg_list(config_manager.comparison_fields)
+        if args.comparison_fields == "*"
+        else cli_tools.get_arg_list(args.comparison_fields)
     )
     comparison_fields = config_manager.build_comp_fields(
         col_list,

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1167,7 +1167,7 @@ class ConfigManager(object):
                     col_names.append(col)
         return col_names
 
-    def build_comp_fields(self, col_list: list, exclude_cols: bool = False) -> list:
+    def build_comp_fields(self, col_list: list, exclude_cols: bool = False) -> dict:
         """This is a utility function processing comp-fields values like we do for hash/concat."""
         source_table = self.get_source_ibis_calculated_table()
         casefold_source_columns = {_.casefold(): str(_) for _ in source_table.columns}

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -608,3 +608,27 @@ def test_get_none_run_id(module_under_test):
         SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
     )
     assert config_manager.run_id is None
+
+
+@mock.patch(
+    "data_validation.config_manager.ConfigManager.get_source_ibis_calculated_table",
+    new=lambda x: MockIbisTable(),
+)
+def test_build_comp_fields(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+
+    # With exclude_columns=False
+    comparison_fields = config_manager.build_comp_fields(
+        ["a", "c", "e"],
+        False,
+    )
+    assert comparison_fields == {"a": "a", "c": "c"}
+
+    # With exclude_columns=True
+    comparison_fields = config_manager.build_comp_fields(
+        ["a", "c", "e"],
+        True,
+    )
+    assert comparison_fields == {"b": "b", "d": "d"}

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -624,6 +624,8 @@ def test_build_comp_fields(module_under_test):
         ["a", "c", "e"],
         False,
     )
+    # Column "e" does not exists and therefore should not be in the list, even though
+    # it was requested.
     assert comparison_fields == {"a": "a", "c": "c"}
 
     # With exclude_columns=True


### PR DESCRIPTION
Fixes a bug introduced in the prior release where we lose the `--comparison-fields` option value and always validate all columns.