### PR TITLE
fix: Explicitly close connection after adding a connection

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -132,6 +132,14 @@ steps:
   - 'NOX_SESSION=integration_filesystem'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
+- id: integration_impala
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  args: ['bash', './ci/build.sh']
+  env:
+  - 'NOX_SESSION=integration_impala'
+  - 'PROJECT_ID=pso-kokoro-resources'
+  - 'IMPALA_HOST=10.128.0.118'
+  waitFor: ['-']
 
 availableSecrets:
   secretManager:

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -643,8 +643,14 @@ def run_connections(args):
     elif args.connect_cmd == "add":
         conn = cli_tools.get_connection_config_from_args(args)
         # Test getting a client to validate connection details
-        _ = clients.get_data_client(conn)
+        data_client = clients.get_data_client(conn)
         cli_tools.store_connection(args.connection_name, conn)
+        try:
+            if hasattr(data_client, "close"):
+                data_client.close()
+        except Exception as exc:
+            # No need to reraise, we can silently fail if exiting throws up an issue.
+            logging.warning("Exception closing connection: %s", str(exc))
     else:
         raise ValueError(f"Connections Argument '{args.connect_cmd}' is not supported")
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -646,6 +646,8 @@ def run_connections(args):
         data_client = clients.get_data_client(conn)
         cli_tools.store_connection(args.connection_name, conn)
         try:
+            # TODO When we upgrade Ibis beyond 5.x this try/except may become redundant.
+            # https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1376
             if hasattr(data_client, "close"):
                 data_client.close()
         except Exception as exc:

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -643,16 +643,8 @@ def run_connections(args):
     elif args.connect_cmd == "add":
         conn = cli_tools.get_connection_config_from_args(args)
         # Test getting a client to validate connection details
-        data_client = clients.get_data_client(conn)
-        cli_tools.store_connection(args.connection_name, conn)
-        try:
-            # TODO When we upgrade Ibis beyond 5.x this try/except may become redundant.
-            # https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1376
-            if hasattr(data_client, "close"):
-                data_client.close()
-        except Exception as exc:
-            # No need to reraise, we can silently fail if exiting throws up an issue.
-            logging.warning("Exception closing connection: %s", str(exc))
+        with clients.get_data_client_ctx(conn) as _:
+            cli_tools.store_connection(args.connection_name, conn)
     else:
         raise ValueError(f"Connections Argument '{args.connect_cmd}' is not supported")
 

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from contextlib import contextmanager
 import copy
 import logging
 from typing import TYPE_CHECKING
@@ -315,6 +316,24 @@ def get_data_client(connection_config):
         raise exceptions.DataClientConnectionFailure(msg)
 
     return data_client
+
+
+@contextmanager
+def get_data_client_ctx(*args, **kwargs):
+    """Provide get_data_client() via a context manager."""
+    client = None
+    try:
+        client = get_data_client(*args, **kwargs)
+        yield client
+    finally:
+        # TODO When we upgrade Ibis beyond 5.x this try/except may become redundant.
+        # https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1376
+        if hasattr(client, "close"):
+            try:
+                client.close()
+            except Exception as exc:
+                # No need to reraise, we can silently fail if exiting throws up an issue.
+                logging.warning("Exception closing connection: %s", str(exc))
 
 
 def get_max_column_length(client):

--- a/data_validation/raw_query.py
+++ b/data_validation/raw_query.py
@@ -20,14 +20,14 @@ from data_validation import clients, state_manager
 def run_raw_query_against_connection(args) -> list:
     """Return results of raw query for ad hoc usage."""
     mgr = state_manager.StateManager()
-    client = clients.get_data_client(mgr.get_connection_config(args.conn))
-    cursor = client.raw_sql(args.query)
-    res = cursor.fetchall()
-    try:
-        cursor.close()
-    except Exception:
-        pass
-    return res
+    with clients.get_data_client_ctx(mgr.get_connection_config(args.conn)) as client:
+        cursor = client.raw_sql(args.query)
+        res = cursor.fetchall()
+        try:
+            cursor.close()
+        except Exception:
+            pass
+        return res
 
 
 def print_raw_query_output(query_output: list):

--- a/noxfile.py
+++ b/noxfile.py
@@ -346,3 +346,18 @@ def integration_filesystem(session):
             raise Exception("Expected Env Var: %s" % env_var)
 
     session.run("pytest", test_path, env=env_vars, *session.posargs)
