### PR TITLE
fix: generate-table-partitions generates correct yaml with multiple tables

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -90,7 +90,8 @@ except Exception:
 # DB2 requires ibm_db_sa
 try:
     from third_party.ibis.ibis_db2.api import db2_connect
-except Exception:
+except Exception as e:
+    logging.error(f"Exception {str(e)} while importing db2_connect")
     db2_connect = _raise_missing_client_error("pip install ibm_db_sa")
 
 

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -14,8 +14,6 @@
 
 import copy
 import logging
-import string
-import random
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, Tuple
 
 import ibis.expr.datatypes as dt
@@ -333,13 +331,11 @@ class ConfigManager(object):
 
     @property
     def full_source_table(self):
-        """Return string value of target table."""
+        """Return string value of fully qualified source table."""
         if self.source_table and self.source_schema:
             return self.source_schema + "." + self.source_table
-        elif self.source_table:
-            return self.source_table
         else:
-            return f"custom.{''.join(random.choice(string.ascii_lowercase) for _ in range(5))}"
+            return self.source_table
 
     @property
     def labels(self):

--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -140,7 +140,6 @@ class PartitionBuilder:
         master_filter_list = []
         for config_manager in self.config_managers:  # For each pair of tables
             validation_builder = ValidationBuilder(config_manager)
-
             source_pks, target_pks = [], []
             for pk in config_manager.primary_keys:
                 source_pks.append(pk["source_column"])
@@ -419,9 +418,13 @@ class PartitionBuilder:
                 yaml_config = self._add_filters_get_yaml_file(
                     config_manager, source_filters_list[i], target_filters_list[i]
                 )
-                yaml_configs_list[ind]["yaml_files"].append(
+                if ind == 0 : # First source/target table pair being partitioned 
+                    yaml_configs_list[0]["yaml_files"].append(
                     {"target_file_name": f"{i:04}.yaml", "yaml_config": yaml_config}
                 )
+                else : # Subsequent table pairs - extend existing yaml by adding additional validations
+                    yaml_configs_list[0]["yaml_files"][i]['yaml_config']['validations'].extend(yaml_config['validations'])
+
         return yaml_configs_list
 
     def _store_partitions(self, yaml_configs_list: List[Dict]) -> None:

--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -395,14 +395,30 @@ class PartitionBuilder:
         Returns:
             yaml_configs_list (List[Dict]): List of YAML dicts (folder), one folder for each table pair being validated.
         """
-        yaml_configs_list = [None] * len(self.config_managers)
+        # Since we store yaml configs in directories by schema.source_table_name, there can be
+        # only one yaml config per schema.source_table_name, even if shows up in multiple table
+        # pairs. We store the configs in a list and a dict mapping source table name to list index
+        yaml_configs_list = []
+        src_config_dict = {}
         for ind, config_manager in enumerate(self.config_managers):
             filter_list = partition_filters[ind]
 
-            yaml_configs_list[ind] = {
-                "target_folder_name": config_manager.full_source_table,
-                "yaml_files": [],
-            }
+            if (
+                src_config_dict.get(config_manager.full_source_table) is None
+            ):  # First time encountering this source table
+                source_table_repeat = False
+                yaml_configs_list.append(
+                    {
+                        "target_folder_name": config_manager.full_source_table,
+                        "yaml_files": [],
+                    }
+                )
+                src_config_dict[config_manager.full_source_table] = (
+                    len(yaml_configs_list) - 1
+                )
+            else:
+                source_table_repeat = True
+            yaml_ind = src_config_dict[config_manager.full_source_table]
 
             # Create a list of lists chunked by partitions per file
             # Both source and target table are divided into the same number of partitions, so we are
@@ -418,13 +434,16 @@ class PartitionBuilder:
                 yaml_config = self._add_filters_get_yaml_file(
                     config_manager, source_filters_list[i], target_filters_list[i]
                 )
-                if ind == 0 : # First source/target table pair being partitioned 
-                    yaml_configs_list[0]["yaml_files"].append(
-                    {"target_file_name": f"{i:04}.yaml", "yaml_config": yaml_config}
-                )
-                else : # Subsequent table pairs - extend existing yaml by adding additional validations
-                    yaml_configs_list[0]["yaml_files"][i]['yaml_config']['validations'].extend(yaml_config['validations'])
-
+                if (
+                    source_table_repeat
+                ):  # Same source table, yaml configs exist, add these validations by extending existing ones.
+                    yaml_configs_list[yaml_ind]["yaml_files"][i]["yaml_config"][
+                        "validations"
+                    ].extend(yaml_config["validations"])
+                else:  # New yaml files, append these validations as yaml_config
+                    yaml_configs_list[yaml_ind]["yaml_files"].append(
+                        {"target_file_name": f"{i:04}.yaml", "yaml_config": yaml_config}
+                    )
         return yaml_configs_list
 
     def _store_partitions(self, yaml_configs_list: List[Dict]) -> None:

--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -18,6 +18,8 @@ import pandas
 import logging
 import re
 import datetime
+import hashlib
+import base64
 from typing import List, Dict, TYPE_CHECKING
 
 from data_validation import cli_tools, consts, util
@@ -397,28 +399,40 @@ class PartitionBuilder:
         """
         # Since we store yaml configs in directories by schema.source_table_name, there can be
         # only one yaml config per schema.source_table_name, even if shows up in multiple table
-        # pairs. We store the configs in a list and a dict mapping source table name to list index
+        # pairs. In the case of custom query validation, we need to generate a "reasonably" unique name for the directory
+        # based on the source query. As mentioned in issue 1428, this not friendly, so something we should change.
+        # We store the configs in a list and a dict mapping source table name, or directory name in case of custom-query to list index
         yaml_configs_list = []
         src_config_dict = {}
+
         for ind, config_manager in enumerate(self.config_managers):
+            if config_manager.source_table:
+                dir_name = config_manager.full_source_table
+            else:
+                dir_name = (
+                    "custom."
+                    + base64.b64encode(
+                        hashlib.sha256(
+                            config_manager.source_query.encode("utf-8")
+                        ).digest()
+                    ).decode("ascii")[:5]
+                )
             filter_list = partition_filters[ind]
 
-            if (
-                src_config_dict.get(config_manager.full_source_table) is None
-            ):  # First time encountering this source table
+            if src_config_dict.get(dir_name) is None:
+                # First time encountering this source table or source query
                 source_table_repeat = False
                 yaml_configs_list.append(
                     {
-                        "target_folder_name": config_manager.full_source_table,
+                        "target_folder_name": dir_name,
                         "yaml_files": [],
                     }
                 )
-                src_config_dict[config_manager.full_source_table] = (
-                    len(yaml_configs_list) - 1
-                )
+                src_config_dict[dir_name] = len(yaml_configs_list) - 1
+
             else:
                 source_table_repeat = True
-            yaml_ind = src_config_dict[config_manager.full_source_table]
+            yaml_ind = src_config_dict[dir_name]
 
             # Create a list of lists chunked by partitions per file
             # Both source and target table are divided into the same number of partitions, so we are

--- a/tests/unit/test_partition_builder.py
+++ b/tests/unit/test_partition_builder.py
@@ -691,10 +691,10 @@ def test_add_partition_filters_to_config(module_under_test):
 
 def test_add_partition_filters_to_multiple_configs(module_under_test):
     """Add partition filters to 2 ConfigManager objects, build YAML config list
-    and assert YAML configs. Generally we don't expect users to invoke generate-table-partitions with
+    and assert number of validations twice as in single config. Generally we don't expect users to invoke generate-table-partitions with
     multiple table pairs from command line, where both pairs have the same primary key, columns to validate,
     number of partitions and partitions per file. DVT can add the same partition_filters to multiple configs
-    because the validation for a table with numerous columns had to be split into multiple validations performeed serially.
+    because the validation for a table with numerous columns had to be split into multiple validations performed serially.
     Each validation has its own config with fewer columns which can be successfully validated.
     This test addresses issue 1549.
     """
@@ -706,6 +706,7 @@ def test_add_partition_filters_to_multiple_configs(module_under_test):
     mock_args = parser.parse_args(TABLE_PART_ARGS)
 
     # two partition filters are needed, one for source and one for target
+    # have to add a pair for each config_manager object
     master_filter_list = []
     for i in range(len(config_managers)):
         master_filter_list.append([PARTITION_FILTERS_LIST, PARTITION_FILTERS_LIST])
@@ -714,7 +715,8 @@ def test_add_partition_filters_to_multiple_configs(module_under_test):
     builder = module_under_test.PartitionBuilder(config_managers, mock_args)
     yaml_configs_list = builder._add_partition_filters(master_filter_list)
 
-    # There were nine validations with one table, there should be 18 now.
+    # There were nine validations with one table in
+    # test_add_partition_filters_to_config, there should be 18 now.
     num_val = 0
     for yaml_config in yaml_configs_list:
         for yaml_file in yaml_config["yaml_files"]:

--- a/tests/unit/test_partition_builder.py
+++ b/tests/unit/test_partition_builder.py
@@ -135,6 +135,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -173,6 +174,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -211,6 +213,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -249,6 +252,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -287,6 +291,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -335,6 +340,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -373,6 +379,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -411,6 +418,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -449,6 +457,7 @@ YAML_CONFIGS_LIST = [
                             "table_name": "test_table",
                             "target_schema_name": None,
                             "target_table_name": "test_table",
+                            "source_query": None,
                             "primary_keys": [
                                 {
                                     "field_alias": "id",
@@ -537,9 +546,14 @@ def _generate_fake_data(
     return data
 
 
-def _generate_config_manager(table_name: str = "my_table") -> ConfigManager:
-    """Returns a Dummy ConfigManager Object"""
+def _generate_config_manager(
+    table_name: str = "test_table", query: str = None
+) -> ConfigManager:
+    """Returns a Dummy ConfigManager Object
+    If query keyword parameter is provided, then query validation is assumed"""
 
+    if query:
+        table_name = None
     row_config = {
         # BigQuery Specific Connection Config
         "source_conn": SOURCE_CONN_CONFIG,
@@ -551,6 +565,7 @@ def _generate_config_manager(table_name: str = "my_table") -> ConfigManager:
         "table_name": table_name,
         "target_schema_name": None,
         "target_table_name": table_name,
+        consts.CONFIG_SOURCE_QUERY: query,
         consts.CONFIG_PRIMARY_KEYS: [
             {
                 consts.CONFIG_FIELD_ALIAS: "id",
@@ -610,7 +625,7 @@ def test_class_object_creation(module_under_test):
     3. single primary_key value (is this already tested in row validation?)
     4. multiple primary keys (is this already tested in row validation?)
     """
-    mock_config_manager = _generate_config_manager("test_table")
+    mock_config_manager = _generate_config_manager()
     config_managers = [mock_config_manager]
 
     parser = cli_tools.configure_arg_parser()
@@ -665,7 +680,7 @@ def test_add_partition_filters_to_config(module_under_test):
     and assert YAML configs
     """
     # Generate dummy YAML configs list
-    config_manager = _generate_config_manager("test_table")
+    config_manager = _generate_config_manager()
     config_managers = [config_manager]
 
     parser = cli_tools.configure_arg_parser()
@@ -699,7 +714,7 @@ def test_add_partition_filters_to_multiple_configs(module_under_test):
     This test addresses issue 1549.
     """
     # Generate dummy YAML configs list
-    config_manager = _generate_config_manager("test_table")
+    config_manager = _generate_config_manager()
     config_managers = [config_manager, config_manager]
 
     parser = cli_tools.configure_arg_parser()
@@ -733,7 +748,7 @@ def test_store_yaml_partitions(module_under_test, tmp_path):
     TABLE_PART_ARGS[TABLE_PART_ARGS.index("-cdir") + 1] = str(folder_path)
 
     # Generate dummy YAML configs list
-    config_manager = _generate_config_manager("test_table")
+    config_manager = _generate_config_manager()
     config_managers = [config_manager]
 
     parser = cli_tools.configure_arg_parser()
@@ -759,7 +774,7 @@ def test_create_partition_query_yaml(module_under_test):
     and assert that the folder name, number of files and number of validations are what we would expect.
     """
     # Generate dummy YAML configs list
-    config_manager = _generate_config_manager(None)
+    config_manager = _generate_config_manager(query="Select 1")
     config_managers = [config_manager]
 
     parser = cli_tools.configure_arg_parser()

--- a/tests/unit/test_partition_builder.py
+++ b/tests/unit/test_partition_builder.py
@@ -689,6 +689,39 @@ def test_add_partition_filters_to_config(module_under_test):
     assert yaml_configs_list == expected_yaml_configs_list
 
 
+def test_add_partition_filters_to_multiple_configs(module_under_test):
+    """Add partition filters to 2 ConfigManager objects, build YAML config list
+    and assert YAML configs. Generally we don't expect users to invoke generate-table-partitions with
+    multiple table pairs from command line, where both pairs have the same primary key, columns to validate,
+    number of partitions and partitions per file. DVT can add the same partition_filters to multiple configs
+    because the validation for a table with numerous columns had to be split into multiple validations performeed serially.
+    Each validation has its own config with fewer columns which can be successfully validated.
+    This test addresses issue 1549.
+    """
+    # Generate dummy YAML configs list
+    config_manager = _generate_config_manager("test_table")
+    config_managers = [config_manager, config_manager]
+
+    parser = cli_tools.configure_arg_parser()
+    mock_args = parser.parse_args(TABLE_PART_ARGS)
+
+    # two partition filters are needed, one for source and one for target
+    master_filter_list = []
+    for i in range(len(config_managers)):
+        master_filter_list.append([PARTITION_FILTERS_LIST, PARTITION_FILTERS_LIST])
+
+    # Create PartitionBuilder object and get YAML configs list
+    builder = module_under_test.PartitionBuilder(config_managers, mock_args)
+    yaml_configs_list = builder._add_partition_filters(master_filter_list)
+
+    # There were nine validations with one table, there should be 18 now.
+    num_val = 0
+    for yaml_config in yaml_configs_list:
+        for yaml_file in yaml_config["yaml_files"]:
+            num_val = num_val + len(yaml_file["yaml_config"]["validations"])
+    assert num_val == 18
+
+
 def test_store_yaml_partitions(module_under_test, tmp_path):
     """Store all the Partition YAMLs for a table to specified local directory"""
 


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to DVT!

Please ensure that your pull request title matches the conventional commits
specification: https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md#conventional-commits
-->

## Description of changes
Fixed generate-table-partitions to produce correct yaml when multiple sets of tables are used, e.g. `-tbls=a=b,c=d`. Customer invoking the command in this way is likely to be rare. DVT creates this situation when a table with numerous columns is validated - that gets split into multiple validations, where the table pairs are the same, but the column list is different.

This PR includes minor functionality change. As stated in [PR 1428](https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1428), when generate-table-partitions is invoked with a custom query a random directory name is generated. With this PR, the directory name is no longer random, but a function of the 5 letter hash of the source query. This ensure that when we receive a custom query the directory name is pre-determined. This PR uses that "pre-determined" name to decide where to add the second validation for the same query/table.

## Issues to be closed
Closes #1549

<!--
For example, if your pull requests resolves multiple issues, such as 1000 and 2000 write:
* Closes #1000
* Closes #2000
-->

## Checklist

- [X] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated any relevant documentation to reflect my changes, if applicable
- [X] I have added unit and/or integration tests relevant to my change as needed
- [X] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [X] I have manually executed end-to-end testing (E2E) with the affected databases/engines


