### PR TITLE
fix: Fix `find-tables` execution for SQL Server to properly filter by schema

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -261,7 +261,7 @@ def list_tables(client, schema_name, tables_only=True):
         if tables_only and client.name != "pandas"
         else client.list_tables
     )
-    if client.name in ["db2", "mssql", "redshift", "snowflake", "pandas"]:
+    if client.name in ["db2", "redshift", "snowflake", "pandas"]:
         return fn()
     return fn(database=schema_name)
 

--- a/data_validation/schema_validation.py
+++ b/data_validation/schema_validation.py
@@ -237,8 +237,10 @@ def split_allow_list_str(allow_list_str: str) -> list:
     # I've not moved this patter to a compiled constant because it should only
     # happen once per command and I felt splitting the pattern into variables
     # aided readability.
-    nullable_pattern = r"!?"
-    precision_scale_pattern = r"(?:\((?:[0-9 ,\-]+|'UTC')\))?"
+    nullable_pattern = r"!?"  # Matches an optional '!'
+    # Matches precision/scale like (N), (N,M), ('UTC'), or (N, 'UTC')
+    # Crucially, [0-9 ,-]+ allows for digits, spaces, commas, and hyphens (for ranges like "1-18").
+    precision_scale_pattern = r"(?:\((?:[0-9 ,-]+(?:,[ ]*'UTC')?|'UTC')\))?"
     data_type_pattern = nullable_pattern + r"[a-z0-9 ]+" + precision_scale_pattern
     csv_split_pattern = data_type_pattern + r":" + data_type_pattern
     data_type_pairs = [

--- a/tests/resources/sqlserver_test_tables.sql
+++ b/tests/resources/sqlserver_test_tables.sql
@@ -59,14 +59,14 @@ CREATE VIEW pso_data_validator.dvt_core_types_vw AS
 SELECT * FROM pso_data_validator.dvt_core_types;
 
 DROP TABLE IF EXISTS pso_data_validator.test_generate_partitions_v2;
-CREATE TABLE pso_data_validator.test_generate_partitions_v2 (
-        course_id VARCHAR(24),
-        quarter_id INT,
-        recd_timestamp datetime2,
-        registration_date DATE,
-        approved BIT,
-        grade DECIMAL(5,2)
-        ) COMMENT = 'Table for testing generate table partitions, consists of 32 rows with a composite primary key Quoted Strings are handled correctly';
+CREATE TABLE pso_data_validator.test_generate_partitions_v2
+(   course_id           VARCHAR(24)
+,   quarter_id          INT
+,   recd_timestamp      datetime2
+,   registration_date   DATE
+,   approved            BIT
+,   grade               DECIMAL(5,2)
+);
 
 INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('ALG001', 1234, '2023-08-26 16:00:00', '1969-07-20', 1, 3.5);
 INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('ALG001', 1234, '2023-08-26 16:00:00', '1969-07-20', 0, 2.8);
@@ -84,22 +84,22 @@ INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('ALG004', 123
 INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('ALG004', 1234, '2023-08-27 15:00:00', '1969-07-20', 0, 2.8);
 INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('ALG004', 5678, '2023-08-27 15:00:00', '2023-08-23', 1, 2.1);
 INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('ALG004', 5678, '2023-08-27 15:00:00', '2023-08-23', 0, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. John''s", 1234, '2023-08-26 16:00:00', '1969-07-20', 1, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. John''s", 1234, '2023-08-26 16:00:00', '1969-07-20', 0, 2.8);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. John''s", 5678, '2023-08-26 16:00:00', '2023-08-23', 1, 2.1);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. John''s", 5678, '2023-08-26 16:00:00', '2023-08-23', 0, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Jude''s", 1234, '2023-08-27 15:00:00', '1969-07-20', 1, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Jude''s", 1234, '2023-08-27 15:00:00', '1969-07-20', 0, 2.8);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Jude''s", 5678, '2023-08-27 15:00:00', '2023-08-23', 1, 2.1);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Jude''s", 5678, '2023-08-27 15:00:00', '2023-08-23', 0, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Edward''s", 1234, '2023-08-26 16:00:00', '1969-07-20', 1, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Edward''s", 1234, '2023-08-26 16:00:00', '1969-07-20', 0, 2.8);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Edward''s", 5678, '2023-08-26 16:00:00', '2023-08-23', 1, 2.1);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Edward''s", 5678, '2023-08-26 16:00:00', '2023-08-23', 0, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Paul''s", 1234, '2023-08-27 15:00:00', '1969-07-20', 1, 3.5);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Paul''s", 1234, '2023-08-27 15:00:00', '1969-07-20', 0, 2.8);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Paul''s", 5678, '2023-08-27 15:00:00', '2023-08-23', 1, 2.1);
-INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ("St. Paul''s", 5678, '2023-08-27 15:00:00', '2023-08-23', 0, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. John''s', 1234, '2023-08-26 16:00:00', '1969-07-20', 1, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. John''s', 1234, '2023-08-26 16:00:00', '1969-07-20', 0, 2.8);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. John''s', 5678, '2023-08-26 16:00:00', '2023-08-23', 1, 2.1);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. John''s', 5678, '2023-08-26 16:00:00', '2023-08-23', 0, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Jude''s', 1234, '2023-08-27 15:00:00', '1969-07-20', 1, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Jude''s', 1234, '2023-08-27 15:00:00', '1969-07-20', 0, 2.8);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Jude''s', 5678, '2023-08-27 15:00:00', '2023-08-23', 1, 2.1);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Jude''s', 5678, '2023-08-27 15:00:00', '2023-08-23', 0, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Edward''s', 1234, '2023-08-26 16:00:00', '1969-07-20', 1, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Edward''s', 1234, '2023-08-26 16:00:00', '1969-07-20', 0, 2.8);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Edward''s', 5678, '2023-08-26 16:00:00', '2023-08-23', 1, 2.1);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Edward''s', 5678, '2023-08-26 16:00:00', '2023-08-23', 0, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Paul''s', 1234, '2023-08-27 15:00:00', '1969-07-20', 1, 3.5);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Paul''s', 1234, '2023-08-27 15:00:00', '1969-07-20', 0, 2.8);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Paul''s', 5678, '2023-08-27 15:00:00', '2023-08-23', 1, 2.1);
+INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Paul''s', 5678, '2023-08-27 15:00:00', '2023-08-23', 0, 3.5);
 
 DROP TABLE pso_data_validator.dvt_null_not_null;
 CREATE TABLE pso_data_validator.dvt_null_not_null

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -629,7 +629,6 @@ def test_custom_query_row_hash_validation_core_types_to_bigquery():
 )
 def test_find_tables():
     """SQL Server to BigQuery test of find-tables command."""
-    pytest.skip("Skipping test_find_tables until issue 1198 has been resolved.")
     find_tables_test()
 
 

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -376,8 +376,7 @@ def test_column_validation_tricky_dates_to_bigquery():
 )
 def test_column_validation_large_decimals_to_bigquery():
     """SQL Server to BigQuery dvt_large_decimals column validation."""
-    # TODO When issue-1079 is complete add col_dec_38_30 to --hash string below.
-    cols = "col_dec_18,col_dec_38,col_dec_38_9"
+    cols = "col_dec_18,col_dec_38,col_dec_38_9,col_dec_38_30"
     column_validation_test(
         tables="pso_data_validator.dvt_large_decimals",
         tc="bq-conn",
@@ -467,8 +466,7 @@ def test_row_validation_large_decimals_to_bigquery():
     row_validation_test(
         tables="pso_data_validator.dvt_large_decimals",
         tc="bq-conn",
-        # TODO When issue-1079 is complete add col_dec_38_30 to --hash string below.
-        hash="id,col_data,col_dec_18,col_dec_38,col_dec_38_9",
+        hash="id,col_data,col_dec_18,col_dec_38,col_dec_38_9,col_dec_38_30",
     )
 
 

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -293,7 +293,9 @@ def test_schema_validation_core_types_to_bigquery():
             # All SQL Server integers go to BigQuery INT64.
             "int8:int64,int16:int64,int32:int64,"
             # BigQuery does not have a float32 type.
-            "float32:float64"
+            "float32:float64,",
+            # SQL Server TIMESTAMP type has scale=7 on Ibis which does not happen in BigQuery.
+            "timestamp(7):timestamp,!timestamp(7):!timestamp,timestamp(7, 'UTC'):timestamp('UTC'),",
         ),
     )
 
@@ -312,6 +314,8 @@ def test_schema_validation_not_null_vs_nullable():
             "-sc=sql-conn",
             "-tc=bq-conn",
             "-tbls=pso_data_validator.dvt_null_not_null=pso_data_validator.dvt_null_not_null",
+            # SQL Server TIMESTAMP type has scale=7 on Ibis which does not happen in BigQuery.
+            "--allow-list=timestamp(7):timestamp,!timestamp(7):!timestamp,timestamp(7, 'UTC'):timestamp('UTC'),",
         ]
     )
     df = run_test_from_cli_args(args)

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 
 from typing import Literal
 