+
+
+@nox.session(python=random.choice(PYTHON_VERSIONS), venv_backend="venv")
+def integration_impala(session):
+    """Run Impala integration tests.
+    Ensure Impala validation is running as expected.
+    """
+    _setup_session_requirements(session)
+
+    expected_env_vars = ["PROJECT_ID", "IMPALA_HOST"]
+    for env_var in expected_env_vars:
+        if not os.environ.get(env_var, ""):
+            raise Exception("Expected Env Var: %s" % env_var)
+
+    session.run("pytest", "tests/system/data_sources/test_impala.py", *session.posargs)

--- a/tests/resources/impala_test_tables.sql
+++ b/tests/resources/impala_test_tables.sql
@@ -53,6 +53,33 @@ INSERT INTO `pso_data_validator`.`dvt_core_types` VALUES
 CREATE VIEW `pso_data_validator`.`dvt_core_types_vw` AS
 SELECT * FROM `pso_data_validator`.`dvt_core_types`;
 
+DROP TABLE IF EXISTS `pso_data_validator`.`dvt_pangrams`;
+CREATE TABLE `pso_data_validator`.`dvt_pangrams`
+(   id          int
+,   lang        varchar(100)
+,   words       varchar(1000)
+,   words_en    varchar(1000)
+)
+STORED AS PARQUET
+TBLPROPERTIES ('comment'='Integration test table used to test unicode characters.');
+-- Text taken from Wikipedia, we cannot guarantee translations :-)
+INSERT INTO `pso_data_validator`.`dvt_pangrams` VALUES
+(1,cast('Hebrew' as varchar(100)),
+ cast('שפן אכל קצת גזר בטעם חסה, ודי' as varchar(1000)),
+ cast('A bunny ate some lettuce-flavored carrots, and he had enough' as varchar(1000))),
+(2,cast('Polish' as varchar(100)),
+ cast('Pchnąć w tę łódź jeża lub ośm skrzyń fig' as varchar(1000)),
+ cast('Push a hedgehog or eight crates of figs in this boat' as varchar(1000))),
+(3,cast('Russian' as varchar(100)),
+ cast('Съешь ещё этих мягких французских булок, да выпей же чаю' as varchar(1000)),
+ cast('Eat more of these soft French loaves and drink a tea' as varchar(1000))),
+(4,cast('Swedish' as varchar(100)),
+ cast('Schweiz för lyxfjäder på qvist bakom ugn' as varchar(1000)),
+ cast('Switzerland brings luxury feather on branch behind oven' as varchar(1000))),
+(5,cast('Turkish' as varchar(100)),
+ cast('Pijamalı hasta yağız şoföre çabucak güvendi' as varchar(1000)),
+ cast('The sick person in pyjamas quickly trusted the swarthy driver' as varchar(1000)));
+
 DROP TABLE IF EXISTS `pso_data_validator`.`dvt_bool`;
 CREATE TABLE `pso_data_validator`.`dvt_bool`
 (   id           int

--- a/tests/resources/impala_test_tables.sql
+++ b/tests/resources/impala_test_tables.sql
@@ -90,3 +90,24 @@ CREATE TABLE `pso_data_validator`.`dvt_bool`
 ) COMMENT 'Integration test table used to test boolean data type, especially in non-boolean columns.';
 INSERT INTO `pso_data_validator`.`dvt_bool` VALUES
 (1,true,true,true,true),(2,false,false,false,false);
