### PR TITLE
fix: Move exclude columns processing to cli_tools from config manager

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -108,14 +108,16 @@ def get_aggregate_config(args, config_manager: ConfigManager):
     if args.count:
         col_args = None if args.count == "*" else cli_tools.get_arg_list(args.count)
         aggregate_configs += config_manager.build_config_column_aggregates(
-            "count", col_args, args.exclude_columns, None, cast_to_bigint=cast_to_bigint
+            "count",
+            col_args,
+            None,
+            cast_to_bigint=cast_to_bigint,
         )
     if args.sum:
         col_args = None if args.sum == "*" else cli_tools.get_arg_list(args.sum)
         aggregate_configs += config_manager.build_config_column_aggregates(
             "sum",
             col_args,
-            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -124,7 +126,6 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "avg",
             col_args,
-            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -133,7 +134,6 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "min",
             col_args,
-            args.exclude_columns,
             supported_data_types + uuid_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -142,7 +142,6 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "max",
             col_args,
-            args.exclude_columns,
             supported_data_types + uuid_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -151,7 +150,6 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "bit_xor",
             col_args,
-            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -160,7 +158,6 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "std",
             col_args,
-            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -181,18 +178,14 @@ def _get_calculated_config(args, config_manager: ConfigManager) -> List[dict]:
             if config_manager.hash == "*"
             else cli_tools.get_arg_list(config_manager.hash)
         )
-        fields = config_manager.build_dependent_aliases(
-            "hash", col_list, args.exclude_columns
-        )
+        fields = config_manager.build_dependent_aliases("hash", col_list)
     elif config_manager.concat:
         col_list = (
             None
             if config_manager.concat == "*"
             else cli_tools.get_arg_list(config_manager.concat)
         )
-        fields = config_manager.build_dependent_aliases(
-            "concat", col_list, args.exclude_columns
-        )
+        fields = config_manager.build_dependent_aliases("concat", col_list)
 
     if len(fields) > 0:
         max_depth = max([x["depth"] for x in fields])
@@ -232,10 +225,7 @@ def _get_comparison_config(
         if args.comparison_fields == "*"
         else cli_tools.get_arg_list(args.comparison_fields)
     )
-    comparison_fields = config_manager.build_comp_fields(
-        col_list,
-        args.exclude_columns,
-    )
+    comparison_fields = config_manager.build_comp_fields(col_list)
     # We can't have the PK columns in the comparison SQL twice therefore filter them out here if included.
     comparison_fields = [_ for _ in comparison_fields if _ not in primary_keys]
 

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -110,6 +110,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "count",
             col_args,
+            args.exclude_columns,
             None,
             cast_to_bigint=cast_to_bigint,
         )
@@ -118,6 +119,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "sum",
             col_args,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -126,6 +128,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "avg",
             col_args,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -134,6 +137,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "min",
             col_args,
+            args.exclude_columns,
             supported_data_types + uuid_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -142,6 +146,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "max",
             col_args,
+            args.exclude_columns,
             supported_data_types + uuid_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -150,6 +155,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "bit_xor",
             col_args,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -158,6 +164,7 @@ def get_aggregate_config(args, config_manager: ConfigManager):
         aggregate_configs += config_manager.build_config_column_aggregates(
             "std",
             col_args,
+            args.exclude_columns,
             supported_data_types,
             cast_to_bigint=cast_to_bigint,
         )
@@ -225,7 +232,7 @@ def _get_comparison_config(
         if args.comparison_fields == "*"
         else cli_tools.get_arg_list(args.comparison_fields)
     )
