### PR TITLE
fix: Fix exception when using --hash on TEXT column for row validation on SQL Server table

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -101,7 +101,7 @@ class ConfigManager(object):
         The raw data type is the source/target engine type, for example it might
         be "NCLOB" or "char" when the Ibis type simply states "string".
         The data is cached in state when fetched for the first time.
-        The retuen value is keyed on the casefolded column name and the tuple is
+        The return value is keyed on the casefolded column name and the tuple is
         the remaining 6 elements of the DB API cursor description specification."""
         if self._source_raw_data_types is None:
             if hasattr(self.source_client, "raw_column_metadata"):
@@ -123,7 +123,7 @@ class ConfigManager(object):
         The raw data type is the source/target engine type, for example it might
         be "NCLOB" or "char" when the Ibis type simply states "string".
         The data is cached in state when fetched for the first time.
-        The retuen value is keyed on the casefolded column name and the tuple is
+        The return value is keyed on the casefolded column name and the tuple is
         the remaining 6 elements of the DB API cursor description specification."""
         if self._target_raw_data_types is None:
             if hasattr(self.target_client, "raw_column_metadata"):

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -418,10 +418,7 @@ def test_column_validation_large_decimals_to_bigquery_mismatch():
 )
 def test_row_validation_core_types():
     """SQL Server to SQL Server dvt_core_types row validation"""
-    # TODO When issue-834 is complete add col_string to --hash string below.
-    cols = ",".join(
-        [_ for _ in DVT_CORE_TYPES_COLUMNS if _ not in ("id", "col_string")]
-    )
+    cols = ",".join([_ for _ in DVT_CORE_TYPES_COLUMNS if _ not in ("id")])
     row_validation_test(
         tc="mock-conn",
         hash=cols,
@@ -448,10 +445,7 @@ def test_row_validation_core_types_auto_pks():
 )
 def test_row_validation_core_types_to_bigquery():
     """SQL Server to BigQuery dvt_core_types row validation"""
-    # TODO When issue-834 is complete add col_string to --hash string below.
-    cols = ",".join(
-        [_ for _ in DVT_CORE_TYPES_COLUMNS if _ not in ("id", "col_string")]
-    )
+    cols = ",".join([_ for _ in DVT_CORE_TYPES_COLUMNS if _ not in ("id")])
     row_validation_test(
         tc="bq-conn",
         hash=cols,

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -353,42 +353,6 @@ def sa_cast_hive(t, op):
         return cast_expr
 
 
-def sa_cast_mssql(t, op):
-    arg = op.arg
-    typ = op.to
-    arg_dtype = arg.output_dtype
-
-    sa_arg = t.translate(arg)
-    # Specialize going from a binary float type to a string.
-    if (arg_dtype.is_float32() or arg_dtype.is_float64()) and typ.is_string():
-        # This prevents output in scientific notation, at least for my tests it did.
-        return sa.func.format(sa_arg, "G")
-    elif arg_dtype.is_binary() and typ.is_string():
-        # Binary to string cast is a "to hex" conversion for DVT.
-        return sa.func.lower(
-            sa.func.convert(sa.text("VARCHAR(MAX)"), sa_arg, sa.literal(2))
-        )
-    elif arg_dtype.is_string() and typ.is_binary():
-        # Binary from string cast is a "from hex" conversion for DVT.
-        return sa.func.convert(sa.text("VARBINARY(MAX)"), sa_arg, sa.literal(2))
-    # Specialize going from DECIMAL(p,s>0) to string
-    elif (
-        arg_dtype.is_decimal()
-        and arg_dtype.scale
-        and arg_dtype.scale > 0
-        and typ.is_string()
-    ):
-        scale = arg_dtype.scale
-        # Considering any number of fractional digits
-        format_string = f'0.{("#" * scale)}'
-        formatted_value = sa.func.format(sa_arg, format_string)
-        # Replace trailing '.0' with ''
-        return sa.func.replace(formatted_value, ".0", "")
-
-    # Follow the original Ibis code path.
-    return sa_fixed_cast(t, op)
-
-
 def sa_cast_mysql(t, op):
     # Add cast from numeric to string
     arg = op.arg
@@ -458,22 +422,6 @@ def sa_cast_snowflake(t, op):
 
     # Follow the original Ibis code path.
     return sa_fixed_cast(t, op)
-
-
-def _sa_string_join(t, op):
-    if (
-        len(op.arg) == 1
-    ):  # SQL Server CONCAT errs when there is one column being hashed (issue #1202), renaming using type_coerce rather than CONCAT
-        return sa.type_coerce(
-            t.translate(op.arg[0]),
-            sa.types.String,
-        )
-    else:
-        return sa.func.concat(*map(t.translate, op.arg))
-
-
-def sa_format_new_id(t, op):
-    return sa.func.NEWID()
 
 
 def sa_format_random(t, op):
@@ -630,15 +578,14 @@ PostgreSQLExprTranslator._registry[
 MsSqlExprTranslator._registry[ops.HashBytes] = mssql_registry.sa_format_hashbytes
 MsSqlExprTranslator._registry[RawSQL] = sa_format_raw_sql
 MsSqlExprTranslator._registry[ops.IfNull] = sa_fixed_arity(sa.func.isnull, 2)
-MsSqlExprTranslator._registry[ops.StringJoin] = _sa_string_join
-MsSqlExprTranslator._registry[ops.RandomScalar] = sa_format_new_id
+MsSqlExprTranslator._registry[ops.StringJoin] = mssql_registry.sa_string_join
+MsSqlExprTranslator._registry[ops.RandomScalar] = mssql_registry.sa_format_new_id
 MsSqlExprTranslator._registry[ops.Strftime] = mssql_registry.strftime
-MsSqlExprTranslator._registry[ops.Cast] = sa_cast_mssql
+MsSqlExprTranslator._registry[ops.Cast] = mssql_registry.sa_cast_mssql
 MsSqlExprTranslator._registry[BinaryLength] = mssql_registry.sa_format_binary_length
 MsSqlExprTranslator._registry[ops.TableColumn] = mssql_registry.sa_table_column
 MsSqlExprTranslator._registry[ops.ExtractEpochSeconds] = mssql_registry.sa_epoch_seconds
-# TODO Uncomment the line below when working on issue-1419.
-# MsSqlExprTranslator._registry[ops.RStrip] = _sa_whitespace_rstrip
+MsSqlExprTranslator._registry[ops.RStrip] = mssql_registry.sa_whitespace_rstrip
 MsSqlExprTranslator._registry[PaddedCharLength] = MsSqlExprTranslator._registry[
     ops.StringLength
 ]

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -116,7 +116,7 @@ class Backend(BaseAlchemyBackend):
         """Define this method to allow DVT to test if backend specific transformations may be needed for comparison.
         Partner method to _metadata that retains raw data type information instead of converting to Ibis types.
         This works in the same way as _metadata by running a query over the DVT source, either schema.table or a
-        custom query, and fetching the first row. From the cursor we can detect data types of the row's columns.
+        custom query, and fetching the first row. From it we can detect data types of the row's columns.
 
         For SQL Server, we use the stored procedure 'sp_describe_first_result_set' to get column metadata.
         https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-describe-first-result-set-transact-sql
@@ -190,4 +190,12 @@ class Backend(BaseAlchemyBackend):
 
     def dvt_list_tables(self, like=None, database=None) -> list:
         """Duplicate of list_tables() but only returning tables in the output."""
+
+        # TODO: Test only block, remove later
+        print("Raw column metadata for dvt_binary table:")
+        for column_info in self.raw_column_metadata(
+            database="pso_data_validator", table="dvt_binary"
+        ):
+            print(column_info)
+
         return self.list_tables(table=like, schema=database, type_like="BASE TABLE")

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import Literal, List, Tuple
+from typing import Literal, Tuple, Iterable
 
 import sqlalchemy as sa
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
@@ -110,22 +110,52 @@ class Backend(BaseAlchemyBackend):
             result = con.exec_driver_sql(list_pk_col_sql, parameters=(database, table))
             return [_[0] for _ in result.cursor.fetchall()]
 
-    def raw_column_metadata_not_implemented(
+    def raw_column_metadata(
         self, database: str = None, table: str = None, query: str = None
-    ) -> List[Tuple]:
+    ) -> Iterable[Tuple]:
         """Define this method to allow DVT to test if backend specific transformations may be needed for comparison.
-        Partner method to _metadata that retains raw data type information instead of converting
-        to Ibis types.  This works in the same way as _metadata by running a query over the DVT
-        source, either schema.table or a custom query, and fetching the metadata using sp_describe_first_result_set.
+        Partner method to _metadata that retains raw data type information instead of converting to Ibis types.
+        This works in the same way as _metadata by running a query over the DVT source, either schema.table or a
+        custom query, and fetching the first row. From the cursor we can detect data types of the row's columns.
 
-        THIS METHOD IS NOT IMPLEMENTED YET.
-        There is a related pyodbc issue https://github.com/mkleehammer/pyodbc/issues/167
+        For SQL Server, we use the stored procedure 'sp_describe_first_result_set' to get column metadata.
+        https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-describe-first-result-set-transact-sql
 
         Returns:
-            list: A list of tuples containing the standard 7 DB API fields:
+            Iterable[Tuple]: An iterable of tuples, each containing the standard 7 DB API fields:
                   https://peps.python.org/pep-0249/#description
         """
-        return ()
+
+        assert (
+            database and table
+        ) or query, "Must provide either database/table or query"
+
+        if database and table:
+            # Properly quote and format the table name with schema
+            quoted_table = f"[{database}].[{table}]"
+            sql = f"SELECT TOP 1 * FROM {quoted_table}"
+        elif query:
+            sql = query
+
+        # Use the stored procedure to get metadata
+        metadata_query = sa.text(
+            "EXEC sp_describe_first_result_set @tsql = :query"
+        ).bindparams(query=sql)
+
+        with self.begin() as con:
+            result = con.execute(metadata_query)
+            for column in result.mappings():
+                # Extract relevant metadata from the result set and construct the metadata tuple (DB API format)
+                # Note: Metadata may vary based on the SQL Server version and the specific query used.
+                yield (
+                    column["name"],
+                    column["system_type_name"],  # type_code
+                    None,  # display_size
+                    None,  # internal_size
+                    column["precision"],
+                    column["scale"],
+                    column["is_nullable"],
+                )
 
     def is_char_type_padded(self, char_type: Tuple) -> bool:
         """Define this method if the backend supports character/string types that are padded and returns

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -190,12 +190,4 @@ class Backend(BaseAlchemyBackend):
 
     def dvt_list_tables(self, like=None, database=None) -> list:
         """Duplicate of list_tables() but only returning tables in the output."""
-
-        # TODO: Test only block, remove later
-        print("Raw column metadata for dvt_binary table:")
-        for column_info in self.raw_column_metadata(
-            database="pso_data_validator", table="dvt_binary"
-        ):
-            print(column_info)
-
         return self.list_tables(table=like, schema=database, type_like="BASE TABLE")

--- a/third_party/ibis/ibis_mssql/registry.py
+++ b/third_party/ibis/ibis_mssql/registry.py
@@ -18,6 +18,7 @@ from ibis.backends.base.sql.alchemy import (
     get_sqla_table,
 )
 from ibis.backends.base.sql.alchemy.registry import get_col
+from ibis.backends.base.sql.alchemy.registry import _cast as sa_fixed_cast
 
 
 def sa_table_column(t, op):
@@ -96,3 +97,60 @@ def sa_format_hashbytes(translator, op):
         sa.sql.literal_column("CHAR(64)"), hash_func, sa.sql.literal_column("2")
     )
     return sa.func.lower(hash_to_string)
+
+
+def sa_cast_mssql(t, op):
+    arg = op.arg
+    typ = op.to
+    arg_dtype = arg.output_dtype
+
+    sa_arg = t.translate(arg)
+    # Specialize going from a binary float type to a string.
+    if (arg_dtype.is_float32() or arg_dtype.is_float64()) and typ.is_string():
+        # This prevents output in scientific notation, at least for my tests it did.
+        return sa.func.format(sa_arg, "G")
+    elif arg_dtype.is_binary() and typ.is_string():
+        # Binary to string cast is a "to hex" conversion for DVT.
+        return sa.func.lower(
+            sa.func.convert(sa.text("VARCHAR(MAX)"), sa_arg, sa.literal(2))
+        )
+    elif arg_dtype.is_string() and typ.is_binary():
+        # Binary from string cast is a "from hex" conversion for DVT.
+        return sa.func.convert(sa.text("VARBINARY(MAX)"), sa_arg, sa.literal(2))
+    # Specialize going from DECIMAL(p,s>0) to string
+    elif (
+        arg_dtype.is_decimal()
+        and arg_dtype.scale
+        and arg_dtype.scale > 0
+        and typ.is_string()
+    ):
+        scale = arg_dtype.scale
+        # Considering any number of fractional digits
+        format_string = f'0.{("#" * scale)}'
+        formatted_value = sa.func.format(sa_arg, format_string)
+        # Replace trailing '.0' with ''
+        return sa.func.replace(formatted_value, ".0", "")
+
+    # Follow the original Ibis code path.
+    return sa_fixed_cast(t, op)
+
+
+def sa_format_new_id(t, op):
+    return sa.func.NEWID()
+
+
+def sa_string_join(t, op):
+    if (
+        len(op.arg) == 1
+    ):  # SQL Server CONCAT errs when there is one column being hashed (issue-1202), renaming using type_coerce rather than CONCAT
+        return sa.type_coerce(
+            t.translate(op.arg[0]),
+            sa.types.String,
+        )
+    else:
+        return sa.func.concat(*map(t.translate, op.arg))
+
+
+def sa_whitespace_rstrip(t, op):
+    sa_arg = t.translate(op.arg)
+    return sa.func.rtrim(sa.cast(sa_arg, sa.VARCHAR(length=None)))


### PR DESCRIPTION
## Description of changes
_Write a description of the changes you have made in this PR. Extremely small changes such as fixing typos do not need a description._

- Fixed typos on `data_validation/config_manager.py`
- Added `col_string` to hash string in `test_row_validation_core_types` and `test_row_validation_core_types_to_bigquery` for SQL Server
- Changes on `third_party/ibis/ibis_addon/operations.py`:
   -  Moved functions used only for SQL Server to its own file on `third_party/ibis/ibis_mssql/registry.py`
   - Updated functions used for SQL Server operations to reference its own registry
- Implemented `sa_whitespace_rstrip` function to perform the correct RStrip behavior for SQL Server which is having one single argument that should always be cast to VARCHAR beforehand
- Implemented the code needed for the function `raw_column_metadata` on `third_party/ibis/ibis_mssql/__init__.py`

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #834
Closes #1419

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines