### PR TITLE
fix: Prevent logging an exception when result_df is empty

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
     from data_validation.metadata import RunMetadata, ValidationMetadata
 
 
+COMBINER_GET_SUMMARY_EXC_TEXT = (
+    "Error while generating summary report of row validation results"
+)
+
+
 def generate_report(
     client,
     run_metadata: "RunMetadata",
@@ -492,6 +497,6 @@ def _get_summary(
             )
     except Exception as e:
         logging.warning(
-            f"Error while generating summary report of row validation results: {e}",
+            f"{COMBINER_GET_SUMMARY_EXC_TEXT}: {e}",
             exc_info=True,
         )

--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -441,12 +441,15 @@ def _get_summary(
 ):
     """Logs a summary report/stats of row validation results."""
     try:
-        if result_df.loc[0, consts.VALIDATION_TYPE] == consts.ROW_VALIDATION:
-            # Vectorized calculations for all counts
+        if (
+            not result_df.empty
+            and result_df.loc[0, consts.VALIDATION_TYPE] == consts.ROW_VALIDATION
+        ):
+            # Vectorized calculations for all counts.
             success_condition = (
                 result_df[consts.VALIDATION_STATUS] == consts.VALIDATION_STATUS_SUCCESS
             )
-            fail_condition = ~success_condition  # Invert success for fail condition
+            fail_condition = ~success_condition  # Invert success for fail condition.
 
             source_not_in_target = (
                 result_df[consts.SOURCE_AGG_VALUE].notnull()

--- a/tests/unit/test_combiner.py
+++ b/tests/unit/test_combiner.py
@@ -1022,3 +1022,45 @@ def test_get_summary_with_non_zero_values_for_all_stats(
     logged = caplog.records[0]  # assuming only one log message
     assert logged.levelname == "INFO"
     assert logged.message == str(expected)
+    assert all(
+        module_under_test.COMBINER_GET_SUMMARY_EXC_TEXT not in _.message
+        for _ in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    ("run_metadata", "result_df", "source_df", "target_df"),
+    (
+        (
+            metadata.RunMetadata(
+                run_id="test-run",
+                start_time=datetime.datetime(
+                    2025, 2, 12, 7, 30, 10, tzinfo=datetime.timezone.utc
+                ),
+                end_time=datetime.datetime(
+                    2025, 2, 12, 7, 32, 15, tzinfo=datetime.timezone.utc
+                ),
+            ),
+            pandas.DataFrame(
+                {
+                    consts.VALIDATION_TYPE: [],
+                    consts.VALIDATION_STATUS: [],
+                    consts.GROUP_BY_COLUMNS: [],
+                    consts.SOURCE_AGG_VALUE: [],
+                    consts.TARGET_AGG_VALUE: [],
+                }
+            ),
+            pandas.DataFrame({"id": [], "value": []}),
+            pandas.DataFrame({"id": [], "value": []}),
+        ),
+    ),
+)
+def test_get_summary_with_empty_inputs(
+    module_under_test, caplog, run_metadata, result_df, source_df, target_df
+):
+    caplog.set_level(logging.INFO)
+    module_under_test._get_summary(run_metadata, result_df, source_df, target_df)
+    assert all(
+        module_under_test.COMBINER_GET_SUMMARY_EXC_TEXT not in _.message
+        for _ in caplog.records
+    )


### PR DESCRIPTION
## Description of changes
This PR prevent logging an exception when result_df is empty in the recently added `_get_summary()` code.
We have a try/catch block so this issue was not fatal to any validations, however it did mean that customers were having to review logged errors that were actually not an issue.

## Issues to be closed

Closes #1460

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


