### PR TITLE
feat: Prevent exceptions due to PostgreSQL xml data type

### DIFF
--- a/tests/resources/postgresql_test_tables.sql
+++ b/tests/resources/postgresql_test_tables.sql
@@ -211,6 +211,7 @@ CREATE TABLE pso_data_validator.dvt_pg_types
 --,   col_bitv        bit varying(3)
 ,   col_uuid        uuid
 ,   col_oid         oid
+,   col_xml         xml
 );
 COMMENT ON TABLE pso_data_validator.dvt_pg_types IS 'PostgreSQL data types integration test table';
 
@@ -223,7 +224,7 @@ INSERT INTO pso_data_validator.dvt_pg_types
 ,col_date,col_ts,col_tstz,col_time,col_timetz
 ,col_binary,col_bool
 --,col_bit,col_bitv
-,col_uuid,col_oid)
+,col_uuid,col_oid,col_xml)
 VALUES
 (1111,123456789,123456789012345678,12345678901234567890.12345,123.12
 --,123.12
@@ -234,7 +235,8 @@ VALUES
 ,TIME'00:00:01.123456',TIME WITH TIME ZONE'00:00:01.123456 +00:00'
 ,CAST('DVT' AS BYTEA),CAST(0 AS BOOLEAN)
 --,B'101', B'101'
-,gen_random_uuid(),1)
+,gen_random_uuid(),1
+,'<?xml version="1.0"?><Test><Name>Test 1</Name><Command>test1.sh</Command></Test>')
 ,(2222,223456789,223456789012345678,22345678901234567890.12345,223.12
 --,223.12
 ,223456.1,22345678.1
@@ -244,7 +246,9 @@ VALUES
 ,TIME'00:00:02.123456',TIME WITH TIME ZONE'00:00:02.123456 +00:00'
 ,CAST('DVT' AS BYTEA),CAST(0 AS BOOLEAN)
 --,B'011', B'110'
-,gen_random_uuid(),2);
+,gen_random_uuid(),2
+,'<?xml version="1.0"?><Test><Name>Test 2</Name><Command>test2.sh</Command></Test>'
+);
 
 DROP TABLE IF EXISTS pso_data_validator.dvt_large_decimals;
 CREATE TABLE pso_data_validator.dvt_large_decimals

--- a/third_party/ibis/ibis_postgres/datatypes.py
+++ b/third_party/ibis/ibis_postgres/datatypes.py
@@ -13,10 +13,24 @@
 # limitations under the License.
 
 import ibis.expr.datatypes as dt
+from sqlalchemy.sql import sqltypes
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.dialects.postgresql.base import PGDialect
+from sqlalchemy.dialects.postgresql.base import PGDialect, ischema_names
+
+
+class XML(sqltypes.TypeEngine):
+    __visit_name__ = "XML"
+
+
+ischema_names["xml"] = XML
 
 
 @dt.dtype.register(PGDialect, postgresql.OID)
 def sa_pg_oid(_, sa_type, nullable=True):
     return dt.int32(nullable=nullable)
+
+
+# Matching Ibis v9.2 behaviour and mapping PostgreSQL xml type to unknown.
+@dt.dtype.register(PGDialect, XML)
+def sa_postgres_xml(_, satype, nullable=True):
+    return dt.Unknown(nullable=nullable)

--- a/third_party/ibis/ibis_postgres/datatypes.py
+++ b/third_party/ibis/ibis_postgres/datatypes.py
@@ -32,5 +32,5 @@ def sa_pg_oid(_, sa_type, nullable=True):
 
 # Matching Ibis v9.2 behaviour and mapping PostgreSQL xml type to unknown.
 @dt.dtype.register(PGDialect, XML)
-def sa_postgres_xml(_, satype, nullable=True):
+def sa_pg_xml(_, sa_type, nullable=True):
     return dt.Unknown(nullable=nullable)


### PR DESCRIPTION
This PR duplicates Ibis 9.2 behaviour for PostgreSQL xml data type to DVT. In essence this maps xml columns to data type "unknown".

I tested with the commands below.

