### PR TITLE
chore: Replace literals with constants and rename the literals to less risky values

### DIFF
--- a/data_validation/combiner.py
+++ b/data_validation/combiner.py
@@ -406,18 +406,18 @@ def _pivot_result(
                             consts.AGGREGATION_TYPE
                         ),
                         ibis.literal(validation.get_table_name(result_type)).name(
-                            "table_name"
+                            consts.COMBINER_TABLE_NAME
                         ),
                         # Cast to string to ensure types match, even when column
                         # name is NULL (such as for count aggregations).
                         ibis.literal(validation.get_column_name(result_type))
                         .cast("string")
-                        .name("column_name"),
+                        .name(consts.COMBINER_COLUMN_NAME),
                         primary_keys,
                         ibis.literal(validation.num_random_rows).name(
                             consts.NUM_RANDOM_ROWS
                         ),
-                        result[field].cast("string").name("agg_value"),
+                        result[field].cast("string").name(consts.COMBINER_AGG_VALUE),
                     )
                     + join_on_fields
                 )
@@ -469,11 +469,11 @@ def _join_pivots(
         + [
             source[consts.VALIDATION_TYPE],
             source[consts.AGGREGATION_TYPE],
-            source[consts.CONFIG_TABLE_NAME],
-            source["column_name"],
+            source[consts.COMBINER_TABLE_NAME],
+            source[consts.COMBINER_COLUMN_NAME],
             source[consts.CONFIG_PRIMARY_KEYS],
             source[consts.NUM_RANDOM_ROWS],
-            source["agg_value"],
+            source[consts.COMBINER_AGG_VALUE],
             differences[consts.VALIDATION_DIFFERENCE],
             differences[consts.VALIDATION_PCT_DIFFERENCE],
             differences[consts.VALIDATION_PCT_THRESHOLD],
@@ -488,12 +488,12 @@ def _join_pivots(
         source_difference[consts.AGGREGATION_TYPE]
         .fillna(target[consts.AGGREGATION_TYPE])
         .name(consts.AGGREGATION_TYPE),
-        source_difference["table_name"].name(consts.SOURCE_TABLE_NAME),
-        source_difference["column_name"].name(consts.SOURCE_COLUMN_NAME),
-        source_difference["agg_value"].name(consts.SOURCE_AGG_VALUE),
-        target["table_name"].name(consts.TARGET_TABLE_NAME),
-        target["column_name"].name(consts.TARGET_COLUMN_NAME),
-        target["agg_value"].name(consts.TARGET_AGG_VALUE),
+        source_difference[consts.COMBINER_TABLE_NAME].name(consts.SOURCE_TABLE_NAME),
+        source_difference[consts.COMBINER_COLUMN_NAME].name(consts.SOURCE_COLUMN_NAME),
+        source_difference[consts.COMBINER_AGG_VALUE].name(consts.SOURCE_AGG_VALUE),
+        target[consts.COMBINER_TABLE_NAME].name(consts.TARGET_TABLE_NAME),
+        target[consts.COMBINER_COLUMN_NAME].name(consts.TARGET_COLUMN_NAME),
+        target[consts.COMBINER_AGG_VALUE].name(consts.TARGET_AGG_VALUE),
         group_by_columns,
         source_difference[consts.CONFIG_PRIMARY_KEYS],
         source_difference[consts.NUM_RANDOM_ROWS],

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -181,6 +181,11 @@ FAILED_SOURCE_NOT_IN_TARGET = "failed_rows_present_in_source_not_in_target"
 FAILED_TARGET_NOT_IN_SOURCE = "failed_rows_present_in_target_not_in_source"
 FAILED_PRESENT_IN_BOTH_TABLES = "failed_rows_present_in_both_source_and_target"
 
+# Combiner only constants
+COMBINER_TABLE_NAME = "dvt_table_name"
+COMBINER_COLUMN_NAME = "dvt_column_name"
+COMBINER_AGG_VALUE = "dvt_agg_value"
+
 # SQL Template Formatting
 # TODO: should this be managed in query_builder if that is the only place its used?
 COUNT_STAR = "{count_star}"


### PR DESCRIPTION
## Description of changes
Some temporary Dataframe column names are used when generating the final report. The names are:

- "table_name"
- "column_name"
- "agg_value"

This PR renames them to have a "dvt_" prefix and changes them to constants too.

## Issues to be closed

Closes #1508

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