+
+DROP TABLE IF EXISTS `pso_data_validator`.`test_generate_partitions`;
+CREATE TABLE `pso_data_validator`.`test_generate_partitions` (
+    course_id string
+,   quarter_id int
+,   student_id int
+,   grade float)
+STORED AS PARQUET
+TBLPROPERTIES ('comment'='Table for testing generate table partitions, consists of 32 rows with a composite primary key');
+
+INSERT INTO `pso_data_validator`.`test_generate_partitions`
+(course_id, quarter_id, student_id, grade) VALUES
+('ALG001',1,1234,2.1),('ALG001',1,5678,3.5),('ALG001',1,9012,2.3)
+,('ALG001',2,1234,3.5),('ALG001',2,5678,2.6),('ALG001',2,9012,3.5)
+,('ALG001',3,1234,2.7),('ALG001',3,5678,3.5),('ALG001',3,9012,2.8)
+,('GEO001',1,1234,2.1),('GEO001',1,5678,3.5),('GEO001',1,9012,2.3)
+,('GEO001',2,1234,3.5),('GEO001',2,5678,2.6),('GEO001',2,9012,3.5)
+,('GEO001',3,1234,2.7),('GEO001',3,5678,3.5),('GEO001',3,9012,2.8)
+,('TRI001',1,1234,2.1),('TRI001',1,5678,3.5),('TRI001',1,9012,2.3)
+,('TRI001',2,1234,3.5),('TRI001',2,5678,2.6),('TRI001',2,9012,3.5)
+,('TRI001',3,1234,2.7),('TRI001',3,5678,3.5),('TRI001',3,9012,2.8);

--- a/tests/resources/impala_test_tables.sql
+++ b/tests/resources/impala_test_tables.sql
@@ -1,0 +1,65 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE DATABASE IF NOT EXISTS `pso_data_validator`;
+
+DROP TABLE IF EXISTS `pso_data_validator`.`dvt_core_types`;
+CREATE TABLE `pso_data_validator`.`dvt_core_types`
+(   id              int
+,   col_int8        tinyint
+,   col_int16       smallint
+,   col_int32       int
+,   col_int64       bigint
+,   col_dec_20      decimal(20)
+,   col_dec_38      decimal(38)
+,   col_dec_10_2    decimal(10,2)
+,   col_float32     float
+,   col_float64     double
+,   col_varchar_30  varchar(30)
+,   col_char_2      char(2)
+,   col_string      string
+,   col_date        date
+,   col_datetime    timestamp
+,   col_tstz        timestamp
+)
+STORED AS PARQUET
+TBLPROPERTIES ('comment'='Core data types integration test table');
+
+INSERT INTO `pso_data_validator`.`dvt_core_types` VALUES
+(1,1,1,1,1
+ ,12345678901234567890,1234567890123456789012345,123.11,123456.1,12345678.1
+ ,CAST('Hello DVT' AS varchar(30)),CAST('A ' AS char(2)),'Hello DVT'
+ ,'1970-01-01','1970-01-01 00:00:01','1970-01-01 01:00:01')
+,(2,2,2,2,2
+ ,12345678901234567890,1234567890123456789012345,123.22,123456.2,12345678.2
+ ,CAST('Hello DVT' AS varchar(30)),CAST('B ' AS char(2)),'Hello DVT'
+ ,'1970-01-02','1970-01-02 00:00:02','1970-01-02 02:00:02')
+,(3,3,3,3,3
+ ,12345678901234567890,1234567890123456789012345,123.3,123456.3,12345678.3
+ ,CAST('Hello DVT' AS varchar(30)),CAST('C ' AS char(2)),'Hello DVT'
+ ,'1970-01-03','1970-01-03 00:00:03','1970-01-03 03:00:03');
+
+CREATE VIEW `pso_data_validator`.`dvt_core_types_vw` AS
+SELECT * FROM `pso_data_validator`.`dvt_core_types`;
+
+DROP TABLE IF EXISTS `pso_data_validator`.`dvt_bool`;
+CREATE TABLE `pso_data_validator`.`dvt_bool`
+(   id           int
+,   col_bool_dec boolean
+,   col_bool_int boolean
+,   col_bool_ch1 boolean
+,   col_bool_chy boolean
+) COMMENT 'Integration test table used to test boolean data type, especially in non-boolean columns.';
+INSERT INTO `pso_data_validator`.`dvt_bool` VALUES
+(1,true,true,true,true),(2,false,false,false,false);

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -359,11 +359,18 @@ def row_validation_test(
     filters="1=1",
     primary_keys="id",
     comp_fields=None,
+    concat=None,
     use_randow_row=False,
     random_row_batch_size=None,
 ):
     """Generic row validation test. All row validation tests expect an empty dataframe as the assertion"""
     parser = cli_tools.configure_arg_parser()
