### PR TITLE
fix: Reduced VARCHAR length when casting Teradata integrals to string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", "r") as fh:
 
 dependencies = [
     "Flask>=2.2",  # Some versions of airflow such as 2.9.1 depend on flask<2.3 and >=2.2
-    "fsspec>=2024.9.0",
+    "fsspec!=2025.3.1",
     "google-api-python-client>=2.144.0",
     "google-cloud-bigquery>=3.25.0",
     "google-cloud-bigquery-storage>=2.26.0",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", "r") as fh:
 
 dependencies = [
     "Flask>=2.2",  # Some versions of airflow such as 2.9.1 depend on flask<2.3 and >=2.2
-    "fsspec!=2025.3.1",
+    "fsspec!=2025.3.1",  # Version 2025.3.1 was breaking Python 3.8 support.
     "google-api-python-client>=2.144.0",
     "google-cloud-bigquery>=3.25.0",
     "google-cloud-bigquery-storage>=2.26.0",

--- a/tests/resources/oracle_test_tables.sql
+++ b/tests/resources/oracle_test_tables.sql
@@ -306,7 +306,7 @@ COMMIT;
 
 DROP TABLE pso_data_validator.dvt_many_cols;
 CREATE TABLE pso_data_validator.dvt_many_cols
-( id NUMBER(5)
+( id NUMBER(5) NOT NULL PRIMARY KEY
 , col_001 VARCHAR2(2)
 , col_002 VARCHAR2(2)
 , col_003 VARCHAR2(2)

--- a/tests/resources/teradata_test_tables.sql
+++ b/tests/resources/teradata_test_tables.sql
@@ -262,7 +262,7 @@ VALUES (5,'Turkish',
 
 DROP TABLE udf.dvt_many_cols;
 CREATE TABLE udf.dvt_many_cols
-( id NUMBER(5)
+( id NUMBER(5) NOT NULL PRIMARY KEY
 , col_001 VARCHAR(2)
 , col_002 VARCHAR(2)
 , col_003 VARCHAR(2)

--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -106,6 +106,21 @@ def teradata_cast_decimal_to_string(compiled_arg, from_, to):
     return "TO_CHAR({},'TM9')".format(compiled_arg)
 
 
+@teradata_cast.register(str, dt.Int8, dt.String)
+@teradata_cast.register(str, dt.Int16, dt.String)
+@teradata_cast.register(str, dt.Int32, dt.String)
+def teradata_cast_integer_to_string(compiled_arg, from_, to):
+    # INTEGER in a string cannot be longer than 10 characters (+1 for sign).
+    # Included smaller integers here too to minimize overloads.
+    return "CAST({} AS VARCHAR(11))".format(compiled_arg)
+
+
+@teradata_cast.register(str, dt.Int64, dt.String)
+def teradata_cast_bigint_to_string(compiled_arg, from_, to):
+    # BIGINT in a string cannot be longer than 20 characters (+1 for sign).
+    return "CAST({} AS VARCHAR(21))".format(compiled_arg)
+
+
 @teradata_cast.register(str, dt.Time, dt.String)
 def teradata_cast_time_to_string(compiled_arg, from_, to):
     # Time always has a time zone associated with it in Teradata


### PR DESCRIPTION
## Description of changes
When casting integers to varchar in Teradata row validations we always used `CAST(... AS VARCHAR(255))`. This was causing unnecessary exceptions when validating a lot of integral columns:
```
[Error 3798] A column or character expression is larger than the max size.
```
This PR modifies those casts to have a more appropriate length.

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1476

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


