### PR TITLE
test: Remove fixed version from pyfakefs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ See [our script](tests/local_check.sh) for using nox to run tests step by step.
 
 You can also run pytest directly:
 ```python
-pip install pytest pytest-cov pyfakefs==4.6.2 freezegun
+pip install pytest pytest-cov pyfakefs freezegun
 pytest tests/unit
 ```
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,7 @@ BLACK_PATHS = (
     "setup.py",
 )
 LINT_PACKAGES = ["flake8", "black==22.3.0"]
-UNIT_PACKAGES = ["pyfakefs==4.6.2", "freezegun", "teradatasql"]
+UNIT_PACKAGES = ["pyfakefs", "freezegun", "teradatasql"]
 
 
 def _setup_session_requirements(session, extra_packages=[]):

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extras_require = {
         "black==22.3.0",
         "flake8",
         "freezegun",
-        "pyfakefs==4.6.2",
+        "pyfakefs",
         "pytest",
         "pytest-cov",
         "pytest-timeout",

--- a/tests/local_check.sh
+++ b/tests/local_check.sh
@@ -18,7 +18,7 @@
 # Step 2: Execute this script only after the virtual env activation
 
 # install/update all necessary libraries
-pip install pytest pytest-cov pyfakefs==5.6.0 freezegun black==22.3.0 flake8
+pip install pytest pytest-cov pyfakefs freezegun black==22.3.0 flake8
 
 # check unit tests and coverage
 echo "Start TEST COVERAGE"


### PR DESCRIPTION

## Description of changes
Remove fixed version from pyfakefs to enable DVT devs to work on internal workstations with very recent version of Python 3.12.

## Issues to be closed

Closes #1477

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


