### PR TITLE
feat: Support customer defined api endpoint for BigQuery and Spanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ data-validation
   [--std COLUMNS]       Comma separated list of columns for stddev_samp or * for all numeric
   [--exclude-columns or -ec]
                         Flag to indicate the list of columns provided should be excluded and not included.
-  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
+  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE or CONNECTION_NAME.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
   [--service-account or -sa PATH_TO_SA_KEY]
@@ -197,7 +197,7 @@ data-validation
                         from the source or target table if available.  See *Primary Keys* section
   [--exclude-columns or -ec]
                         Flag to indicate the list of columns provided should be excluded from hash or concat instead of included.
-  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
+  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE or CONNECTION_NAME.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
   [--service-account or -sa PATH_TO_SA_KEY]
@@ -278,7 +278,7 @@ data-validation
   [--primary-keys PRIMARY_KEYS, -pk PRIMARY_KEYS]
                         Comma separated list of primary key columns, when not specified the value will be inferred
                         from the source or target table if available.  See *Primary Keys* section
-  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
+  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE or CONNECTION_NAME.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
   [--service-account or -sa PATH_TO_SA_KEY]
@@ -324,7 +324,7 @@ data-validation
                         Comma separated list of tables in the form schema.table=target_schema.target_table. Or shorthand schema.* for all tables.
                         Target schema name and table name are optional.
                         e.g.: 'bigquery-public-data.new_york_citibike.citibike_trips'
-  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
+  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE or CONNECTION_NAME.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
   [--service-account or -sa PATH_TO_SA_KEY]
@@ -384,7 +384,7 @@ data-validation
   [--std COLUMNS]       Comma separated list of columns for stddev_samp or * for all numeric
   [--exclude-columns or -ec]
                         Flag to indicate the list of columns provided should be excluded and not included.
-  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
+  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE or CONNECTION_NAME.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
   [--service-account or -sa PATH_TO_SA_KEY]
@@ -453,7 +453,7 @@ data-validation
                        Common column between source and target queries for join
   [--exclude-columns or -ec]
                         Flag to indicate the list of columns provided should be excluded from hash or concat instead of included.
-  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE]
+  [--bq-result-handler or -bqrh PROJECT_ID.DATASET.TABLE or CONNECTION_NAME.DATASET.TABLE]
                         BigQuery destination for validation results. Defaults to stdout.
                         See: *Validation Reports* section
   [--service-account or -sa PATH_TO_SA_KEY]

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -65,7 +65,10 @@ CONNECTION_SOURCE_FIELDS = {
     "BigQuery": [
         ["project_id", "GCP Project to use for BigQuery"],
         ["google_service_account_key_path", "(Optional) GCP SA Key Path"],
-        ["api_endpoint", "(Optional) GCP BigQuery API endpoint"],
+        [
+            "api_endpoint",
+            '(Optional) GCP BigQuery API endpoint (e.g. "https://mybq.p.googleapis.com")',
+        ],
     ],
     "Teradata": [
         ["host", "Desired Teradata host"],
@@ -126,7 +129,10 @@ CONNECTION_SOURCE_FIELDS = {
         ["instance_id", "ID of Spanner instance to connect to"],
         ["database_id", "ID of Spanner database (schema) to connect to"],
         ["google_service_account_key_path", "(Optional) GCP SA Key Path"],
-        ["api_endpoint", "(Optional) GCP Spanner API endpoint"],
+        [
+            "api_endpoint",
+            '(Optional) GCP Spanner API endpoint (e.g. "https://mycs.p.googleapis.com")',
+        ],
     ],
     "FileSystem": [
         ["table_name", "Table name to use as reference for file data"],

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1186,25 +1186,38 @@ def get_filters(filter_value: str) -> List[Dict]:
     return filter_config
 
 
-def get_result_handler(rc_value, sa_file=None):
+def get_result_handler(rc_value: str, sa_file=None) -> dict:
     """Returns dict of result handler config. Backwards compatible for JSON input.
 
     rc_value (str): Result config argument specified.
     sa_file (str): SA path argument specified.
     """
-    # TODO how to handle api_endpoint here?
     config = rc_value.split(".", 1)
-    if len(config) == 2:
-        result_handler = {
-            "type": "BigQuery",
-            "project_id": config[0],
-            "table_id": config[1],
-        }
-    else:
+    if len(config) != 2:
         raise ValueError(f"Unable to parse result handler config: `{rc_value}`")
 
+    # Check if the first part of the BQRH is a connection name.
+    mgr = state_manager.StateManager()
+    connections = mgr.list_connections()
+    if config[0] in connections:
+        # We received connection_name.bq_results_table
+        conn_from_file = get_connection(config[0])
+        result_handler = {
+            "type": "BigQuery",
+            consts.PROJECT_ID: conn_from_file["project_id"],
+            consts.TABLE_ID: config[1],
+            consts.API_ENDPOINT: conn_from_file.get("api_endpoint", None),
+        }
+    else:
+        # We received project_name.bq_results_table
+        result_handler = {
+            "type": "BigQuery",
+            consts.PROJECT_ID: config[0],
+            consts.TABLE_ID: config[1],
+        }
+
     if sa_file:
-        result_handler["google_service_account_key_path"] = sa_file
+        result_handler[consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH] = sa_file
 
     return result_handler
 

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -65,6 +65,7 @@ CONNECTION_SOURCE_FIELDS = {
     "BigQuery": [
         ["project_id", "GCP Project to use for BigQuery"],
         ["google_service_account_key_path", "(Optional) GCP SA Key Path"],
+        ["api_endpoint", "(Optional) GCP BigQuery API endpoint"],
     ],
     "Teradata": [
         ["host", "Desired Teradata host"],
@@ -125,6 +126,7 @@ CONNECTION_SOURCE_FIELDS = {
         ["instance_id", "ID of Spanner instance to connect to"],
         ["database_id", "ID of Spanner database (schema) to connect to"],
         ["google_service_account_key_path", "(Optional) GCP SA Key Path"],
+        ["api_endpoint", "(Optional) GCP Spanner API endpoint"],
     ],
     "FileSystem": [
         ["table_name", "Table name to use as reference for file data"],
@@ -1184,6 +1186,7 @@ def get_result_handler(rc_value, sa_file=None):
     rc_value (str): Result config argument specified.
     sa_file (str): SA path argument specified.
     """
+    # TODO how to handle api_endpoint here?
     config = rc_value.split(".", 1)
     if len(config) == 2:
         result_handler = {

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -288,10 +288,10 @@ def get_data_client(connection_config):
             consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH
         )
         if key_path:
-            decrypted_connection_config["credentials"] = (
-                google.oauth2.service_account.Credentials.from_service_account_file(
-                    key_path
-                )
+            decrypted_connection_config[
+                "credentials"
+            ] = google.oauth2.service_account.Credentials.from_service_account_file(
+                key_path
             )
 
     if source_type not in CLIENT_LOOKUP:

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -278,10 +278,10 @@ def get_data_client(connection_config):
             consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH
         )
         if key_path:
-            decrypted_connection_config[
-                "credentials"
-            ] = google.oauth2.service_account.Credentials.from_service_account_file(
-                key_path
+            decrypted_connection_config["credentials"] = (
+                google.oauth2.service_account.Credentials.from_service_account_file(
+                    key_path
+                )
             )
 
     if source_type not in CLIENT_LOOKUP:

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -19,10 +19,10 @@ from typing import TYPE_CHECKING
 import warnings
 
 import google.oauth2.service_account
-import ibis
-import pandas
 from google.cloud import bigquery
 from google.api_core import client_options
+import ibis
+import pandas
 
 from data_validation import client_info, consts, exceptions
 from data_validation.secret_manager import SecretManagerBuilder
@@ -91,7 +91,7 @@ except Exception:
     db2_connect = _raise_missing_client_error("pip install ibm_db_sa")
 
 
-def get_bigquery_client(project_id, dataset_id="", credentials=None, api_endpoint=None):
+def get_google_bigquery_client(project_id, credentials=None, api_endpoint=None):
     info = client_info.get_http_client_info()
     job_config = bigquery.QueryJobConfig(
         connection_properties=[bigquery.ConnectionProperty("time_zone", "UTC")]
@@ -99,12 +99,18 @@ def get_bigquery_client(project_id, dataset_id="", credentials=None, api_endpoin
     options = None
     if api_endpoint:
         options = client_options.ClientOptions(api_endpoint=api_endpoint)
-    google_client = bigquery.Client(
+    return bigquery.Client(
         project=project_id,
         client_info=info,
         credentials=credentials,
         default_query_job_config=job_config,
         client_options=options,
+    )
+
+
+def get_bigquery_client(project_id, dataset_id="", credentials=None, api_endpoint=None):
+    google_client = get_google_bigquery_client(
+        project_id, credentials=credentials, api_endpoint=api_endpoint
     )
 
     ibis_client = ibis.bigquery.connect(

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -91,7 +91,9 @@ except Exception:
     db2_connect = _raise_missing_client_error("pip install ibm_db_sa")
 
 
-def get_google_bigquery_client(project_id, credentials=None, api_endpoint=None):
+def get_google_bigquery_client(
+    project_id: str, credentials=None, api_endpoint: str = None
+):
     info = client_info.get_http_client_info()
     job_config = bigquery.QueryJobConfig(
         connection_properties=[bigquery.ConnectionProperty("time_zone", "UTC")]
@@ -108,7 +110,9 @@ def get_google_bigquery_client(project_id, credentials=None, api_endpoint=None):
     )
 
 
-def get_bigquery_client(project_id, dataset_id="", credentials=None, api_endpoint=None):
+def get_bigquery_client(
+    project_id: str, dataset_id: str = "", credentials=None, api_endpoint: str = None
+):
     google_client = get_google_bigquery_client(
         project_id, credentials=credentials, api_endpoint=api_endpoint
     )
@@ -284,10 +288,10 @@ def get_data_client(connection_config):
             consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH
         )
         if key_path:
-            decrypted_connection_config[
-                "credentials"
-            ] = google.oauth2.service_account.Credentials.from_service_account_file(
-                key_path
+            decrypted_connection_config["credentials"] = (
+                google.oauth2.service_account.Credentials.from_service_account_file(
+                    key_path
+                )
             )
 
     if source_type not in CLIENT_LOOKUP:

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -284,10 +284,10 @@ def get_data_client(connection_config):
             consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH
         )
         if key_path:
-            decrypted_connection_config["credentials"] = (
-                google.oauth2.service_account.Credentials.from_service_account_file(
-                    key_path
-                )
+            decrypted_connection_config[
+                "credentials"
+            ] = google.oauth2.service_account.Credentials.from_service_account_file(
+                key_path
             )
 
     if source_type not in CLIENT_LOOKUP:

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -479,11 +479,13 @@ class ConfigManager(object):
                 )
             else:
                 credentials = None
+            api_endpoint = self.result_handler_config.get(consts.API_ENDPOINT)
             return BigQueryResultHandler.get_handler_for_project(
                 project_id,
                 self.filter_status,
                 table_id=table_id,
                 credentials=credentials,
+                api_endpoint=api_endpoint,
                 text_format=self._config.get(consts.CONFIG_FORMAT, "table"),
             )
         else:

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -123,6 +123,7 @@ YAML_VALIDATIONS = "validations"
 PROJECT_ID = "project_id"
 TABLE_ID = "table_id"
 GOOGLE_SERVICE_ACCOUNT_KEY_PATH = "google_service_account_key_path"
+API_ENDPOINT = "api_endpoint"
 
 # BigQuery Output Table Fields
 VALIDATION_TYPE = "validation_type"

--- a/data_validation/gcs_helper.py
+++ b/data_validation/gcs_helper.py
@@ -20,6 +20,9 @@ from google.cloud import storage
 from data_validation import client_info
 
 
+WRITE_SUCCESS_STRING = "Success! Config output written to"
+
+
 def _is_gcs_path(file_path: str) -> bool:
     return True if file_path.startswith("gs://") else False
 
@@ -81,7 +84,7 @@ def write_file(file_path: str, data: str, include_log: bool = True):
             file.write(data)
 
     if include_log:
-        logging.info("Success! Config output written to {}".format(file_path))
+        logging.info(f"{WRITE_SUCCESS_STRING} {file_path}")
 
 
 def list_gcs_directory(directory_path: str) -> List[str]:

--- a/data_validation/result_handlers/bigquery.py
+++ b/data_validation/result_handlers/bigquery.py
@@ -16,10 +16,11 @@
 
 import logging
 
-from google.cloud import bigquery
-
-from data_validation import client_info
+from data_validation import clients
 from data_validation.result_handlers import text as text_handler
+
+
+BQRH_WRITE_MESSAGE = "Results written to BigQuery"
 
 
 class BigQueryResultHandler(object):
@@ -51,6 +52,7 @@ class BigQueryResultHandler(object):
         status_list=None,
         table_id: str = "pso_data_validator.results",
         credentials=None,
+        api_endpoint: str = None,
         text_format: str = "table",
     ):
         """Return BigQueryResultHandler instance for given project.
@@ -62,16 +64,19 @@ class BigQueryResultHandler(object):
                 Explicit credentials to use in case default credentials
                 aren't working properly.
             status_list (list): provided status to filter the results with
+            api_endpoint (str): provided status to filter the results with
             text_format (str, optional):
                 This allows the user to influence the text results written via logger.debug.
                 See: https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/871
         """
-        info = client_info.get_http_client_info()
-        client = bigquery.Client(
-            project=project_id, client_info=info, credentials=credentials
+        client = clients.get_google_bigquery_client(
+            project_id, credentials=credentials, api_endpoint=api_endpoint
         )
         return BigQueryResultHandler(
-            client, status_list=status_list, table_id=table_id, text_format=text_format
+            client,
+            status_list=status_list,
+            table_id=table_id,
+            text_format=text_format,
         )
 
     def execute(self, result_df):
@@ -106,9 +111,7 @@ class BigQueryResultHandler(object):
         if result_df.empty:
             logging.info("No results to write to BigQuery")
         else:
-            logging.info(
-                f'Results written to BigQuery, run id: {result_df.iloc[0]["run_id"]}'
-            )
+            logging.info(f'{BQRH_WRITE_MESSAGE}, run id: {result_df.iloc[0]["run_id"]}')
 
         # Handler also logs results after saving to BigQuery.
         logger = logging.getLogger()

--- a/data_validation/result_handlers/bigquery.py
+++ b/data_validation/result_handlers/bigquery.py
@@ -64,7 +64,7 @@ class BigQueryResultHandler(object):
                 Explicit credentials to use in case default credentials
                 aren't working properly.
             status_list (list): provided status to filter the results with
-            api_endpoint (str): provided status to filter the results with
+            api_endpoint (str): BigQuery API endpoint (e.g. https://mybq.p.googleapis.com)
             text_format (str, optional):
                 This allows the user to influence the text results written via logger.debug.
                 See: https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/871

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -23,7 +23,6 @@ data-validation connections add \
     --secret-manager-project-id <MY-PROJECT> \
     --connection-name bq BigQuery \
     --project-id 'dvt-project-id'
-
 ```
 
 ## List existing connections
@@ -80,6 +79,7 @@ data-validation connections add
     --connection-name CONN_NAME BigQuery                Connection name
     --project-id MY_PROJECT                             Project ID where BQ data resides
     [--google-service-account-key-path PATH_TO_SA_KEY]  Path to SA key
+    [--api-endpoint ENDPOINT_URI]                       BigQuery API endpoint
 ```
 
 ### User/Service account needs following BigQuery permissions to run DVT:

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -79,7 +79,8 @@ data-validation connections add
     --connection-name CONN_NAME BigQuery                Connection name
     --project-id MY_PROJECT                             Project ID where BQ data resides
     [--google-service-account-key-path PATH_TO_SA_KEY]  Path to SA key
-    [--api-endpoint ENDPOINT_URI]                       BigQuery API endpoint
+    [--api-endpoint ENDPOINT_URI]                       BigQuery API endpoint (e.g.
+                                                        "https://mybq.p.googleapis.com)
 ```
 
 ### User/Service account needs following BigQuery permissions to run DVT:
@@ -103,6 +104,8 @@ data-validation connections add
     --instance-id MY_INSTANCE                           Spanner instance to connect to
     --database-id MY-DB                                 Spanner database (schema) to connect to
     [--google-service-account-key-path PATH_TO_SA_KEY]  Path to SA key
+    [--api-endpoint ENDPOINT_URI]                       Spanner API endpoint (e.g.
+                                                        "https://mycs.p.googleapis.com)
 ```
 
 ###  User/Service account needs following Spanner role to run DVT:

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -165,9 +165,11 @@ def find_tables_assertions(command_output: str):
 def schema_validation_test(
     tables="pso_data_validator.dvt_core_types",
     tc="bq-conn",
+    filter_status="fail",
     exclusion_columns="id",
     allow_list=None,
     allow_list_file=None,
+    bq_result_handler=None,
 ):
     """Generic schema validation test.
 
@@ -181,15 +183,17 @@ def schema_validation_test(
         f"-tc={tc}",
         f"-tbls={tables}",
         f"--exclusion-columns={exclusion_columns}",
-        "--filter-status=fail",
+        f"--filter-status={filter_status}" if filter_status else None,
         f"--allow-list={allow_list}" if allow_list else None,
         f"--allow-list-file={allow_list_file}" if allow_list_file else None,
+        (f"--bq-result-handler={bq_result_handler}" if bq_result_handler else None),
     ]
     cli_arg_list = [_ for _ in cli_arg_list if _]
     args = parser.parse_args(cli_arg_list)
     df = run_test_from_cli_args(args)
-    # With filter on failures the data frame should be empty
-    assert len(df) == 0
+    if filter_status == "fail":
+        # With filter on failures the data frame should be empty
+        assert len(df) == 0
 
 
 def column_validation_test_args(

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -163,13 +163,13 @@ def find_tables_assertions(command_output: str):
 
 
 def schema_validation_test(
-    tables="pso_data_validator.dvt_core_types",
-    tc="bq-conn",
-    filter_status="fail",
-    exclusion_columns="id",
-    allow_list=None,
-    allow_list_file=None,
-    bq_result_handler=None,
+    tables: str = "pso_data_validator.dvt_core_types",
+    tc: str = "bq-conn",
+    filter_status: str = "fail",
+    exclusion_columns: str = "id",
+    allow_list: str = None,
+    allow_list_file: str = None,
+    bq_result_handler: str = None,
 ):
     """Generic schema validation test.
 
@@ -186,7 +186,7 @@ def schema_validation_test(
         f"--filter-status={filter_status}" if filter_status else None,
         f"--allow-list={allow_list}" if allow_list else None,
         f"--allow-list-file={allow_list_file}" if allow_list_file else None,
-        (f"--bq-result-handler={bq_result_handler}" if bq_result_handler else None),
+        f"--bq-result-handler={bq_result_handler}" if bq_result_handler else None,
     ]
     cli_arg_list = [_ for _ in cli_arg_list if _]
     args = parser.parse_args(cli_arg_list)

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import logging
 import os
 from unittest import mock
 
@@ -30,6 +31,7 @@ from data_validation import (
 )
 from data_validation.query_builder import random_row_builder
 from data_validation.query_builder.query_builder import QueryBuilder
+from data_validation.result_handlers.bigquery import BQRH_WRITE_MESSAGE
 from tests.system.data_sources.common_functions import (
     partition_table_test,
     partition_query_test,
@@ -39,6 +41,7 @@ from tests.system.data_sources.common_functions import (
     row_validation_test,
     custom_query_validation_test,
 )
+from tests.system.result_handlers.test_bigquery import create_bigquery_results_table
 
 
 PROJECT_ID = os.environ["PROJECT_ID"]
@@ -1359,3 +1362,21 @@ def test_row_validation_identifiers(mock_conn):
         tc="mock-conn",
         hash="*",
     )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
+def test_bq_result_handler(mock_conn, bigquery_client, bigquery_dataset_id, caplog):
+    """Test BigQuery result handler using dvt_core_types schema validation."""
+    table_id = f"{bigquery_dataset_id}.test_bq_result_handler"
+    create_bigquery_results_table(bigquery_client, table_id)
+    caplog.set_level(logging.INFO)
+    schema_validation_test(
+        tables="pso_data_validator.dvt_core_types",
+        tc="mock-conn",
+        filter_status=None,
+        bq_result_handler=f"{PROJECT_ID}.{table_id}",
+    )
+    assert any(_ for _ in caplog.records if BQRH_WRITE_MESSAGE in _.msg)

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -152,6 +152,7 @@ CONNECTION_ADD_ARGS = {
     consts.PROJECT_ID: "dummy-gcp-project",
     consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH: None,
     "connection_name": "dummy-bq-connection",
+    "api_endpoint": None,
 }
 BROKEN_CONNECTION_CONFIG_INCORRECT_COMMAND = {
     "verbose": False,
@@ -164,6 +165,7 @@ BROKEN_CONNECTION_CONFIG_INCORRECT_COMMAND = {
     consts.PROJECT_ID: "dummy-gcp-project",
     consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH: None,
     "connection_name": "dummy-bq-connection",
+    "api_endpoint": None,
 }  # same as CONNECTION_ADD_ARGS but with the command item replaced
 FIND_TABLES_ARGS = {
     "verbose": False,

--- a/third_party/ibis/ibis_cloud_spanner/__init__.py
+++ b/third_party/ibis/ibis_cloud_spanner/__init__.py
@@ -14,6 +14,7 @@
 
 from typing import Any, Mapping, Optional, Tuple
 
+from google.api_core import client_options
 import google.cloud.spanner as cs
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
@@ -39,6 +40,7 @@ class Backend(BaseSQLBackend):
         database_id: str = None,
         project_id: str = None,
         credentials=None,
+        api_endpoint: str = None,
     ) -> None:
 
         self.spanner_client = spanner.Client(
@@ -50,7 +52,12 @@ class Backend(BaseSQLBackend):
             self.data_instance,
             self.dataset,
         ) = parse_instance_and_dataset(instance_id, database_id)
-        self.client = cs.Client()
+
+        options = None
+        if api_endpoint:
+            options = client_options.ClientOptions(api_endpoint=api_endpoint)
+
+        self.client = cs.Client(client_options=options)
 
     def _parse_instance_and_dataset(self, dataset):
         if not dataset and not self.dataset:

--- a/third_party/ibis/ibis_cloud_spanner/api.py
+++ b/third_party/ibis/ibis_cloud_spanner/api.py
@@ -22,6 +22,7 @@ def spanner_connect(
     database_id,
     project_id=None,
     credentials=None,
+    api_endpoint=None,
 ):
     """Create a Cloud Spanner Backend for use with Ibis.
 
@@ -40,5 +41,6 @@ def spanner_connect(
         database_id=database_id,
         project_id=project_id,
         credentials=credentials,
+        api_endpoint=api_endpoint,
     )
     return backend


### PR DESCRIPTION
This PR add a new attribute to BigQuery and Spanner connection files: api_endpoint.

This is because some customers do not expose the default API endpoints, for example "bigquery.googleapis.com"` internally and instead have a private endpoint. Both the BigQuery and Spanner client support provision of a customer endpoint.

There was a further complication regarding the BigQuery Request Handler. Our command line shorthand does not really cater for extra attributes. I figured it made much more sense to allow a defined connection to be used in the result handler in place of the project. This future proofs us for the addition of more BigQuery related attributes.