-    comparison_fields = config_manager.build_comp_fields(col_list)
+    comparison_fields = config_manager.build_comp_fields(col_list, args.exclude_columns)
     # We can't have the PK columns in the comparison SQL twice therefore filter them out here if included.
     comparison_fields = [_ for _ in comparison_fields if _ not in primary_keys]
 

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1505,33 +1505,44 @@ def _concat_column_count_configs(
     return return_list
 
 
-def _get_pre_build_configs_cols_from_arg(
-    concat_arg: str, client, table_obj: dict, query_str: str, exclude_columns: bool
+def _get_pre_build_configs_base_columns(
+    client, table_obj: dict, query_str: str
 ) -> list:
-    if concat_arg == "*" and exclude_columns:
+    """Return a list of base columns for the table/custom query, used for both columns="*" and --exclude-columns."""
+    if table_obj:
+        full_col_list = clients.get_ibis_table_schema(
+            client,
+            table_obj["schema_name"],
+            table_obj["table_name"],
+        ).names
+    else:
+        full_col_list = clients.get_ibis_query_schema(
+            client,
+            query_str,
+        ).names
+    return [_.casefold() for _ in full_col_list]
+
+
+def _get_pre_build_configs_cols_from_arg(
+    column_csv_arg: str, casefold_columns: list, exclude_columns: bool
+) -> Optional[list]:
+    if column_csv_arg is None:
+        return None
+
+    column_arg_list = [_.casefold() for _ in get_arg_list(column_csv_arg)]
+    if column_csv_arg == "*" and exclude_columns:
         raise ValueError(
-            "Exclude columns flag cannot be present with '*' column aggregation"
+            "Exclude columns flag cannot be present with '*' column specification"
         )
-    elif concat_arg == "*" or exclude_columns:
+    elif column_csv_arg == "*" or exclude_columns:
         # If validating with "*" or need to invert the list then we need to expand to count the columns.
-        if table_obj:
-            full_col_list = clients.get_ibis_table_schema(
-                client,
-                table_obj["schema_name"],
-                table_obj["table_name"],
-            ).names
-        else:
-            full_col_list = clients.get_ibis_query_schema(
-                client,
-                query_str,
-            ).names
-        if concat_arg == "*":
-            return full_col_list
+        if column_csv_arg == "*":
+            return casefold_columns
 
         if exclude_columns:
-            return [col for col in full_col_list if col not in get_arg_list(concat_arg)]
+            return [col for col in casefold_columns if col not in column_arg_list]
     else:
-        return get_arg_list(concat_arg)
+        return column_arg_list
 
 
 def get_pre_build_configs(args: "Namespace", validate_cmd: str) -> List[Dict]:
@@ -1616,6 +1627,10 @@ def get_pre_build_configs(args: "Namespace", validate_cmd: str) -> List[Dict]:
             tables_list, source_client, target_client
         )
     for table_obj in tables_list:
+        casefold_source_columns = _get_pre_build_configs_base_columns(
+            source_client, table_obj, query_str
+        )
+
         pre_build_configs = {
             "config_type": config_type,
             consts.CONFIG_SOURCE_CONN_NAME: args.source_conn,
@@ -1639,19 +1654,25 @@ def get_pre_build_configs(args: "Namespace", validate_cmd: str) -> List[Dict]:
             consts.CONFIG_RUN_ID: getattr(args, consts.CONFIG_RUN_ID, None),
             "verbose": args.verbose,
         }
+
         if (
-            pre_build_configs[consts.CONFIG_ROW_CONCAT]
-            or pre_build_configs[consts.CONFIG_ROW_HASH]
+            pre_build_configs[consts.CONFIG_ROW_HASH]
+            or pre_build_configs[consts.CONFIG_ROW_CONCAT]
         ):
             # Ensure we don't have too many columns for the engines involved.
             cols = _get_pre_build_configs_cols_from_arg(
                 pre_build_configs[consts.CONFIG_ROW_HASH]
                 or pre_build_configs[consts.CONFIG_ROW_CONCAT],
-                source_client,
-                table_obj,
-                query_str,
+                casefold_source_columns,
                 args.exclude_columns,
             )
+            if args.exclude_columns:
+                # Put the column csv back into pre_build_configs because it has been inverted.
+                if pre_build_configs[consts.CONFIG_ROW_HASH]:
+                    pre_build_configs[consts.CONFIG_ROW_HASH] = ",".join(cols)
+                elif pre_build_configs[consts.CONFIG_ROW_CONCAT]:
+                    pre_build_configs[consts.CONFIG_ROW_CONCAT] = ",".join(cols)
+
             new_pre_build_configs = _concat_column_count_configs(
                 cols,
                 pre_build_configs,

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1505,25 +1505,37 @@ def _concat_column_count_configs(
     return return_list
 
 
+def _get_pre_build_configs_cols_from_arg(
+    concat_arg: str, client, table_obj: dict, query_str: str, exclude_columns: bool
+) -> list:
+    if concat_arg == "*" and exclude_columns:
+        raise ValueError(
+            "Exclude columns flag cannot be present with '*' column aggregation"
+        )
+    elif concat_arg == "*" or exclude_columns:
+        # If validating with "*" or need to invert the list then we need to expand to count the columns.
+        if table_obj:
+            full_col_list = clients.get_ibis_table_schema(
+                client,
+                table_obj["schema_name"],
+                table_obj["table_name"],
+            ).names
+        else:
+            full_col_list = clients.get_ibis_query_schema(
+                client,
+                query_str,
+            ).names
+        if concat_arg == "*":
+            return full_col_list
+
+        if exclude_columns:
+            return [col for col in full_col_list if col not in get_arg_list(concat_arg)]
+    else:
+        return get_arg_list(concat_arg)
+
+
 def get_pre_build_configs(args: "Namespace", validate_cmd: str) -> List[Dict]:
     """Return a dict of configurations to build ConfigManager object"""
-
-    def cols_from_arg(concat_arg: str, client, table_obj: dict, query_str: str) -> list:
-        if concat_arg == "*":
-            # If validating with "*" then we need to expand to count the columns.
-            if table_obj:
-                return clients.get_ibis_table_schema(
-                    client,
-                    table_obj["schema_name"],
-                    table_obj["table_name"],
-                ).names
-            else:
-                return clients.get_ibis_query_schema(
-                    client,
-                    query_str,
-                ).names
-        else:
-            return get_arg_list(concat_arg)
 
     # validate_cmd will be set to 'row`, or 'Custom-query' if invoked by generate-table-partitions depending
     # on what is being partitioned. Otherwise validate_cmd will be set to None
@@ -1632,12 +1644,13 @@ def get_pre_build_configs(args: "Namespace", validate_cmd: str) -> List[Dict]:
             or pre_build_configs[consts.CONFIG_ROW_HASH]
         ):
             # Ensure we don't have too many columns for the engines involved.
-            cols = cols_from_arg(
+            cols = _get_pre_build_configs_cols_from_arg(
                 pre_build_configs[consts.CONFIG_ROW_HASH]
                 or pre_build_configs[consts.CONFIG_ROW_CONCAT],
                 source_client,
                 table_obj,
                 query_str,
+                args.exclude_columns,
             )
             new_pre_build_configs = _concat_column_count_configs(
                 cols,

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1656,8 +1656,8 @@ def get_pre_build_configs(args: "Namespace", validate_cmd: str) -> List[Dict]:
         }
 
         if (
-            pre_build_configs[consts.CONFIG_ROW_HASH]
-            or pre_build_configs[consts.CONFIG_ROW_CONCAT]
+            pre_build_configs[consts.CONFIG_ROW_CONCAT]
+            or pre_build_configs[consts.CONFIG_ROW_HASH]
         ):
             # Ensure we don't have too many columns for the engines involved.
             cols = _get_pre_build_configs_cols_from_arg(

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -943,7 +943,7 @@ class ConfigManager(object):
         return bool(source_type in supported_types and target_type in supported_types)
 
     def build_config_column_aggregates(
-        self, agg_type, arg_value, exclude_cols, supported_types, cast_to_bigint=False
+        self, agg_type, arg_value, supported_types, cast_to_bigint=False
     ):
         """Return list of aggregate objects of given agg_type."""
 
@@ -998,13 +998,6 @@ class ConfigManager(object):
 
         if arg_value:
             arg_value = [x.casefold() for x in arg_value]
-            if exclude_cols:
-                included_cols = [
-                    column
-                    for column in casefold_source_columns
-                    if column not in arg_value
-                ]
-                arg_value = included_cols
 
             if supported_types:
                 # This mutates external supported_types, making it local as part of adding more values.
@@ -1018,11 +1011,6 @@ class ConfigManager(object):
                     "binary",
                     "!binary",
                 ]
-        else:
-            if exclude_cols:
-                raise ValueError(
-                    "Exclude columns flag cannot be present with '*' column aggregation"
-                )
 
         allowlist_columns = arg_value or casefold_source_columns
         for column_position, column in enumerate(casefold_source_columns):
@@ -1202,29 +1190,17 @@ class ConfigManager(object):
         return order_of_operations
 
     def _filter_columns_by_column_list(
-        self, casefold_columns: list, col_list: list, exclude_cols: bool
-    ) -> list:
+        self, casefold_columns: dict, col_list: list
+    ) -> dict:
         if col_list:
             filter_list = [_.casefold() for _ in col_list]
-            if exclude_cols:
-                # Exclude columns based on col_list if provided
-                casefold_columns = {
-                    k: v for (k, v) in casefold_columns.items() if k not in filter_list
-                }
-            else:
-                # Include columns based on col_list if provided
-                casefold_columns = {
-                    k: v for (k, v) in casefold_columns.items() if k in filter_list
-                }
-        elif exclude_cols:
-            raise ValueError(
-                "Exclude columns flag cannot be present with column list '*'"
-            )
+            # Include columns based on col_list if provided
+            casefold_columns = {
+                k: v for (k, v) in casefold_columns.items() if k in filter_list
+            }
         return casefold_columns
 
-    def build_dependent_aliases(
-        self, calc_type: str, col_list=None, exclude_cols=False
-    ) -> List[Dict]:
+    def build_dependent_aliases(self, calc_type: str, col_list=None) -> List[Dict]:
         """This is a utility function for determining the required depth of all fields"""
         source_table = self.get_source_ibis_calculated_table()
         target_table = self.get_target_ibis_calculated_table()
@@ -1233,10 +1209,10 @@ class ConfigManager(object):
         casefold_target_columns = {x.casefold(): str(x) for x in target_table.columns}
 
         casefold_source_columns = self._filter_columns_by_column_list(
-            casefold_source_columns, col_list, exclude_cols
+            casefold_source_columns, col_list
         )
         casefold_target_columns = self._filter_columns_by_column_list(
-            casefold_target_columns, col_list, exclude_cols
+            casefold_target_columns, col_list
         )
 
         column_aliases = {}
@@ -1288,13 +1264,13 @@ class ConfigManager(object):
                     col_names.append(col)
         return col_names
 
-    def build_comp_fields(self, col_list: list, exclude_cols: bool = False) -> dict:
+    def build_comp_fields(self, col_list: list) -> dict:
         """This is a utility function processing comp-fields values like we do for hash/concat."""
         source_table = self.get_source_ibis_calculated_table()
         casefold_source_columns = {_.casefold(): str(_) for _ in source_table.columns}
 
         casefold_source_columns = self._filter_columns_by_column_list(
-            casefold_source_columns, col_list, exclude_cols
+            casefold_source_columns, col_list
         )
 
         return casefold_source_columns

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -943,7 +943,7 @@ class ConfigManager(object):
         return bool(source_type in supported_types and target_type in supported_types)
 
     def build_config_column_aggregates(
-        self, agg_type, arg_value, supported_types, cast_to_bigint=False
+        self, agg_type, arg_value, exclude_cols, supported_types, cast_to_bigint=False
     ):
         """Return list of aggregate objects of given agg_type."""
 
@@ -998,6 +998,13 @@ class ConfigManager(object):
 
         if arg_value:
             arg_value = [x.casefold() for x in arg_value]
+            if exclude_cols:
+                included_cols = [
+                    column
+                    for column in casefold_source_columns
+                    if column not in arg_value
+                ]
+                arg_value = included_cols
 
             if supported_types:
                 # This mutates external supported_types, making it local as part of adding more values.
@@ -1011,6 +1018,11 @@ class ConfigManager(object):
                     "binary",
                     "!binary",
                 ]
+        else:
+            if exclude_cols:
+                raise ValueError(
+                    "Exclude columns flag cannot be present with '*' column aggregation"
+                )
 
         allowlist_columns = arg_value or casefold_source_columns
         for column_position, column in enumerate(casefold_source_columns):
@@ -1190,14 +1202,24 @@ class ConfigManager(object):
         return order_of_operations
 
     def _filter_columns_by_column_list(
-        self, casefold_columns: dict, col_list: list
+        self, casefold_columns: dict, col_list: list, exclude_cols: bool = False
     ) -> dict:
         if col_list:
             filter_list = [_.casefold() for _ in col_list]
-            # Include columns based on col_list if provided
-            casefold_columns = {
-                k: v for (k, v) in casefold_columns.items() if k in filter_list
-            }
+            if exclude_cols:
+                # Exclude columns based on col_list if provided
+                casefold_columns = {
+                    k: v for (k, v) in casefold_columns.items() if k not in filter_list
+                }
+            else:
+                # Include columns based on col_list if provided
+                casefold_columns = {
+                    k: v for (k, v) in casefold_columns.items() if k in filter_list
+                }
+        elif exclude_cols:
+            raise ValueError(
+                "Exclude columns flag cannot be present with column list '*'"
+            )
         return casefold_columns
 
     def build_dependent_aliases(self, calc_type: str, col_list=None) -> List[Dict]:
@@ -1264,15 +1286,13 @@ class ConfigManager(object):
                     col_names.append(col)
         return col_names
 
-    def build_comp_fields(self, col_list: list) -> dict:
+    def build_comp_fields(self, col_list: list, exclude_cols: bool) -> dict:
         """This is a utility function processing comp-fields values like we do for hash/concat."""
         source_table = self.get_source_ibis_calculated_table()
         casefold_source_columns = {_.casefold(): str(_) for _ in source_table.columns}
-
         casefold_source_columns = self._filter_columns_by_column_list(
-            casefold_source_columns, col_list
+            casefold_source_columns, col_list, exclude_cols=exclude_cols
         )
-
         return casefold_source_columns
 
     def auto_list_primary_keys(self) -> list:

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -144,39 +144,41 @@ def row_validation_many_columns_test(
     concat_arg: str = "hash",
     expected_config_managers: int = 1,
     target_conn: str = "mock-conn",
+    columns: str = "*",
+    exclude_columns: bool = None,
 ):
     """Runs a dvt_many_cols validation (standard or custom-query) based on input parameters and tests results."""
     parser = cli_tools.configure_arg_parser()
     schema_prefix = f"{schema}." if schema else ""
     if validation_type == "row":
-        args = parser.parse_args(
-            [
-                "validate",
-                "row",
-                "-sc=mock-conn",
-                f"-tc={target_conn}",
-                f"-tbls={schema_prefix}{table}",
-                "--primary-keys=id",
-                f"--{concat_arg}=*",
-                "--filter-status=fail",
-            ]
-        )
+        cli_arg_list = [
+            "validate",
+            "row",
+            "-sc=mock-conn",
+            f"-tc={target_conn}",
+            f"-tbls={schema_prefix}{table}",
+            "--primary-keys=id",
+            f"--{concat_arg}={columns}",
+            "--filter-status=fail",
+            "--exclude-columns" if exclude_columns else None,
+        ]
     else:
         query = f"SELECT * FROM {schema_prefix}{table}"
-        args = parser.parse_args(
-            [
-                "validate",
-                "custom-query",
-                "row",
-                "-sc=mock-conn",
-                "-tc=mock-conn",
-                f"--source-query={query}",
-                f"--target-query={query}",
-                "--primary-keys=id",
-                f"--{concat_arg}=*",
-                "--filter-status=fail",
-            ]
-        )
+        cli_arg_list = [
+            "validate",
+            "custom-query",
+            "row",
+            "-sc=mock-conn",
+            "-tc=mock-conn",
+            f"--source-query={query}",
+            f"--target-query={query}",
+            "--primary-keys=id",
+            f"--{concat_arg}={columns}",
+            "--filter-status=fail",
+            "--exclude-columns" if exclude_columns else None,
+        ]
+    cli_arg_list = [_ for _ in cli_arg_list if _]
+    args = parser.parse_args(cli_arg_list)
     # We expect the validation to be split into multiple config managers.
     for df in run_tests_from_cli_args(
         args, expected_config_managers=expected_config_managers

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -187,6 +187,40 @@ def row_validation_many_columns_test(
         assert len(df) == 0
 
 
+def exclude_columns_test(
+    capsys,
+    tables="pso_data_validator.dvt_core_types",
+    tc="mock-conn",
+    validation_type: str = "row",
+    column_arg: str = "hash",
+    columns: str = "col_string,col_float64",
+    expected_column: str = "col_float32",
+):
+    """Runs a dvt_many_cols validation (standard or custom-query) based on input parameters and tests results."""
+    parser = cli_tools.configure_arg_parser()
+    cli_arg_list = [
+        "validate",
+        validation_type,
+        "-sc=mock-conn",
+        f"-tc={tc}",
+        f"-tbls={tables}",
+        "--primary-keys=id" if validation_type == "row" else None,
+        f"--{column_arg}={columns}",
+        "--filter-status=fail",
+        "--exclude-columns",
+    ]
+    cli_arg_list = [_ for _ in cli_arg_list if _]
+    args = parser.parse_args(cli_arg_list)
+    config_managers = main.build_config_managers_from_args(args)
+    main.run_validation(config_managers[0], dry_run=True)
+    out, err = capsys.readouterr()
+    assert err == ""
+    dry_run = json.loads(out)
+    for col in columns.lower().split(","):
+        assert col not in dry_run["source_query"].lower()
+    assert expected_column.lower() in dry_run["source_query"].lower()
+
+
 def find_tables_assertions(
     command_output: str,
     expected_source_schema: str = "pso_data_validator",

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -41,6 +41,7 @@ from tests.system.data_sources.common_functions import (
     raw_query_test,
     row_validation_test,
     custom_query_validation_test,
+    exclude_columns_test,
 )
 from tests.system.result_handlers.test_bigquery import create_bigquery_results_table
 
@@ -1202,6 +1203,42 @@ def test_bigquery_dry_run(mock_conn, capsys):
         dry_run["source_query"]
         == f"WITH t0 AS (\n  SELECT t5.*, t5.`col_string` AS `cast__col_string`\n  FROM `{PROJECT_ID}.pso_data_validator.dvt_core_types` t5\n),\nt1 AS (\n  SELECT t0.*,\n         IFNULL(t0.`cast__col_string`, 'DEFAULT_REPLACEMENT_STRING') AS `ifnull__cast__col_string`\n  FROM t0\n),\nt2 AS (\n  SELECT t1.*,\n         rtrim(t1.`ifnull__cast__col_string`) AS `rstrip__ifnull__cast__col_string`\n  FROM t1\n),\nt3 AS (\n  SELECT t2.*,\n         ARRAY_TO_STRING([t2.`rstrip__ifnull__cast__col_string`], '') AS `concat__all`\n  FROM t2\n)\nSELECT t4.`hash__all`, t4.`id`\nFROM (\n  SELECT t3.*, TO_HEX(SHA256(t3.`concat__all`)) AS `hash__all`\n  FROM t3\n) t4"
     )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
+def test_bigquery_exclude_columns_row_hash_dry_run(mock_conn, capsys):
+    """Test BigQuery dry run mode with --exclude-columns and validate the generated SQL.
+
+    The code being tested is not BigQuery specific therefore we do not need this in other test files.
+    """
+    exclude_columns_test(capsys)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
+def test_bigquery_exclude_columns_row_concat_dry_run(mock_conn, capsys):
+    """Test BigQuery dry run mode with --exclude-columns and validate the generated SQL.
+
+    The code being tested is not BigQuery specific therefore we do not need this in other test files.
+    """
+    exclude_columns_test(capsys, column_arg="concat")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
+def test_bigquery_exclude_columns_row_comp_fields_dry_run(mock_conn, capsys):
+    """Test BigQuery dry run mode with --exclude-columns and validate the generated SQL.
+
+    The code being tested is not BigQuery specific therefore we do not need this in other test files.
+    """
+    exclude_columns_test(capsys, column_arg="comparison-fields")
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -1245,6 +1245,30 @@ def test_bigquery_exclude_columns_row_comp_fields_dry_run(mock_conn, capsys):
     "data_validation.state_manager.StateManager.get_connection_config",
     return_value=BQ_CONN,
 )
+def test_bigquery_exclude_columns_column_count_dry_run(mock_conn, capsys):
+    """Test BigQuery dry run mode with --exclude-columns and validate the generated SQL.
+
+    The code being tested is not BigQuery specific therefore we do not need this in other test files.
+    """
+    exclude_columns_test(capsys, validation_type="column", column_arg="count")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
+def test_bigquery_exclude_columns_column_sum_dry_run(mock_conn, capsys):
+    """Test BigQuery dry run mode with --exclude-columns and validate the generated SQL.
+
+    The code being tested is not BigQuery specific therefore we do not need this in other test files.
+    """
+    exclude_columns_test(capsys, validation_type="column", column_arg="sum")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=BQ_CONN,
+)
 def test_schema_validation_core_types(mock_conn):
     """BigQuery to BigQuery dvt_core_types schema validation"""
     schema_validation_test(

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -1024,11 +1024,28 @@ def test_column_validation_many_columns():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_row_validation_many_columns():
+def test_row_validation_many_columns_standard():
     """dvt_many_cols row validation.
     This is testing many columns logic for --hash, there's a Teradata test for --concat.
     """
     row_validation_many_columns_test(expected_config_managers=5)
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_many_columns_exclude():
+    """dvt_many_cols row validation including --exclude-columns.
+
+    We have this specific test for --exlcude-columns as a regression test for issue-1542.
+    The code being tested is not PostgreSQL specific therefore we do not need this in other test files.
+    """
+    row_validation_many_columns_test(
+        expected_config_managers=5,
+        columns="col_004,col_005,col_006",
+        exclude_columns=True,
+    )
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -1038,7 +1038,7 @@ def test_row_validation_many_columns_standard():
 def test_row_validation_many_columns_exclude():
     """dvt_many_cols row validation including --exclude-columns.
 
-    We have this specific test for --exlcude-columns as a regression test for issue-1542.
+    We have this specific test for --exclude-columns as a regression test for issue-1542.
     The code being tested is not PostgreSQL specific therefore we do not need this in other test files.
     """
     row_validation_many_columns_test(

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -892,6 +892,97 @@ def test_concat_column_count_configs(
         assert result == [pre_build_config]
 
 
+class MockIbisSchema:
+    def __init__(self, names):
+        self.names = names
+
+
+@mock.patch("data_validation.clients.get_ibis_query_schema")
+@mock.patch("data_validation.clients.get_ibis_table_schema")
+@pytest.mark.parametrize(
+    "concat_arg,exclude_columns,table_obj,query_str,mock_schema_names,expected_result,expected_exception",
+    [
+        # Scenario 1: wildcard with exclude_columns raises ValueError
+        (
+            "*",
+            True,
+            {"schema_name": "a", "table_name": "b"},
+            None,
+            ["col1", "col2"],
+            None,
+            ValueError,
+        ),
+        # Scenario 2a: wildcard with table_obj
+        (
+            "*",
+            False,
+            {"schema_name": "a", "table_name": "b"},
+            None,
+            ["col1", "col2", "col3"],
+            ["col1", "col2", "col3"],
+            None,
+        ),
+        # Scenario 2b: wildcard with query_str
+        (
+            "*",
+            False,
+            None,
+            "SELECT * FROM a.b",
+            ["col_a", "col_b"],
+            ["col_a", "col_b"],
+            None,
+        ),
+        # Scenario 3a: exclude_columns with table_obj
+        (
+            "col1,col3",
+            True,
+            {"schema_name": "a", "table_name": "b"},
+            None,
+            ["col1", "col2", "col3", "col4"],
+            ["col2", "col4"],
+            None,
+        ),
+        # Scenario 3b: exclude_columns with query_str
+        (
+            "col_a",
+            True,
+            None,
+            "SELECT * FROM a.b",
+            ["col_a", "col_b", "col_c"],
+            ["col_b", "col_c"],
+            None,
+        ),
+        # Scenario 4: simple column list
+        ("col1,col2", False, None, None, [], ["col1", "col2"], None),
+    ],
+)
+def test__get_pre_build_configs_cols_from_arg(
+    mock_get_table_schema,
+    mock_get_query_schema,
+    concat_arg,
+    exclude_columns,
+    table_obj,
+    query_str,
+    mock_column_names,
+    expected_result,
+    expected_exception,
+):
+    """Test _get_pre_build_configs_cols_from_arg."""
+    mock_get_table_schema.return_value = MockIbisSchema(mock_column_names)
+    mock_get_query_schema.return_value = MockIbisSchema(mock_column_names)
+
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            cli_tools._get_pre_build_configs_cols_from_arg(
+                concat_arg, None, table_obj, query_str, exclude_columns
+            )
+    else:
+        result = cli_tools._get_pre_build_configs_cols_from_arg(
+            concat_arg, None, table_obj, query_str, exclude_columns
+        )
+        assert result == expected_result
+
+
 @pytest.mark.parametrize(
     "test_input",
     ["tests/resources/custom-query.sql"],

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -897,17 +897,13 @@ class MockIbisSchema:
         self.names = names
 
 
-@mock.patch("data_validation.clients.get_ibis_query_schema")
-@mock.patch("data_validation.clients.get_ibis_table_schema")
 @pytest.mark.parametrize(
-    "concat_arg,exclude_columns,table_obj,query_str,mock_schema_names,expected_result,expected_exception",
+    "concat_arg,exclude_columns,base_columns,expected_result,expected_exception",
     [
         # Scenario 1: wildcard with exclude_columns raises ValueError
         (
             "*",
             True,
-            {"schema_name": "a", "table_name": "b"},
-            None,
             ["col1", "col2"],
             None,
             ValueError,
@@ -916,8 +912,6 @@ class MockIbisSchema:
         (
             "*",
             False,
-            {"schema_name": "a", "table_name": "b"},
-            None,
             ["col1", "col2", "col3"],
             ["col1", "col2", "col3"],
             None,
@@ -926,8 +920,6 @@ class MockIbisSchema:
         (
             "*",
             False,
-            None,
-            "SELECT * FROM a.b",
             ["col_a", "col_b"],
             ["col_a", "col_b"],
             None,
@@ -936,8 +928,6 @@ class MockIbisSchema:
         (
             "col1,col3",
             True,
-            {"schema_name": "a", "table_name": "b"},
-            None,
             ["col1", "col2", "col3", "col4"],
             ["col2", "col4"],
             None,
@@ -946,39 +936,30 @@ class MockIbisSchema:
         (
             "col_a",
             True,
-            None,
-            "SELECT * FROM a.b",
             ["col_a", "col_b", "col_c"],
             ["col_b", "col_c"],
             None,
         ),
         # Scenario 4: simple column list
-        ("col1,col2", False, None, None, [], ["col1", "col2"], None),
+        ("col1,col2", False, [], ["col1", "col2"], None),
     ],
 )
 def test__get_pre_build_configs_cols_from_arg(
-    mock_get_table_schema,
-    mock_get_query_schema,
     concat_arg,
     exclude_columns,
-    table_obj,
-    query_str,
-    mock_column_names,
+    base_columns,
     expected_result,
     expected_exception,
 ):
     """Test _get_pre_build_configs_cols_from_arg."""
-    mock_get_table_schema.return_value = MockIbisSchema(mock_column_names)
-    mock_get_query_schema.return_value = MockIbisSchema(mock_column_names)
-
     if expected_exception:
         with pytest.raises(expected_exception):
             cli_tools._get_pre_build_configs_cols_from_arg(
-                concat_arg, None, table_obj, query_str, exclude_columns
+                concat_arg, base_columns, exclude_columns
             )
     else:
         result = cli_tools._get_pre_build_configs_cols_from_arg(
-            concat_arg, None, table_obj, query_str, exclude_columns
+            concat_arg, base_columns, exclude_columns
         )
         assert result == expected_result
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -587,10 +587,30 @@ def test_build_comp_fields(module_under_test):
 
     comparison_fields = config_manager.build_comp_fields(
         ["a", "c", "e"],
+        False,
     )
     # Column "e" does not exists and therefore should not be in the list, even though
     # it was requested.
     assert comparison_fields == {"a": "a", "c": "c"}
+
+
+@mock.patch(
+    "data_validation.config_manager.ConfigManager.get_source_ibis_calculated_table",
+    new=lambda x: MockIbisTable(),
+)
+def test_build_comp_fields_exclude_columns(module_under_test):
+    config_manager = module_under_test.ConfigManager(
+        SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+    )
+
+    comparison_fields = config_manager.build_comp_fields(
+        [
+            "a",
+        ],
+        True,
+    )
+    # Column "a" was excluded and therefore should not be in the list.
+    assert comparison_fields == {"b": "b", "c": "c", "d": "d"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -562,19 +562,6 @@ def test_build_dependent_aliases(module_under_test):
     ]
 
 
-def test_build_dependent_aliases_exception(module_under_test):
-    config_manager = module_under_test.ConfigManager(
-        SAMPLE_ROW_CONFIG_DEP_ALIASES, MockIbisClient(), MockIbisClient(), verbose=False
-    )
-
-    with pytest.raises(ValueError) as excinfo:
-        config_manager.build_dependent_aliases("hash", None, True)
-    assert (
-        str(excinfo.value)
-        == "Exclude columns flag cannot be present with column list '*'"
-    )
-
-
 def test_get_correct_run_id(module_under_test):
     config_manager = module_under_test.ConfigManager(
         SAMPLE_ROW_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -555,29 +555,10 @@ def test_build_dependent_aliases(module_under_test):
     )
 
     # Hash includes col a
-    dependent_aliases = config_manager.build_dependent_aliases(
-        "hash", ["a"], exclude_cols=False
-    )
+    dependent_aliases = config_manager.build_dependent_aliases("hash", ["a"])
     concat_config = dependent_aliases[-2]
     assert concat_config["source_reference"] == [
         "rstrip__ifnull__cast__a",
-    ]
-
-
-def test_build_dependent_aliases_exclude_columns(module_under_test):
-    config_manager = module_under_test.ConfigManager(
-        SAMPLE_ROW_CONFIG_DEP_ALIASES, MockIbisClient(), MockIbisClient(), verbose=False
-    )
-
-    # Hash excludes col a
-    dependent_aliases = config_manager.build_dependent_aliases(
-        "hash", ["a"], exclude_cols=True
-    )
-    concat_config = dependent_aliases[-2]
-    assert concat_config["source_reference"] == [
-        "rstrip__ifnull__cast__b",
-        "rstrip__ifnull__cast__c",
-        "rstrip__ifnull__cast__d",
     ]
 
 
@@ -617,21 +598,12 @@ def test_build_comp_fields(module_under_test):
         SAMPLE_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
     )
 
-    # With exclude_columns=False
     comparison_fields = config_manager.build_comp_fields(
         ["a", "c", "e"],
-        False,
     )
     # Column "e" does not exists and therefore should not be in the list, even though
     # it was requested.
     assert comparison_fields == {"a": "a", "c": "c"}
-
-    # With exclude_columns=True
-    comparison_fields = config_manager.build_comp_fields(
-        ["a", "c", "e"],
-        True,
-    )
-    assert comparison_fields == {"b": "b", "d": "d"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes
This PR:
- Adds an PostgreSQL integration test to trigger exception referenced in issue 1542
- Adds BigQuery integration tests covering `--exclude-columns` for row concat/hash/comp fields and column count/sum
- Moves processing for `--exclude-columns` option for concat and hash validations from config manager cli_tools, I needed to do this because of the `--max-concat-columns` logic which needed to be earlier in the process.
- I looked at moving all `--exclude-columns` logic to the same place in cli_tools but it was difficult and was turning my PR into a monster, so I abandoned that thought and stuck to the proble, I was trying to fix.
- Adds unit tests for the cli_tools function that includes the exclude columns processing

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1542

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


