### PR TITLE
fix: Issue 1325

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1431,7 +1431,9 @@ def get_pre_build_configs(args: Namespace, validate_cmd: str) -> List[Dict]:
     format = args.format if args.format else "table"
 
     # Get random row arguments. Only in row validations these attributes can be present.
-    use_random_rows = getattr(args, consts.CONFIG_USE_RANDOM_ROWS, False)
+    # Bad coding here, but keeping it so as not to introduce a breaking change. See
+    # consts.py Line 17 for a more detailed explanation.
+    use_random_rows = getattr(args, "use_random_row", False)
     random_row_batch_size = getattr(args, consts.CONFIG_RANDOM_ROW_BATCH_SIZE, None)
 
     # Get table list. Not supported in case of custom query validation

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -14,6 +14,12 @@
 
 
 # Configuration Fields
+# These are all keys into the config dict. Where these values come from the command line, these would
+# match with the command line argument - so --secret-manager-type value would be inserted with the
+# 'secret_manager_type' key.
+# This is true for the most part, except where a typo gets introduced, i.e. --use-random-row became use_random_rows
+# Fixing this would be a breaking change. A future cleanup to prevent this would be to use
+# f'--{config_constant.repl('_','-')}' as the name argument to argparse.
 SOURCE_TYPE = "source_type"
 SECRET_MANAGER_TYPE = "secret_manager_type"
 SECRET_MANAGER_PROJECT_ID = "secret_manager_project_id"


### PR DESCRIPTION
Hi,

Random Row validation was not possible due to a CLI bug introduced in [PR 1310](https://github.com/GoogleCloudPlatform/professional-services-data-validator/pull/1310). Basically, the command line would only accept `--use-random-row` or `-rr`, while the backend could only understand `use_random_rows` which was always false because `'use_random_row' != 'use_random_rows'`. 

In order to not create a breaking change - the CLI accepts `--use-random-row` and `-rr` and translates them into `use_random_rows`, which the backend can understand.

We have tests for random rows, for multiple engines - they all bypass the CLI. We have a CLI unit test, but only for column validation. Random rows is an argument to Row validation, therefore opened [issue 1327](https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1327)

Sundar Mudupalli