### PR TITLE
fix: Cater for generate-table-partitions num partitions being 0 or 1

### DIFF
--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -30,6 +30,11 @@ if TYPE_CHECKING:
     from argparse import Namespace
 
 
+NO_FILTERS_WARNING_TOKEN = (
+    "is too low to generate partitions, partition filters are not included."
+)
+
+
 class PartitionBuilder:
     def __init__(self, config_managers: List[ConfigManager], args: "Namespace") -> None:
         self.config_managers = config_managers
@@ -76,6 +81,20 @@ class PartitionBuilder:
             yaml_validations.append(config_manager.get_yaml_validation_block())
             config_manager.filters.pop()
 
+        yaml_config = {
+            consts.YAML_SOURCE: self.args.source_conn,
+            consts.YAML_TARGET: self.args.target_conn,
+            consts.YAML_RESULT_HANDLER: config_manager.result_handler_config,
+            consts.YAML_VALIDATIONS: yaml_validations,
+        }
+        return yaml_config
+
+    def _get_yaml_file_when_no_filters(
+        self,
+        config_manager: ConfigManager,
+    ) -> Dict:
+        """Equivalent of _add_filters_get_yaml_file() but for when we have no partition filters."""
+        yaml_validations = [config_manager.get_yaml_validation_block()]
         yaml_config = {
             consts.YAML_SOURCE: self.args.source_conn,
             consts.YAML_TARGET: self.args.target_conn,
@@ -167,18 +186,34 @@ class PartitionBuilder:
             if isinstance(target_count, pandas.DataFrame):
                 target_count = target_count.values[0][0]
 
-            if abs(source_count - target_count) > source_count * 0.1:
-                logging.warning(
-                    "Source and Target table row counts vary by more than 10%,"
-                    "partitioning may result in partitions with very different sizes"
-                )
-
             # Decide on number of partitions after checking number requested is not > number of rows in source
             number_of_part = (
                 self.args.partition_num
                 if self.args.partition_num < source_count
                 else source_count
             )
+
+            if number_of_part <= 1:
+                # 0 or 1 partitions does not make sense for generating partition configs.
+                # In these cases we can flag it and omit partition filters.
+                msg_action = (
+                    "Derived"
+                    if number_of_part != self.args.partition_num
+                    else "Requested"
+                )
+                logging.warning(
+                    f"{msg_action} partition number {number_of_part} for "
+                    f"{config_manager.source_schema}.{config_manager.source_table} {NO_FILTERS_WARNING_TOKEN}"
+                )
+                # Appending source and target filters of None which will be ignored later when processing filters.
+                master_filter_list.append(None)
+                continue
+
+            if abs(source_count - target_count) > source_count * 0.1:
+                logging.warning(
+                    "Source and Target table row counts vary by more than 10%,"
+                    "partitioning may result in partitions with very different sizes"
+                )
 
             # First we number each row in the source table. Using row_number instead of ntile since it is
             # available on all platforms (Teradata does not support NTILE). For our purposes, it is likely
@@ -391,23 +426,31 @@ class PartitionBuilder:
                 "yaml_files": [],
             }
 
-            # Create a list of lists chunked by partitions per file
-            # Both source and target table are divided into the same number of partitions, so we are
-            # guaranteed filter_list[0] (source) and filter_list[1] (target) are of the same length
-            source_filters_list = list_to_sublists(
-                filter_list[0], self.args.parts_per_file
-            )
-            target_filters_list = list_to_sublists(
-                filter_list[1], self.args.parts_per_file
-            )
-            for i in range(len(source_filters_list)):
-                # Build and append partition YAML
-                yaml_config = self._add_filters_get_yaml_file(
-                    config_manager, source_filters_list[i], target_filters_list[i]
+            if filter_list:
+                # Create a list of lists chunked by partitions per file
+                # Both source and target table are divided into the same number of partitions, so we are
+                # guaranteed filter_list[0] (source) and filter_list[1] (target) are of the same length
+                source_filters_list = list_to_sublists(
+                    filter_list[0], self.args.parts_per_file
                 )
+                target_filters_list = list_to_sublists(
+                    filter_list[1], self.args.parts_per_file
+                )
+                for i in range(len(source_filters_list)):
+                    # Build and append partition YAML
+                    yaml_config = self._add_filters_get_yaml_file(
+                        config_manager, source_filters_list[i], target_filters_list[i]
+                    )
+                    yaml_configs_list[ind]["yaml_files"].append(
+                        {"target_file_name": f"{i:04}.yaml", "yaml_config": yaml_config}
+                    )
+            else:
+                # There are no partition filters.
+                yaml_config = self._get_yaml_file_when_no_filters(config_manager)
                 yaml_configs_list[ind]["yaml_files"].append(
-                    {"target_file_name": f"{i:04}.yaml", "yaml_config": yaml_config}
+                    {"target_file_name": f"{0:04}.yaml", "yaml_config": yaml_config}
                 )
+
         return yaml_configs_list
 
     def _store_partitions(self, yaml_configs_list: List[Dict]) -> None:

--- a/tests/resources/bigquery_test_tables.sql
+++ b/tests/resources/bigquery_test_tables.sql
@@ -8,6 +8,23 @@ SELECT
     CAST(2 AS STRING) text_type,
     CAST('2021-01-01 00:00:00' AS TIMESTAMP) timestamp_type
 
+CREATE OR REPLACE TABLE `pso_data_validator`.`test_generate_partitions`
+( course_id STRING
+, quarter_id INT64
+, student_id INT64
+, grade FLOAT64
+, registration_timestamp TIMESTAMP
+, registration_date DATE );
+INSERT INTO `pso_data_validator`.`test_generate_partitions`
+(course_id,quarter_id,student_id,grade)
+VALUES ('ALG001',1,5678,3.5), ('TRI001',1,5678,3.5), ('GEO001',1,5678,3.5), ('TRI001',1,9012,2.3),
+('ALG001',1,9012,2.3), ('GEO001',1,9012,2.3), ('ALG001',1,1234,2.1), ('TRI001',1,1234,2.1),
+('GEO001',1,1234,2.1), ('TRI001',2,1234,3.5), ('GEO001',2,9012,3.5), ('GEO001',2,1234,3.5),
+('ALG001',2,9012,3.5), ('ALG001',2,1234,3.5), ('TRI001',2,9012,3.5), ('TRI001',2,5678,2.6),
+('ALG001',2,5678,2.6), ('GEO001',2,5678,2.6), ('GEO001',3,5678,3.5), ('ALG001',3,5678,3.5),
+('TRI001',3,5678,3.5), ('ALG001',3,9012,2.8), ('TRI001',3,9012,2.8), ('GEO001',3,9012,2.8),
+('TRI001',3,1234,2.7), ('ALG001',3,1234,2.7), ('GEO001',3,1234,2.7);
+
 
 -- Core data types test table, to be kept in sync with same table in other SQL engines
 CREATE OR REPLACE TABLE `pso_data_validator`.`dvt_core_types`

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -440,11 +440,11 @@ def id_column_row_validation_test(
 
 def partition_table_test(
     expected_filter: str,
-    pk="course_id,quarter_id,student_id",
-    tables="pso_data_validator.test_generate_partitions",
-    filters="quarter_id != 1111",
-    partition_num=9,
-    parts_per_file=5,
+    pk: str = "course_id,quarter_id,student_id",
+    tables: str = "pso_data_validator.test_generate_partitions",
+    filters: str = "quarter_id != 1111",
+    partition_num: int = 9,
+    parts_per_file: int = 5,
 ):
     """Test generate table partitions for a database. Usually only the partition_filter is different
     because of the differences in SQL between the databases. Some databases have different table names,
@@ -473,9 +473,13 @@ def partition_table_test(
     partition_filters = partition_builder._get_partition_key_filters()
 
     assert len(partition_filters) == 1  # only one pair of tables
-    # Number of partitions is as requested - assume table rows > partitions requested
-    assert len(partition_filters[0][0]) == partition_builder.args.partition_num
-    assert partition_filters[0] == expected_filter
+    if expected_filter:
+        # Number of partitions is as requested - assume table rows > partitions requested
+        assert len(partition_filters[0][0]) == partition_builder.args.partition_num
+        assert partition_filters[0] == expected_filter
+
+    # Check that the filters can be combined with config managers without throwing an exception.
+    _ = partition_builder._add_partition_filters(partition_filters)
 
 
 def partition_query_test(

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -29,6 +29,7 @@ from data_validation import (
     find_tables,
     gcs_helper,
 )
+from data_validation.partition_builder import NO_FILTERS_WARNING_TOKEN
 from data_validation.query_builder import random_row_builder
 from data_validation.query_builder.query_builder import QueryBuilder
 from data_validation.result_handlers.bigquery import BQRH_WRITE_MESSAGE
@@ -1166,6 +1167,17 @@ def test_generate_partitions(mock_conn, tmp_path: pathlib.Path):
     """Test generate partitions on BigQuery, first on table, then on custom query"""
     partition_table_test(EXPECTED_PARTITION_FILTER)
     partition_query_test(EXPECTED_PARTITION_FILTER, tmp_path)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
+def test_generate_partitions_num_1(mock_conn, tmp_path: pathlib.Path, caplog):
+    """Test generate partitions with -pn=1."""
+    caplog.set_level(logging.WARNING)
+    partition_table_test(None, partition_num=1)
+    assert any(_ for _ in caplog.records if NO_FILTERS_WARNING_TOKEN in _.msg)
 
 
 @mock.patch(


### PR DESCRIPTION
## Description of changes
If a table is empty or contains only a single row then generate-table-partitions will tune num_partitions down to the row count. If the resulting value became 0 or 1 then we would throw an unhandled exception.

I decided to allow the process to continue when this happens and not throw an exception. But we may decide it is better and clearer to simply throw an exception if the table is empty or contains only a single row. I'm assigning this to Sundar as he knows this code well.

## Issues to be closed

Closes #1489
Closes #1306

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [ ] I have manually executed end-to-end testing (E2E) with the affected databases/engines