+    if comp_fields:
+        col_option = f"--comparison-fields={comp_fields}"
+    elif concat:
+        col_option = f"--concat={concat}"
+    else:
+        col_option = f"--hash={hash}"
     cli_arg_list = [
         "validate",
         "row",
@@ -372,8 +379,8 @@ def row_validation_test(
         f"-tbls={tables}",
         f"--filters={filters}",
         f"--primary-keys={primary_keys}" if primary_keys else None,
+        col_option,
         "--filter-status=fail",
-        f"--comparison-fields={comp_fields}" if comp_fields else f"--hash={hash}",
         "--use-random-row" if use_randow_row else None,
         (
             f"--random-row-batch-size={random_row_batch_size}"

--- a/tests/system/data_sources/test_hive.py
+++ b/tests/system/data_sources/test_hive.py
@@ -151,7 +151,7 @@ def test_schema_validation_core_types_to_bigquery():
         allow_list=(
             # All Hive integers go to BigQuery INT64.
             "int8:int64,int16:int64,int32:int64,"
-            # Hive does not have a time zoned
+            # Hive does not have a time zoned timestamp.
             "timestamp:timestamp('UTC'),"
             # BigQuery does not have a float32 type.
             "float32:float64"
@@ -167,7 +167,7 @@ def test_schema_validation_not_null_vs_nullable():
     """
     Disabled this test because we don't currently pull nullable from Hive.
       https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/934
-    Compares a source table with a BigQuery target and ensure we match/fail on nnot null/nullable correctly.
+    Compares a source table with a BigQuery target and ensure we match/fail on not null/nullable correctly.
     """
     pytest.skip(
         "Skipping test_schema_validation_not_null_vs_nullable because we don't currently pull nullable from Hive."

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -177,7 +177,7 @@ def test_row_validation_core_types():
     """Impala to Impala dvt_core_types row validation"""
     row_validation_test(
         tc="mock-conn",
-        hash="*",
+        concat="*",
         filters="id>0 AND col_int8>0",
     )
 
@@ -192,11 +192,12 @@ def test_row_validation_core_types_to_bigquery():
     # float32/64 are lossy and cannot be compared.
     # col_float64 is excluded below because there is no way to control the format
     # when casting to string.
+    # TODO Change cols to include col_dec_10_2 when issue-1379 is complete.
     cols = ",".join(
         [
             _
             for _ in DVT_CORE_TYPES_COLUMNS
-            if _ not in ("id", "col_float32", "col_float64")
+            if _ not in ("id", "col_float32", "col_float64", "col_dec_10_2")
         ]
     )
     # Impala does not have sha2() until Impala v4.1.

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -1,0 +1,138 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest import mock
+
+import pytest
+import pathlib
+
+from data_validation import cli_tools, data_validation, consts
+from tests.system.data_sources.common_functions import (
+    binary_key_assertions,
+    column_validation_test,
+    column_validation_test_config_managers,
+    find_tables_test,
+    id_type_test_assertions,
+    null_not_null_assertions,
+    raw_query_test,
+    row_validation_many_columns_test,
+    row_validation_test,
+    run_test_from_cli_args,
+    schema_validation_test,
+    custom_query_validation_test,
+)
+from tests.system.data_sources.test_bigquery import BQ_CONN
+from tests.system.data_sources.common_functions import (
+    DVT_CORE_TYPES_COLUMNS,
+    partition_table_test,
+    partition_query_test,
+)
+
+
+IMPALA_HOST = os.getenv("IMPALA_HOST", "localhost")
+IMPALA_PORT = os.getenv("IMPALA_PORT", "21050")
+IMPALA_DATABASE = os.getenv("IMPALA_DATABASE", "default")
+
+
+CONN = {
+    "source_type": "Impala",
+    "host": IMPALA_HOST,
+    "port": IMPALA_PORT,
+    "database": IMPALA_DATABASE,
+}
+
+
+def mock_get_connection_config(*args):
+    if args[1] in ("impala-conn", "mock-conn"):
+        return CONN
+    elif args[1] == "bq-conn":
+        return BQ_CONN
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_schema_validation_core_types():
+    """Impala to Impala dvt_core_types schema validation"""
+    schema_validation_test(
+        tables="pso_data_validator.dvt_core_types",
+        tc="mock-conn",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_schema_validation_core_types_to_bigquery():
+    """Impala to BigQuery dvt_core_types schema validation"""
+    schema_validation_test(
+        tables="pso_data_validator.dvt_core_types",
+        tc="bq-conn",
+        allow_list=(
+            # Impala integers go to BigQuery INT64.
+            "int8:int64,int16:int64,int32:int64,"
+            # Hive does not have a time zoned timestamp.
+            "timestamp:timestamp('UTC'),"
+            # BigQuery does not have a float32 type.
+            "float32:float64"
+        ),
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_schema_validation_view_core_types_vw():
+    """Impala to Impala view dvt_core_types_vw schema validation"""
+    schema_validation_test(
+        tables="pso_data_validator.dvt_core_types_vw",
+        tc="mock-conn",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_schema_validation_bool():
+    """Impala to Impala dvt_bool schema validation"""
+    schema_validation_test(tables="pso_data_validator.dvt_bool", tc="mock-conn")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_core_types():
+    # """
+    # Disabled this test in favour of test_column_validation_core_types_to_bigquery().
+    # The Hive integration tests are too slow and timing out but I believe
+    # test_column_validation_core_types_to_bigquery() will cover off most of what this test does.
+    # """
+    # pytest.skip(
+    #    "Skipping test_column_validation_core_types in favour of test_column_validation_core_types_to_bigquery (due to elapsed time)."
+    # )
+    column_validation_test(
+        tc="mock-conn",
+        count_cols="*",
+        sum_cols="*",
+        min_cols="*",
+        max_cols="*",
+        filters="id>0 AND col_int8>0",
+        grouped_columns="col_varchar_30",
+    )

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -15,6 +15,8 @@
 import os
 from unittest import mock
 
+import pytest
+
 from data_validation import cli_tools
 from tests.system.data_sources.common_functions import (
     column_validation_test,
@@ -258,8 +260,9 @@ def test_custom_query_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_row_validation_hash_bool_to_bigquery():
+def test_row_validation_bool_to_bigquery():
     """Test row validation on a table with bool data types."""
+    pytest.skip("Skipping test_row_validation_bool_to_bigquery due to issue-1380.")
     # Impala does not have sha2() until Impala v4.1.
     # Our test infrastructiure is Impala v3 therefore we use --concat below.
     row_validation_test(

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -121,14 +121,6 @@ def test_schema_validation_bool():
     new=mock_get_connection_config,
 )
 def test_column_validation_core_types():
-    # """
-    # Disabled this test in favour of test_column_validation_core_types_to_bigquery().
-    # The Hive integration tests are too slow and timing out but I believe
-    # test_column_validation_core_types_to_bigquery() will cover off most of what this test does.
-    # """
-    # pytest.skip(
-    #    "Skipping test_column_validation_core_types in favour of test_column_validation_core_types_to_bigquery (due to elapsed time)."
-    # )
     column_validation_test(
         tc="mock-conn",
         count_cols="*",
@@ -148,8 +140,13 @@ def test_column_validation_core_types_to_bigquery():
     """Impala to BigQuery dvt_core_types column validation"""
     # Excluded col_float32 because BigQuery does not have an exact same type and
     # float32/64 are lossy and cannot be compared.
+    # TODO Change cols to include col_char_2 when issue-842 is complete.
     cols = ",".join(
-        [_ for _ in DVT_CORE_TYPES_COLUMNS if _ not in ("id", "col_float32")]
+        [
+            _
+            for _ in DVT_CORE_TYPES_COLUMNS
+            if _ not in ("id", "col_float32", "col_char_2")
+        ]
     )
     column_validation_test(
         tc="bq-conn",

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -199,7 +199,9 @@ def test_row_validation_core_types_to_bigquery():
             if _ not in ("id", "col_float32", "col_float64")
         ]
     )
-    row_validation_test(tc="bq-conn", hash=cols)
+    # Impala does not have sha2() until Impala v4.1.
+    # Our test infrastructiure is Impala v3 therefore we use --concat below.
+    row_validation_test(tc="bq-conn", concat=cols)
 
 
 @mock.patch(
@@ -224,6 +226,8 @@ def test_row_validation_pangrams_to_bigquery():
     This is testing comparisons across a wider set of characters than standard test data.
     """
     parser = cli_tools.configure_arg_parser()
+    # Impala does not have sha2() until Impala v4.1.
+    # Our test infrastructiure is Impala v3 therefore we use --concat below.
     args = parser.parse_args(
         [
             "validate",
@@ -232,7 +236,7 @@ def test_row_validation_pangrams_to_bigquery():
             "-tc=bq-conn",
             "-tbls=pso_data_validator.dvt_pangrams",
             "--primary-keys=id",
-            "--hash=*",
+            "--concat=*",
         ]
     )
     df = run_test_from_cli_args(args)
@@ -255,10 +259,12 @@ def test_custom_query_validation_core_types_to_bigquery():
 )
 def test_row_validation_hash_bool_to_bigquery():
     """Test row validation on a table with bool data types."""
+    # Impala does not have sha2() until Impala v4.1.
+    # Our test infrastructiure is Impala v3 therefore we use --concat below.
     row_validation_test(
         tables="pso_data_validator.dvt_bool",
         tc="bq-conn",
-        hash="*",
+        concat="*",
     )
 
 

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -44,6 +44,7 @@ from tests.system.data_sources.common_functions import (
 IMPALA_HOST = os.getenv("IMPALA_HOST", "localhost")
 IMPALA_PORT = os.getenv("IMPALA_PORT", "21050")
 IMPALA_DATABASE = os.getenv("IMPALA_DATABASE", "default")
+IMPALA_AUTH_MECH = os.getenv("IMPALA_AUTH_MECH", "NOSASL")
 
 
 CONN = {
@@ -51,6 +52,7 @@ CONN = {
     "host": IMPALA_HOST,
     "port": IMPALA_PORT,
     "database": IMPALA_DATABASE,
+    "auth_mechanism": IMPALA_AUTH_MECH,
 }
 
 

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pathlib
 from unittest import mock
 
 import pytest
@@ -49,6 +50,32 @@ CONN = {
     "database": IMPALA_DATABASE,
     "auth_mechanism": IMPALA_AUTH_MECH,
 }
+
+# Expected result from partitioning table on 3 keys
+EXPECTED_PARTITION_FILTER = [
+    [
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` < 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` < 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` > 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` < 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` > 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` < 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` > 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` < 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` > 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` < 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` > 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` < 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` > 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` < 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` > 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` < 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` > 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` >= 1234 ) ) ) ) )",
+    ],
+    [
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` < 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` < 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` > 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` < 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'ALG001' ) OR ( ( `course_id` = 'ALG001' ) AND ( ( `quarter_id` > 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` < 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` > 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` < 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` > 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` < 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'GEO001' ) OR ( ( `course_id` = 'GEO001' ) AND ( ( `quarter_id` > 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` < 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` > 1 ) OR ( ( `quarter_id` = 1 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` < 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` > 2 ) OR ( ( `quarter_id` = 2 ) AND ( `student_id` >= 1234 ) ) ) ) ) AND ( ( `course_id` < 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` < 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` < 1234 ) ) ) ) )",
+        " ( quarter_id <> 1111 ) AND ( ( `course_id` > 'TRI001' ) OR ( ( `course_id` = 'TRI001' ) AND ( ( `quarter_id` > 3 ) OR ( ( `quarter_id` = 3 ) AND ( `student_id` >= 1234 ) ) ) ) )",
+    ],
+]
 
 
 def mock_get_connection_config(*args):
@@ -109,6 +136,16 @@ def test_schema_validation_view_core_types_vw():
 def test_schema_validation_bool():
     """Impala to Impala dvt_bool schema validation"""
     schema_validation_test(tables="pso_data_validator.dvt_bool", tc="mock-conn")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_generate_partitions(tmp_path: pathlib.Path):
+    """Test generate partitions on Impala, first on table, then on custom query"""
+    partition_table_test(EXPECTED_PARTITION_FILTER)
+    partition_query_test(EXPECTED_PARTITION_FILTER, tmp_path)
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -228,7 +228,7 @@ def test_row_validation_pangrams_to_bigquery():
         [
             "validate",
             "row",
-            "-sc=ora-conn",
+            "-sc=mock-conn",
             "-tc=bq-conn",
             "-tbls=pso_data_validator.dvt_pangrams",
             "--primary-keys=id",

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -138,3 +138,88 @@ def test_column_validation_core_types():
         filters="id>0 AND col_int8>0",
         grouped_columns="col_varchar_30",
     )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_core_types_to_bigquery():
+    """Impala to BigQuery dvt_core_types column validation"""
+    # Excluded col_float32 because BigQuery does not have an exact same type and
+    # float32/64 are lossy and cannot be compared.
+    cols = ",".join(
+        [_ for _ in DVT_CORE_TYPES_COLUMNS if _ not in ("id", "col_float32")]
+    )
+    column_validation_test(
+        tc="bq-conn",
+        tables="pso_data_validator.dvt_core_types",
+        sum_cols=cols,
+        min_cols=cols,
+        max_cols=cols,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_view_core_types_vw():
+    """Impala to Impala view dvt_core_types_vw column validation"""
+    cols = ",".join([_ for _ in DVT_CORE_TYPES_COLUMNS if _ not in ("id")])
+    column_validation_test(
+        tc="mock-conn",
+        tables="pso_data_validator.dvt_core_types_vw",
+        count_cols=cols,
+        sum_cols=cols,
+        min_cols=cols,
+        max_cols=cols,
+        filters="id>0 AND col_int8>0",
+        grouped_columns="col_varchar_30",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_core_types():
+    """Impala to Impala dvt_core_types row validation"""
+    row_validation_test(
+        tc="mock-conn",
+        hash="*",
+        filters="id>0 AND col_int8>0",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_core_types_to_bigquery():
+    """Impala to BigQuery dvt_core_types row validation"""
+    # Excluded col_float32 because BigQuery does not have an exact same type and
+    # float32/64 are lossy and cannot be compared.
+    # col_float64 is excluded below because there is no way to control the format
+    # when casting to string.
+    cols = ",".join(
+        [
+            _
+            for _ in DVT_CORE_TYPES_COLUMNS
+            if _ not in ("id", "col_float32", "col_float64")
+        ]
+    )
+    row_validation_test(tc="bq-conn", hash=cols)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_comp_fields_core_types():
+    """Impala to Impala dvt_core_types row validation with --comp-fields"""
+    row_validation_test(
+        tables="pso_data_validator.dvt_core_types",
+        tc="mock-conn",
+        comp_fields="*",
+    )

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -15,19 +15,12 @@
 import os
 from unittest import mock
 
-import pytest
-import pathlib
-
-from data_validation import cli_tools, data_validation, consts
+from data_validation import cli_tools
 from tests.system.data_sources.common_functions import (
-    binary_key_assertions,
     column_validation_test,
-    column_validation_test_config_managers,
     find_tables_test,
     id_type_test_assertions,
-    null_not_null_assertions,
     raw_query_test,
-    row_validation_many_columns_test,
     row_validation_test,
     run_test_from_cli_args,
     schema_validation_test,
@@ -220,3 +213,69 @@ def test_row_validation_comp_fields_core_types():
         tc="mock-conn",
         comp_fields="*",
     )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_pangrams_to_bigquery():
+    """Impala to BigQuery dvt_pangrams row validation.
+    This is testing comparisons across a wider set of characters than standard test data.
+    """
+    parser = cli_tools.configure_arg_parser()
+    args = parser.parse_args(
+        [
+            "validate",
+            "row",
+            "-sc=ora-conn",
+            "-tc=bq-conn",
+            "-tbls=pso_data_validator.dvt_pangrams",
+            "--primary-keys=id",
+            "--hash=*",
+        ]
+    )
+    df = run_test_from_cli_args(args)
+    id_type_test_assertions(df)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_custom_query_validation_core_types_to_bigquery():
+    """Impala to BigQuery dvt_core_types custom-query validation
+    Using BigQuery target because Hive queries are really slow."""
+    custom_query_validation_test(tc="bq-conn", count_cols="*")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_hash_bool_to_bigquery():
+    """Test row validation on a table with bool data types."""
+    row_validation_test(
+        tables="pso_data_validator.dvt_bool",
+        tc="bq-conn",
+        hash="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_find_tables():
+    """Impala to BigQuery test of find-tables command."""
+    # check_for_view=False because there is no practical way to exclude views on Impala.
+    find_tables_test(check_for_view=False)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_raw_query_dvt_row_types(capsys):
+    """Test data-validation query command."""
+    raw_query_test(capsys)


### PR DESCRIPTION
This PR adds code to explicitly close client connections after adding a connection.

When connecting to an Impala cluster hosted in Docker we were getting an exception on variable clean up in SQL Alchemy. Closing clients before exiting prevented these exceptions.

I also took this opportunity to add some integration tests for Impala and raised a few new issues as a result of running them.