### PR TITLE
fix: Ensure --partition-num option is > 1

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -298,7 +298,7 @@ def _configure_partition_parser(subparsers):
         "-pn",
         required=True,
         help="Number of partitions into which the table should be split",
-        type=_check_positive,
+        type=_check_gt_one,
     )
     # User can provide tables or custom queries, but not both
     # However, Argparse does not support adding an argument_group to an argument_group or adding a
@@ -1064,11 +1064,20 @@ def _add_common_arguments(
     )
 
 
-def _check_positive(value: int) -> int:
+def _check_positive(value: int, lower_bound: int = 1) -> int:
     ivalue = int(value)
-    if ivalue <= 0:
-        raise argparse.ArgumentTypeError("%s is an invalid positive int value" % value)
+    if ivalue < lower_bound:
+        if lower_bound == 1:
+            raise argparse.ArgumentTypeError(
+                f"{value} is an invalid positive int value"
+            )
+        else:
+            raise argparse.ArgumentTypeError(f"{value} must be >= {lower_bound}")
     return ivalue
+
+
+def _check_gt_one(value: int) -> int:
+    return _check_positive(value, lower_bound=2)
 
 
 def check_no_yaml_files(partition_num: int, parts_per_file: int):

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1072,7 +1072,7 @@ def _check_positive(value: int, lower_bound: int = 1) -> int:
                 f"{value} is an invalid positive int value"
             )
         else:
-            raise argparse.ArgumentTypeError(f"{value} must be >= {lower_bound}")
+            raise argparse.ArgumentTypeError(f"Value must be >= {lower_bound}: {value}")
     return ivalue
 
 

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -988,3 +988,42 @@ def test_arg_parser_generate_table_partitions_help(capsys):
         _ = parser.parse_args(["generate-table-partitions", "--help"])
     captured = capsys.readouterr()
     assert "--partition-num" in captured.out
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        (1),
+        (100),
+        (99999),
+    ],
+)
+def test_check_positive_pass(test_input: int):
+    """Test _check_positive."""
+    _ = cli_tools._check_positive(test_input)
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        (-1),
+        (0),
+        (-99999),
+    ],
+)
+def test_check_positive_fail(test_input: int):
+    """Test _check_positive."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        _ = cli_tools._check_positive(test_input)
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        (0),
+    ],
+)
+def test_check_gt_one_fail(test_input: int):
+    """Test _check_positive."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        _ = cli_tools._check_gt_one(test_input)


### PR DESCRIPTION
## Description of changes
Simple option validation tweak for `--partition-num` option.

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1489

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