+import pandas
+import warnings
+
 import sqlalchemy as sa
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.mssql.compiler import MsSqlCompiler
@@ -30,6 +33,7 @@ class Backend(BaseAlchemyBackend):
     name = "mssql"
     compiler = MsSqlCompiler
     supports_create_or_replace = False
+    LOCK_SQL = "WITH (ROWLOCK)"
 
     _sqlglot_dialect = "tsql"
 
@@ -81,6 +85,7 @@ class Backend(BaseAlchemyBackend):
             with dbapi_connection.cursor() as cur:
                 cur.execute("SET DATEFIRST 1")
 
+        self.client = engine
         return super().do_connect(engine)
 
     def _metadata(self, query):
@@ -109,3 +114,74 @@ class Backend(BaseAlchemyBackend):
         with self.begin() as con:
             result = con.exec_driver_sql(list_pk_col_sql, parameters=(database, table))
             return [_[0] for _ in result.cursor.fetchall()]
+
+    LIST_DATABASE_SQL = """
+        SELECT schema_name FROM information_schema.schemata
+        WHERE schema_name LIKE '%{schema_like}%'
+    """
+
+    def list_databases(self, like=None):
+        schema_like = like or ""
+
+        list_database_sql = self.LIST_DATABASE_SQL.format(schema_like=schema_like)
+        databases_df = self._execute(list_database_sql, results=True)
+
+        return list(databases_df.schema_name.str.rstrip())
+
+    LIST_TABLE_SQL = """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema LIKE '%{schema_like}%'
+        AND table_name LIKE '%{table_like}%'
+        AND table_type LIKE '{type_like}'
+    """
+
+    def list_tables(self, like=None, schema=None, type_like: str = "%") -> list:
+        schema = schema or ""
+        table = like or ""
+
+        list_table_sql = self.LIST_TABLE_SQL.format(
+            schema_like=schema, table_like=table, type_like=type_like
+        )
+        tables_df = self._execute(list_table_sql, results=True)
+        return list(tables_df.table_name.str.rstrip())
+
+    def dvt_list_tables(self, like=None, database=None) -> list:
+        """Duplicate of list_tables() but only returning tables in the output."""
+        return self.list_tables(like=like, schema=database, type_like="BASE TABLE")
+
+    def _execute(self, sql, results=False, params=None):
+        import re
+
+        def add_rowlock_to_select(sql):
+            # Only add ROWLOCK to SELECTs from user tables, not system views
+            # This regex matches: FROM [schema.]table (with optional alias)
+            pattern = re.compile(
+                r"(FROM\s+(\[?\w+\]?\.)?\[?\w+\]?)(\s+AS\s+\w+)?", re.IGNORECASE
+            )
+            # Do not add ROWLOCK to information_schema or sys tables
+            if (
+                "information_schema" in sql.lower()
+                or "sys." in sql.lower()
+                or "sysobjects" in sql.lower()
+            ):
+                return sql
+
+            # Insert 'WITH (ROWLOCK)' after the table name
+            def replacer(match):
+                return f"{match.group(1)}{ self.LOCK_SQL}{match.group(3) or ''}"
+
+            return pattern.sub(replacer, sql, count=1)
+
+        if self.LOCK_SQL and sql.strip().upper().startswith("SELECT"):
+            sql = add_rowlock_to_select(sql)
+
+        with warnings.catch_warnings():
+            # Suppress pandas warning of SQLAlchemy connectable DB support
+            warnings.simplefilter("ignore")
+            df = pandas.read_sql(sql, self.client, params=params)
+
+        if results:
+            return df
+
+        return None

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -33,7 +33,6 @@ class Backend(BaseAlchemyBackend):
     name = "mssql"
     compiler = MsSqlCompiler
     supports_create_or_replace = False
-    LOCK_SQL = "WITH (ROWLOCK)"
 
     _sqlglot_dialect = "tsql"
 
@@ -115,73 +114,32 @@ class Backend(BaseAlchemyBackend):
             result = con.exec_driver_sql(list_pk_col_sql, parameters=(database, table))
             return [_[0] for _ in result.cursor.fetchall()]
 
