### PR TITLE
fix: Cater for extreme datetime pk values

### DIFF
--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -17,6 +17,7 @@ import ibis
 import pandas
 import logging
 import re
+import datetime
 from typing import List, Dict, TYPE_CHECKING
 
 from data_validation import cli_tools, consts
@@ -253,12 +254,13 @@ class PartitionBuilder:
 
             def less_than_value(table, keys, values):
                 key_column = table.__getattr__(keys[0])
-                if key_column.type().is_date():
-                    # Ensure date PKs are treated as date literals as per #1191
-                    value = values[0].date()
-                else:
-                    value = values[0]
-
+                # Due to issue 1474, the type can be datetime.datetime or datetime.date
+                value = (
+                    values[0].date()
+                    if key_column.type().is_date()
+                    and isinstance(values[0], datetime.datetime)
+                    else values[0]
+                )
                 if len(keys) == 1:
                     return key_column < value
                 else:
@@ -269,10 +271,13 @@ class PartitionBuilder:
 
             def geq_value(table, keys, values):
                 key_column = table.__getattr__(keys[0])
-                if key_column.type().is_date():
-                    value = values[0].date()
-                else:
-                    value = values[0]
+                # Due to issue 1474, the type can be datetime.datetime or datetime.date
+                value = (
+                    values[0].date()
+                    if key_column.type().is_date()
+                    and isinstance(values[0], datetime.datetime)
+                    else values[0]
+                )
 
                 if len(keys) == 1:
                     return key_column >= value

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -440,6 +440,8 @@ def partition_table_test(
     pk="course_id,quarter_id,student_id",
     tables="pso_data_validator.test_generate_partitions",
     filters="quarter_id != 1111",
+    partition_num=9,
+    parts_per_file=5,
 ):
     """Test generate table partitions for a database. Usually only the partition_filter is different
     because of the differences in SQL between the databases. Some databases have different table names,
@@ -449,20 +451,20 @@ def partition_table_test(
     """
 
     parser = cli_tools.configure_arg_parser()
-    args = parser.parse_args(
-        [
-            "generate-table-partitions",
-            "-sc=mock-conn",
-            "-tc=mock-conn",
-            f"-tbls={tables}",
-            f"-pk={pk}",
-            "-hash=*",
-            "-cdir=/home/users/yaml",
-            "-pn=9",
-            "-ppf=5",
-            f"-filters={filters}",
-        ]
-    )
+    cli_arg_list = [
+        "generate-table-partitions",
+        "-sc=mock-conn",
+        "-tc=mock-conn",
+        f"-tbls={tables}",
+        f"-pk={pk}",
+        "-hash=*",
+        "-cdir=/home/users/yaml",
+        f"-pn={partition_num}",
+        f"-ppf={parts_per_file}",
+        f"-filters={filters}" if filters else None,
+    ]
+    cli_arg_list = [_ for _ in cli_arg_list if _]
+    args = parser.parse_args(cli_arg_list)
     config_managers = main.build_config_managers_from_args(args, consts.ROW_VALIDATION)
     partition_builder = PartitionBuilder(config_managers, args)
     partition_filters = partition_builder._get_partition_key_filters()

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -425,6 +425,7 @@ def test_row_validation_datetime_pk_to_bigquery():
 )
 def test_generate_partitions_datetime_pk():
     """Test generate partitions on datetime primary key"""
+    pytest.skip("Skipping test_generate_partitions_datetime_pk due to issue-1443.")
     partition_table_test(
         EXPECTED_DATETIME_ID_PARTITION_FILTER,
         pk="id",

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -73,6 +73,17 @@ CONFIG_COUNT_VALID = {
     consts.CONFIG_FILTER_STATUS: None,
 }
 
+EXPECTED_DATETIME_ID_PARTITION_FILTER = [
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+]
+
 
 def mock_get_connection_config(*args):
     if args[1] in ("mysql-conn", "mock-conn"):
@@ -405,6 +416,21 @@ def test_row_validation_datetime_pk_to_bigquery():
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
         use_randow_row=False,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_generate_partitions_datetime_pk():
+    """Test generate partitions on datetime primary key"""
+    partition_table_test(
+        EXPECTED_DATETIME_ID_PARTITION_FILTER,
+        pk="id",
+        tables="pso_data_validator.dvt_datetime_id",
+        filters="other_data IS NOT NULL",
+        partition_num=2,
     )
 
 

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -665,6 +665,7 @@ def test_row_validation_datetime_pk_to_bigquery():
 )
 def test_generate_partitions_datetime_pk():
     """Test generate partitions on datetime primary key"""
