### PR TITLE
tests: Check Oracle integration tests with Python 3.11

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,6 @@ DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
-PYTHON_VERSIONS = ["3.11"]
 PYTHON_VERSIONS_ORACLE = ["3.8", "3.9", "3.10"]
 
 BLACK_PATHS = (

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,7 @@ DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
+PYTHON_VERSIONS_ORACLE = ["3.11"]
 
 BLACK_PATHS = (
     "data_validation",
@@ -235,7 +236,7 @@ def integration_state(session):
     session.run("pytest", test_path, *session.posargs)
 
 
-@nox.session(python=random.choice(PYTHON_VERSIONS), venv_backend="venv")
+@nox.session(python=random.choice(PYTHON_VERSIONS_ORACLE), venv_backend="venv")
 def integration_oracle(session):
     """Run Oracle integration tests.
     Ensure Oracle validation is running as expected.

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,8 @@ DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
-PYTHON_VERSIONS_ORACLE = ["3.11"]
+PYTHON_VERSIONS = ["3.11"]
+PYTHON_VERSIONS_ORACLE = ["3.8", "3.9", "3.10"]
 
 BLACK_PATHS = (
     "data_validation",


### PR DESCRIPTION
The docker image used for Oracle testing does not include Python 3.11. I incorrectly added 3.11 to all tests. This PR removes it for only Oracle integration tests, all other source/target types continue to test with 3.11.