Schema validation no longer throws an exception but does show the type as "unknown":
```
$ data-validation validate schema -sc pg -tc pg --tables-list "dvt_test.tab_xml"

╒══════╤═══════════════════╤═══════════════════╤══════════╤═════════════════════╤═════════════════════╤══════════════════════╤══════════════════════╤════════════════════╤════════════════════╤═════════════════════╕
│ run_ │ validation_name   │ validation_type   │ labels   │ source_table_name   │ target_table_name   │ source_column_name   │ target_column_name   │ source_agg_value   │ target_agg_value   │ validation_status   │
╞══════╪═══════════════════╪═══════════════════╪══════════╪═════════════════════╪═════════════════════╪══════════════════════╪══════════════════════╪════════════════════╪════════════════════╪═════════════════════╡
...
├──────┼───────────────────┼───────────────────┼──────────┼─────────────────────┼─────────────────────┼──────────────────────┼──────────────────────┼────────────────────┼────────────────────┼─────────────────────┤
│ d..d │ Schema            │ Schema            │ []       │ dvt_test.tab_xml    │ dvt_test.tab_xml    │ xml_data             │ xml_data             │ unknown            │ unknown            │ success             │
╘══════╧═══════════════════╧═══════════════════╧══════════╧═════════════════════╧═════════════════════╧══════════════════════╧══════════════════════╧════════════════════╧════════════════════╧═════════════════════╛
```

Column validation includes the XML column for count but skips it for min/max/sum:
```
$ data-validation validate column -sc pg -tc pg --tables-list "dvt_test.tab_xml" --count="*" --min="*" --sum="*"

╒═══════════════════╤═══════════════════╤═════════════════════╤══════════════════════╤════════════════════╤════════════════════╤══════════════════╤═════════════════════╤══════════════════════════════════════╕
│ validation_name   │ validation_type   │ source_table_name   │ source_column_name   │ source_agg_value   │ target_agg_value   │   pct_difference │ validation_status   │ run_id                               │
╞═══════════════════╪═══════════════════╪═════════════════════╪══════════════════════╪════════════════════╪════════════════════╪══════════════════╪═════════════════════╪══════════════════════════════════════╡
│ count__xml_data   │ Column            │ dvt_test.tab_xml    │ xml_data             │ 0                  │ 0                  │                0 │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
├───────────────────┼───────────────────┼─────────────────────┼──────────────────────┼────────────────────┼────────────────────┼──────────────────┼─────────────────────┼──────────────────────────────────────┤
│ min__batch_id     │ Column            │ dvt_test.tab_xml    │ batch_id             │ None               │ None               │              nan │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
├───────────────────┼───────────────────┼─────────────────────┼──────────────────────┼────────────────────┼────────────────────┼──────────────────┼─────────────────────┼──────────────────────────────────────┤
│ sum__id           │ Column            │ dvt_test.tab_xml    │ id                   │ None               │ None               │              nan │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
├───────────────────┼───────────────────┼─────────────────────┼──────────────────────┼────────────────────┼────────────────────┼──────────────────┼─────────────────────┼──────────────────────────────────────┤
│ min__id           │ Column            │ dvt_test.tab_xml    │ id                   │ None               │ None               │              nan │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
├───────────────────┼───────────────────┼─────────────────────┼──────────────────────┼────────────────────┼────────────────────┼──────────────────┼─────────────────────┼──────────────────────────────────────┤
│ count__batch_id   │ Column            │ dvt_test.tab_xml    │ batch_id             │ 0                  │ 0                  │              nan │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
├───────────────────┼───────────────────┼─────────────────────┼──────────────────────┼────────────────────┼────────────────────┼──────────────────┼─────────────────────┼──────────────────────────────────────┤
│ count             │ Column            │ dvt_test.tab_xml    │                      │ 0                  │ 0                  │                0 │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
├───────────────────┼───────────────────┼─────────────────────┼──────────────────────┼────────────────────┼────────────────────┼──────────────────┼─────────────────────┼──────────────────────────────────────┤
│ sum__batch_id     │ Column            │ dvt_test.tab_xml    │ batch_id             │ None               │ None               │              nan │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
├───────────────────┼───────────────────┼─────────────────────┼──────────────────────┼────────────────────┼────────────────────┼──────────────────┼─────────────────────┼──────────────────────────────────────┤
│ count__id         │ Column            │ dvt_test.tab_xml    │ id                   │ 0                  │ 0                  │              nan │ success             │ 9f7fe71a-ec1b-45ce-9d11-5b5bceb0e50a │
╘═══════════════════╧═══════════════════╧═════════════════════╧══════════════════════╧════════════════════╧════════════════════╧══════════════════╧═════════════════════╧══════════════════════════════════════╛
```

Row validation includes the column:
```
$ data-validation validate row -sc pg_local -tc pg_local --tables-list "dvt_test.tab_xml" --concat="*"

╒═══════════════════╤═══════════════════╤═════════════════════╤══════════════════════╤═════════════════════════════════╤═════════════════════════════════╤══════════════════╤═════════════════════╤══════════════════════════════════════╕
│ validation_name   │ validation_type   │ source_table_name   │ source_column_name   │ source_agg_value                │ target_agg_value                │ pct_difference   │ validation_status   │ run_id                               │
╞═══════════════════╪═══════════════════╪═════════════════════╪══════════════════════╪═════════════════════════════════╪═════════════════════════════════╪══════════════════╪═════════════════════╪══════════════════════════════════════╡
│ concat__all       │ Row               │ dvt_test.tab_xml    │ concat__all          │ 11<?xml version="1.0"?>         │ 11<?xml version="1.0"?>         │                  │ success             │ f2fa1d9f-3a08-420a-beed-4ff075689d0d │
│                   │                   │                     │                      │ <Tests>                         │ <Tests>                         │                  │                     │                                      │
│                   │                   │                     │                      │   <Test Id="1">                 │   <Test Id="1">                 │                  │                     │                                      │
│                   │                   │                     │                      │     <Name>Test 1</Name>         │     <Name>Test 1</Name>         │                  │                     │                                      │
│                   │                   │                     │                      │     <Command>test1.sh</Command> │     <Command>test1.sh</Command> │                  │                     │                                      │
│                   │                   │                     │                      │   </Test>                       │   </Test>                       │                  │                     │                                      │
│                   │                   │                     │                      │   <Test Id="2">                 │   <Test Id="2">                 │                  │                     │                                      │
│                   │                   │                     │                      │     <Name>Test 2</Name>         │     <Name>Test 2</Name>         │                  │                     │                                      │
│                   │                   │                     │                      │     <Command>test2.sh</Command> │     <Command>test2.sh</Command> │                  │                     │                                      │
│                   │                   │                     │                      │   </Test>                       │   </Test>                       │                  │                     │                                      │
│                   │                   │                     │                      │ </Tests>                        │ </Tests>                        │                  │                     │                                      │
╘═══════════════════╧═══════════════════╧═════════════════════╧══════════════════════╧═════════════════════════════════╧═════════════════════════════════╧══════════════════╧═════════════════════╧══════════════════════════════════════╛

$ data-validation validate row -sc pg_local -tc pg_local --tables-list "dvt_test.tab_xml" --hash="*"
╒═══════════════════╤═══════════════════╤═════════════════════╤══════════════════════╤══════════════════════════════════════════════════════════════════╤══════════════════════════════════════════════════════════════════╤══════════════════╤═════════════════════╤══════════════════════════════════════╕
│ validation_name   │ validation_type   │ source_table_name   │ source_column_name   │ source_agg_value                                                 │ target_agg_value                                                 │ pct_difference   │ validation_status   │ run_id                               │
╞═══════════════════╪═══════════════════╪═════════════════════╪══════════════════════╪══════════════════════════════════════════════════════════════════╪══════════════════════════════════════════════════════════════════╪══════════════════╪═════════════════════╪══════════════════════════════════════╡
│ hash__all         │ Row               │ dvt_test.tab_xml    │ hash__all            │ 4b5b2e664058162cf31c1c8a9bb3ef862398dd015616b069d05df0b25f909618 │ 4b5b2e664058162cf31c1c8a9bb3ef862398dd015616b069d05df0b25f909618 │                  │ success             │ cb821d2a-4c0a-415a-8668-38ca3ed086f4 │
╘═══════════════════╧═══════════════════╧═════════════════════╧══════════════════════╧══════════════════════════════════════════════════════════════════╧══════════════════════════════════════════════════════════════════╧══════════════════╧═════════════════════╧══════════════════════════════════════╛
```

I've added a column to the `pso_data_validator.dvt_pg_types` test table in the repo but cannot yet add it to the actual test table because tests on other branches will then fail. I do that part after we decide on correct behaviour and approve the PR in principal.