+    pytest.skip("Skipping test_generate_partitions_datetime_pk due to issue-1443.")
     partition_table_test(
         EXPECTED_DATETIME_ID_PARTITION_FILTER,
         pk="id",

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -128,6 +128,17 @@ DVT_CORE_TYPES_RAW_DATA_TYPES = [
     ("COL_TSTZ", "TIMESTAMP_TZ", None, None, 0, 3, 1),
 ]
 
+EXPECTED_DATETIME_ID_PARTITION_FILTER = [
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+]
+
 
 def test_count_validator():
     validator = data_validation.DataValidation(ORACLE_CONFIG, verbose=True)
@@ -645,6 +656,21 @@ def test_row_validation_datetime_pk_to_bigquery():
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
         use_randow_row=False,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_generate_partitions_datetime_pk():
+    """Test generate partitions on datetime primary key"""
+    partition_table_test(
+        EXPECTED_DATETIME_ID_PARTITION_FILTER,
+        pk="id",
+        tables="pso_data_validator.dvt_datetime_id",
+        filters="other_data IS NOT NULL",
+        partition_num=5,
     )
 
 

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -670,7 +670,7 @@ def test_generate_partitions_datetime_pk():
         pk="id",
         tables="pso_data_validator.dvt_datetime_id",
         filters="other_data IS NOT NULL",
-        partition_num=5,
+        partition_num=2,
     )
 
 

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -109,6 +109,17 @@ DVT_CORE_TYPES_RAW_DATA_TYPES = [
     ("col_tstz", "timestamp with time zone", None, 8, None, None, None),
 ]
 
+EXPECTED_DATETIME_ID_PARTITION_FILTER = [
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+]
+
 
 @pytest.fixture
 def cloud_sql(request):
@@ -876,6 +887,21 @@ def test_row_validation_datetime_pk_to_bigquery():
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
         use_randow_row=False,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_generate_partitions_datetime_pk():
+    """Test generate partitions on datetime primary key"""
+    partition_table_test(
+        EXPECTED_DATETIME_ID_PARTITION_FILTER,
+        pk="id",
+        tables="pso_data_validator.dvt_datetime_id",
+        filters="other_data IS NOT NULL",
+        partition_num=2,
     )
 
 

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -896,6 +896,7 @@ def test_row_validation_datetime_pk_to_bigquery():
 )
 def test_generate_partitions_datetime_pk():
     """Test generate partitions on datetime primary key"""
+    pytest.skip("Skipping test_generate_partitions_datetime_pk due to issue-1443.")
     partition_table_test(
         EXPECTED_DATETIME_ID_PARTITION_FILTER,
         pk="id",

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -509,6 +509,7 @@ def test_row_validation_datetime_pk_to_bigquery():
 )
 def test_generate_partitions_datetime_pk():
     """Test generate partitions on datetime primary key"""
+    pytest.skip("Skipping test_generate_partitions_datetime_pk due to issue-1443.")
     partition_table_test(
         EXPECTED_DATETIME_ID_PARTITION_FILTER,
         pk="id",

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -57,6 +57,17 @@ CONN = {
     "database": "guestbook",
 }
 
+EXPECTED_DATETIME_ID_PARTITION_FILTER = [
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+]
+
 
 @pytest.fixture
 def cloud_sql(request):
@@ -489,6 +500,21 @@ def test_row_validation_datetime_pk_to_bigquery():
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
         use_randow_row=False,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_generate_partitions_datetime_pk():
+    """Test generate partitions on datetime primary key"""
+    partition_table_test(
+        EXPECTED_DATETIME_ID_PARTITION_FILTER,
+        pk="id",
+        tables="pso_data_validator.dvt_datetime_id",
+        filters="other_data IS NOT NULL",
+        partition_num=2,
     )
 
 

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -217,6 +217,18 @@ DVT_CORE_TYPES_RAW_DATA_TYPES = [
 ]
 
 
+EXPECTED_DATETIME_ID_PARTITION_FILTER = [
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+    [
+        " ( NOT other_data IS NULL ) AND ( \"id\" < '2020-03-01T12:00:00' )",
+        " ( NOT other_data IS NULL ) AND ( \"id\" >= '2020-03-01T12:00:00' )",
+    ],
+]
+
+
 def test_count_validator():
     validator = data_validation.DataValidation(TERADATA_COLUMN_CONFIG, verbose=True)
     df = validator.execute()
@@ -623,6 +635,22 @@ def test_row_validation_datetime_pk_to_bigquery():
     id_column_row_validation_test(
         "udf.dvt_datetime_id=pso_data_validator.dvt_datetime_id",
         use_randow_row=False,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_generate_partitions_datetime_pk():
+    """Test generate partitions on datetime primary key"""
+    pytest.skip("Skipping test_generate_partitions_datetime_pk because of issue-1443")
+    partition_table_test(
+        EXPECTED_DATETIME_ID_PARTITION_FILTER,
+        pk="id",
+        tables="udf.dvt_datetime_id",
+        filters="other_data IS NOT NULL",
+        partition_num=2,
     )
 
 


### PR DESCRIPTION
## Description of changes
Sundar: The problem fixed by this PR is how dates are represented internally by Pandas and Numpy. Generally everything is represented as a timestamp (i.e. datetime.datetime) with nanosecond resolution as long as it can "fit" - see [Timestamp resolution](https://pandas.pydata.org/docs/user_guide/timeseries.html#timestamp-limitations). When it does not fit - that is it is before AD 1677 or after AD 2262, Pandas seems to default to datetime.date type. That is the behavior observed with the Teradata backend.

Neil: I took the opportunity to add some generate partitions integration tests. Not testing this exact problem but at least giving us some coverage of datetimes used in primary keys.

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1474

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