-    LIST_DATABASE_SQL = """
-        SELECT schema_name FROM information_schema.schemata
-        WHERE schema_name LIKE '%{schema_like}%'
-    """
+    def list_databases(self, schema=None):
+        schema_like = f"%{schema or ''}%"
+        list_database_sql = """
+            SELECT schema_name FROM information_schema.schemata
+            WHERE schema_name LIKE ?
+        """
+        with self.begin() as con:
+            result = con.exec_driver_sql(list_database_sql, parameters=(schema_like,))
+            return [_[0] for _ in result.cursor.fetchall()]
 
-    def list_databases(self, like=None):
-        schema_like = like or ""
-
-        list_database_sql = self.LIST_DATABASE_SQL.format(schema_like=schema_like)
-        databases_df = self._execute(list_database_sql, results=True)
-
-        return list(databases_df.schema_name.str.rstrip())
-
-    LIST_TABLE_SQL = """
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema LIKE '%{schema_like}%'
-        AND table_name LIKE '%{table_like}%'
-        AND table_type LIKE '{type_like}'
-    """
-
-    def list_tables(self, like=None, schema=None, type_like: str = "%") -> list:
-        schema = schema or ""
-        table = like or ""
-
-        list_table_sql = self.LIST_TABLE_SQL.format(
-            schema_like=schema, table_like=table, type_like=type_like
-        )
-        tables_df = self._execute(list_table_sql, results=True)
-        return list(tables_df.table_name.str.rstrip())
+    def list_tables(self, table=None, schema=None, type_like: str = "%") -> list:
+        schema_like = f"%{schema or ''}%"
+        table_like = f"%{table or ''}%"
+        list_table_sql = """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema LIKE ?
+            AND table_name LIKE ?
+            AND table_type LIKE ?
+        """
+        with self.begin() as con:
+            result = con.exec_driver_sql(
+                list_table_sql, parameters=(schema_like, table_like, type_like)
+            )
+            return [_[0] for _ in result.cursor.fetchall()]
 
     def dvt_list_tables(self, like=None, database=None) -> list:
         """Duplicate of list_tables() but only returning tables in the output."""
-        return self.list_tables(like=like, schema=database, type_like="BASE TABLE")
-
-    def _execute(self, sql, results=False, params=None):
-        import re
-
-        def add_rowlock_to_select(sql):
-            # Only add ROWLOCK to SELECTs from user tables, not system views
-            # This regex matches: FROM [schema.]table (with optional alias)
-            pattern = re.compile(
-                r"(FROM\s+(\[?\w+\]?\.)?\[?\w+\]?)(\s+AS\s+\w+)?", re.IGNORECASE
-            )
-            # Do not add ROWLOCK to information_schema or sys tables
-            if (
-                "information_schema" in sql.lower()
-                or "sys." in sql.lower()
-                or "sysobjects" in sql.lower()
-            ):
-                return sql
-
-            # Insert 'WITH (ROWLOCK)' after the table name
-            def replacer(match):
-                return f"{match.group(1)}{ self.LOCK_SQL}{match.group(3) or ''}"
-
-            return pattern.sub(replacer, sql, count=1)
-
-        if self.LOCK_SQL and sql.strip().upper().startswith("SELECT"):
-            sql = add_rowlock_to_select(sql)
-
-        with warnings.catch_warnings():
-            # Suppress pandas warning of SQLAlchemy connectable DB support
-            warnings.simplefilter("ignore")
-            df = pandas.read_sql(sql, self.client, params=params)
-
-        if results:
-            return df
-
-        return None
+        return self.list_tables(table=like, schema=database, type_like="BASE TABLE")

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -15,15 +15,11 @@ from __future__ import annotations
 
 from typing import Literal
 
-import pandas
-import warnings
-
 import sqlalchemy as sa
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.mssql.compiler import MsSqlCompiler
 from ibis.backends.mssql.datatypes import _type_from_result_set_info
 
-import third_party.ibis.ibis_mssql.datatypes
 import json
 
 


### PR DESCRIPTION
## Description of changes
_Write a description of the changes you have made in this PR. Extremely small changes such as fixing typos do not need a description._

- Fix DDL and DML for `test_generate_partitions_v2` table on SQL Server
- Changes on `tests/system/data_sources/test_sql_server.py`:
   - Unskip `test_find_tables`
   - Add `col_dec_38_30` to hash string in `test_column_validation_large_decimals_to_bigquery` and `test_row_validation_large_decimals_to_bigquery` as issue #1079 ended up being solved by PR #1499 
   - Add allow list types for `test_schema_validation_core_types_to_bigquery` and `test_schema_validation_not_null_vs_nullable`
- Add functions on `third_party/ibis/ibis_mssql/__init__.py` to fix `find_tables` execution 

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1198
Closes #1079 

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines