### PR TITLE
fix: Convert base64 Spanner BYTES string to standard bytes string

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,6 +32,7 @@ DEFAULT_PYTHON_VERSION = "3.10"
 # Python versions used for testing.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 PYTHON_VERSIONS_ORACLE = ["3.8", "3.9", "3.10"]
+PYTHON_VERSIONS_DB2 = ["3.9", "3.10", "3.11"]
 
 BLACK_PATHS = (
     "data_validation",
@@ -298,7 +299,7 @@ def integration_snowflake(session):
     )
 
 
-@nox.session(python=random.choice(PYTHON_VERSIONS), venv_backend="venv")
+@nox.session(python=random.choice(PYTHON_VERSIONS_DB2), venv_backend="venv")
 def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,6 @@ DEFAULT_PYTHON_VERSION = "3.10"
 # Python versions used for testing.
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 PYTHON_VERSIONS_ORACLE = ["3.8", "3.9", "3.10"]
-PYTHON_VERSIONS_DB2 = ["3.9", "3.10", "3.11"]
 
 BLACK_PATHS = (
     "data_validation",
@@ -299,12 +298,12 @@ def integration_snowflake(session):
     )
 
 
-@nox.session(python=random.choice(PYTHON_VERSIONS_DB2), venv_backend="venv")
+@nox.session(python=random.choice(PYTHON_VERSIONS), venv_backend="venv")
 def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
-    _setup_session_requirements(session, extra_packages=["ibm-db-sa"])
+    _setup_session_requirements(session, extra_packages=["ibm-db-sa<0.4.2"])
 
     expected_env_vars = [
         "PROJECT_ID",

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -400,6 +400,20 @@ def test_row_validation_binary_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_binary_values_to_bigquery():
+    """dvt_binary row validation with comparison fields."""
+    row_validation_test(
+        tables="pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        primary_keys="int_id",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_fixed_char_pk_row_validation_to_bigquery():
     """Test fixed char primary keys"""
     id_column_row_validation_test("pso_data_validator.dvt_fixed_char_id")

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -636,6 +636,20 @@ def test_row_validation_binary_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_binary_values_to_bigquery():
+    """dvt_binary row validation with comparison fields."""
+    row_validation_test(
+        tables="pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        primary_keys="int_id",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_fixed_char_pk_row_validation_to_bigquery():
     """Test fixed char primary keys"""
     id_column_row_validation_test("pso_data_validator.dvt_fixed_char_id")

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -864,6 +864,20 @@ def test_row_validation_binary_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_binary_values_to_bigquery():
+    """dvt_binary row validation with comparison fields."""
+    row_validation_test(
+        tables="pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        primary_keys="int_id",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_fixed_char_pk_row_validation_to_bigquery():
     """Test fixed char primary keys"""
     id_column_row_validation_test("pso_data_validator.dvt_fixed_char_id")

--- a/tests/system/data_sources/test_snowflake.py
+++ b/tests/system/data_sources/test_snowflake.py
@@ -385,6 +385,20 @@ def test_row_validation_binary_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_binary_values_to_bigquery():
+    """dvt_binary row validation with comparison fields."""
+    row_validation_test(
+        tables="PSO_DATA_VALIDATOR.PUBLIC.DVT_BINARY=pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        primary_keys="int_id",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_row_validation_char_pk_to_bigquery():
     """Test padded char primary key join columns.
 

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -338,6 +338,20 @@ def test_row_validation_binary_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_binary_values_to_bigquery():
+    """dvt_binary row validation with comparison fields."""
+    row_validation_test(
+        tables="pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        primary_keys="int_id",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_custom_query_validation_core_types():
     """Spanner to Spanner dvt_core_types custom-query validation"""
     custom_query_validation_test(

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -501,6 +501,20 @@ def test_row_validation_binary_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_binary_values_to_bigquery():
+    """dvt_binary row validation with comparison fields."""
+    row_validation_test(
+        tables="pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        primary_keys="int_id",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns"""
     # TODO Remove use_randow_row option below when issue-1445 is actioned.

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -604,6 +604,20 @@ def test_row_validation_binary_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_binary_values_to_bigquery():
+    """dvt_binary row validation with comparison fields."""
+    row_validation_test(
+        tables="udf.dvt_binary=pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        primary_keys="int_id",
+        comp_fields="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_fixed_char_pk_row_validation_to_bigquery():
     """Test fixed char primary keys"""
     id_column_row_validation_test(

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -23,6 +23,16 @@ from ibis.backends.pandas import BasePandasBackend as PandasBackend
 
 from data_validation import clients, consts, exceptions
 
+try:
+    import ibm_db_sa
+except Exception:
+    ibm_db_sa = None
+
+try:
+    import oracledb
+except Exception:
+    oracledb = None
+
 
 TABLE_NAME = "my_table"
 DATA = [{"a": 1, "b": 2}]
@@ -35,6 +45,14 @@ SOURCE_CONN_CONFIG = {
     "table_name": "my_table",
     "file_path": SOURCE_TABLE_FILE_PATH,
     "file_type": "json",
+}
+
+DB2_CONN_CONFIG = {
+    consts.SOURCE_TYPE: consts.SOURCE_TYPE_DB2,
+    "database": "db",
+    "host": "127.0.0.1",
+    "user": "u",
+    "password": "p",
 }
 
 ORACLE_CONN_CONFIG = {
@@ -82,11 +100,13 @@ def test_import_oracle_client():
         assert "No module named 'oracledb'" in str(e)
 
 
-def test_get_oracle_data_client():
-    with pytest.raises(
-        exceptions.DataClientConnectionFailure, match=r".*pip install oracledb"
-    ):
-        clients.get_data_client(ORACLE_CONN_CONFIG)
+if oracledb is None:
+
+    def test_get_oracle_data_client_when_no_driver():
+        with pytest.raises(
+            exceptions.DataClientConnectionFailure, match=r".*pip install oracledb"
+        ):
+            clients.get_data_client(ORACLE_CONN_CONFIG)
 
 
 def test_get_pandas_data_client():
@@ -95,3 +115,21 @@ def test_get_pandas_data_client():
     ibis_client = clients.get_data_client(conn_config)
 
     assert isinstance(ibis_client, PandasBackend)
+
+
+if ibm_db_sa:
+
+    @mock.patch("ibm_db.connect", return_value=mock.Mock())
+    @mock.patch("ibm_db_dbi.Connection", return_value=mock.MagicMock())
+    @mock.patch.object(ibm_db_sa.ibm_db.DB2Dialect_ibm_db, "get_isolation_level")
+    def test_get_db2_data_client(fn_mock, connection_mock, connect_mock):
+        # The import is good, we can test the code.
+        clients.get_data_client(DB2_CONN_CONFIG)
+
+else:
+
+    def test_get_db2_data_client_when_no_driver():
+        with pytest.raises(
+            exceptions.DataClientConnectionFailure, match=r".*pip install ibm_db_sa"
+        ):
+            clients.get_data_client(DB2_CONN_CONFIG)

--- a/third_party/ibis/ibis_cloud_spanner/to_pandas.py
+++ b/third_party/ibis/ibis_cloud_spanner/to_pandas.py
@@ -45,7 +45,7 @@ class pandas_df:
         # Creating pandas dataframe from data and columns
         df = DataFrame(data, columns=columns)
 
-        # In Spanner BYTES columns are returned as a base64 string.
+        # Spanner BYTES columns are returned as a base64 string.
         # Here we convert them to a byte string to match other DVT supported engines.
         for bytes_column in bytes_columns:
             df[bytes_column] = df[bytes_column].map(base64.b64decode)

--- a/third_party/ibis/ibis_cloud_spanner/to_pandas.py
+++ b/third_party/ibis/ibis_cloud_spanner/to_pandas.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+
+from google.cloud.spanner_v1.types import TypeCode
 from pandas import DataFrame
 
 
@@ -34,9 +37,17 @@ class pandas_df:
         for row in data_qry:
             data.append(row)
 
-        columns = [f.name for f in data_qry.fields]
+        columns = [_.name for _ in data_qry.fields]
+        bytes_columns = [
+            _.name for _ in data_qry.fields if _.type_.code == TypeCode.BYTES
+        ]
 
         # Creating pandas dataframe from data and columns
         df = DataFrame(data, columns=columns)
+
+        # In Spanner BYTES columns are returned as a base64 string.
+        # Here we convert them to a byte string to match other DVT supported engines.
+        for bytes_column in bytes_columns:
+            df[bytes_column] = df[bytes_column].map(base64.b64decode)
 
         return df


### PR DESCRIPTION
## Description of changes
This PR:

1. Adds tests for binary values in comp-fields validations (the newly added Spanner test failed).
2. Changed our Spanner `to_pandas()` method to decode base64 Spanner output from BYTES columns to a binary string. The test added in item 1 now passes.
3. Cleans up some unit tests for optionally installed packages.
4. Limits the version of ibm_db_sa package so that tests pass (I created a new issue for this problem: https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1541)

## Issues to be closed

Closes #1524

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


