### PR TITLE
chore: Add Python 3.11 to test coverage

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ import random
 import nox
 
 # Python version used for linting.
-DEFAULT_PYTHON_VERSION = "3.10"
+DEFAULT_PYTHON_VERSION = "3.11"
 
 # Python versions used for testing. TODO: Add 3.11 and 3.12 when issue-1321 is complete.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ import random
 import nox
 
 # Python version used for linting.
-DEFAULT_PYTHON_VERSION = "3.11"
+DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing. TODO: Add 3.11 and 3.12 when issue-1321 is complete.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ import nox
 # Python version used for linting.
 DEFAULT_PYTHON_VERSION = "3.10"
 
-# Python versions used for testing. TODO: Add 3.11 and 3.12 when issue-1321 is complete.
+# Python versions used for testing.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 
 BLACK_PATHS = (

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ import nox
 DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing. TODO: Add 3.11 and 3.12 when issue-1321 is complete.
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 
 BLACK_PATHS = (
     "data_validation",


### PR DESCRIPTION
This PR adds Python 3.11 to unit test coverage and into the assorted Pythons we pick from for integration tests.

To prepare for this I hardcoded all tests to 3.11 and they passed so I'm confident we can start testing on 3.11.