### PR TITLE
test: Cater for Spanner config via env vars in integration test module

### DIFF
--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -34,6 +34,8 @@ from tests.system.data_sources.test_bigquery import BQ_CONN
 
 
 PROJECT_ID = os.environ["PROJECT_ID"]
+SPANNER_INSTANCE = os.getenv("SPANNER_INSTANCE", "span1")
+SPANNER_DATABASE = os.getenv("SPANNER_DATABASE", "pso_data_validator")
 SPANNER_CONN_NAME = "spanner-integration-test"
 CLI_FIND_TABLES_ARGS = [
     "find-tables",
@@ -46,8 +48,8 @@ CLI_FIND_TABLES_ARGS = [
 SPANNER_CONN = {
     "source_type": "Spanner",
     "project_id": PROJECT_ID,
-    "instance_id": "span1",
-    "database_id": "pso_data_validator",
+    "instance_id": SPANNER_INSTANCE,
+    "database_id": SPANNER_DATABASE,
 }
 
 


### PR DESCRIPTION
## Description of changes
Cater for Spanner config via env vars in integration test module

## Issues to be closed

Closes #1483

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


