### PR TITLE
fix: catch InvalidArgument when checking if config vals are secrets

### DIFF
--- a/data_validation/secret_manager.py
+++ b/data_validation/secret_manager.py
@@ -53,6 +53,6 @@ class GCPSecretManager:
             # Return the decoded payload.
             payload = response.payload.data.decode("UTF-8")
             return payload
-        except exceptions.NotFound:
+        except (exceptions.NotFound, exceptions.InvalidArgument):
             # The secret does not exist and therefore we can assume it is just a token to be returned.
             return secret_id

--- a/tests/system/test_secret_manager.py
+++ b/tests/system/test_secret_manager.py
@@ -1,7 +1,8 @@
 import os
-import pytest
-from data_validation import secret_manager
 
+import pytest
+
+from data_validation import secret_manager
 
 project_id = os.getenv("PROJECT_ID")
 
@@ -20,7 +21,7 @@ def test_access_gcp_secret_exists():
     secret_id = "db_test_user"
     manager = secret_manager.SecretManagerBuilder().build(client_type)
     secret_value = manager.maybe_secret(project_id, secret_id)
-    assert secret_value == "db_test_user"
+    assert secret_value == secret_id
 
 
 def test_access_gcp_secret_not_exists():


### PR DESCRIPTION
In #1285, SecretManager's exception catching scope was reduced from BaseException to just NotFound. This introduces a bug where if the value passed contains invalid chars for a secret name, eg. IP address for the 'host' config parameter, SecretManager throws InvalidArgument instead of NotFound. This PR catches InvalidArgument as well.

Sample error:
```
google.api_core.exceptions.InvalidArgument: 400 The provided Secret ID [projects/myproject/secrets/10.128.0.27/versions/latest] does not match the expected format [projects/*/secrets/*/versions/*]
```