### PR TITLE
feat: Reinstate support for SQLAlchemy url for Oracle connections

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -321,14 +321,6 @@ def get_data_client(connection_config):
                 key_path
             )
 
-    # Oracle no longer supports the url option, so check and warn users
-    if (
-        source_type == consts.SOURCE_TYPE_ORACLE
-        and "url" in decrypted_connection_config
-    ):
-        msg = f"Connection Configuration Error: url parameter no longer supported for {source_type}.\nRecreate connection with --connect-args parameter."
-        raise Exception(msg)
-
     if source_type not in CLIENT_LOOKUP:
         msg = 'ConfigurationError: Source type "{source_type}" is not supported'.format(
             source_type=source_type

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -199,7 +199,20 @@ data-validation connections add
     [--password PASSWORD]                               Oracle password
     [--database DATABASE]                               Oracle database
     [--connect-args CONNECT_PARAMS]                     Additional oracledb ConnectParams, JSON String dict
+    [--url URL]                                         SQLAlchemy connection URL
 ```
+
+### --url note
+
+Note that the `--url` option allows specification of a SQLAlchemy URL, not an Oracle Easy Connect URL. This can be used to supply oracledb parameters inline, for example:
+```
+"oracle+oracledb://dvt_user:dvt_user@localhost:1521/?service_name=pdb1&disable_oob=true"
+```
+or in conjunction with `--connect-args` to combine a SQLAlchemy URL and additional oracledb parameters, for example:
+```
+{"source_type": "Oracle", "url": "oracle+oracledb://dvt_user:dvt_user@localhost:1521/?service_name=pdb1", "connect_args": "{\"disable_oob\": true}"}
+```
+See [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/20/dialects/oracle.html#module-sqlalchemy.dialects.oracle.oracledb) for additional details. You may also use `--thick-mode` with the `--url` option.
 
 ### Oracle User permissions to run DVT
 
@@ -208,7 +221,7 @@ data-validation connections add
 * Optional - Read on SYS.V_$TRANSACTION (required to get isolation level, if privilege is not given then will default to Read Committed, [more_details](https://docs.sqlalchemy.org/en/14/dialects/oracle.html#transaction-isolation-level-autocommit))
 
 ### Additional Connect parameters, using TLS, mTLS connections and running DVT within a container
-oracledb supports a large number of connection parameters documented as [ConnectParams](https://python-oracledb.readthedocs.io/en/latest/api_manual/connect_params.html#ConnectParams.set). Any of these params can be set by providing the `--connect-args` as a python dict. 
+oracledb supports a large number of connection parameters documented as [ConnectParams](https://python-oracledb.readthedocs.io/en/latest/api_manual/connect_params.html#ConnectParams.set). Any of these params can be set by providing the `--connect-args` as a python dict.
 
 For setting up a TLS connection, specify the configuration directory where `tnsnames.ora` is located, the wallet directory where `ewallet.pem` is located and the distinguished name of the server used when creating the certificate. The protocol, host, port and service_name are best specified in `tnsnames.ora` as they take precedence. For example, the `--connect-args` parameter can be specified as follows:
 
@@ -404,7 +417,7 @@ data-validation connections add
     --user USER                                         DB2 user
     --password PASSWORD                                 DB2 password
     --database DATABASE                                 DB2 database
-    [--url URL]                                         URL link in DB2 to connect to
+    [--url URL]                                         SQLAlchemy connection URL
     [--driver DRIVER]                                   DB2 driver, defaults to "ibm_db_sa"
 ```
 

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -50,14 +50,21 @@ ORACLE_HOST = os.getenv("ORACLE_HOST", "localhost")
 ORACLE_PORT = os.getenv("ORACLE_PORT", "1521")
 ORACLE_PASSWORD = os.getenv("ORACLE_PASSWORD")
 ORACLE_DATABASE = os.getenv("ORACLE_DATABASE", "XEPDB1")
+ORACLE_USER = "SYSTEM"
 
 CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_ORACLE,
     "host": ORACLE_HOST,
-    "user": "SYSTEM",
+    "user": ORACLE_USER,
     "password": ORACLE_PASSWORD,
     "port": int(ORACLE_PORT),
     "database": ORACLE_DATABASE,
+}
+CONN_BY_URL = {
+    consts.SOURCE_TYPE: consts.SOURCE_TYPE_ORACLE,
+    consts.SECRET_MANAGER_TYPE: None,
+    consts.SECRET_MANAGER_PROJECT_ID: None,
+    "url": f"oracle+oracledb://{ORACLE_USER}:{ORACLE_PASSWORD}@{ORACLE_HOST}:{ORACLE_PORT}/?service_name={ORACLE_DATABASE}",
 }
 
 
@@ -152,6 +159,8 @@ def test_count_validator():
 def mock_get_connection_config(*args):
     if args[1] in ("ora-conn", "mock-conn"):
         return CONN
+    elif args[1] == "ora-url-conn":
+        return CONN_BY_URL
     elif args[1] == "bq-conn":
         return BQ_CONN
     elif args[1] == "pg-conn":
@@ -1289,6 +1298,18 @@ def test_row_validation_intervals():
         tables="pso_data_validator.dvt_intervals",
         tc="bq-conn",
         hash="col_interval_ds,col_interval_ym",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_schema_validation_by_url():
+    """Oracle to Oracle validation testing connection by URL string works."""
+    schema_validation_test(
+        tables="pso_data_validator.dvt_core_types",
+        tc="ora-url-conn",
     )
 
 

--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -131,7 +131,7 @@ class Backend(BaseAlchemyBackend):
         else:
             connect_args = {} if not connect_args else connect_args
             if thick_mode:
-                # Configuration explicitly requests thick_mode or user not specified, credentials in wallet - requires thick_mode
+                # Configuration explicitly requests thick_mode.
                 oracledb.init_oracle_client(
                     config_dir=connect_args.get("config_dir", None)
                 )

--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Literal, Tuple, Dict, Any
+from typing import Iterable, Literal, Optional, Tuple, Dict, Any
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.oracle.base import (
@@ -97,35 +97,48 @@ class Backend(BaseAlchemyBackend):
     def do_connect(
         self,
         host: str = "localhost",
-        user: str = None,
-        password: str = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
         port: int = 1521,
-        database: str = None,
+        database: Optional[str] = None,
         protocol: str = "TCP",
         thick_mode: bool = False,
         driver: Literal["oracledb"] = "oracledb",
         connect_args: Dict[str, Any] = None,
+        url: Optional[str] = None,
     ) -> None:
         if driver != "oracledb":
             raise NotImplementedError("oracledb is currently the only supported driver")
-        if thick_mode or not user:
-            # Configuration explicitly requests thick_mode or user not specified, credentials in wallet - requires thick_mode
-            oracledb.init_oracle_client(config_dir=connect_args.get("config_dir", None))
-        connect_args = {} if not connect_args else connect_args
-        if user:
-            connect_args.update(
-                {
-                    "host": host,
-                    "user": user,
-                    "password": password,
-                    "port": port,
-                    "service_name": database,
-                    "protocol": protocol,
-                }
-            )
+        if url is None:
+            if thick_mode or not user:
+                # Configuration explicitly requests thick_mode or user not specified, credentials in wallet - requires thick_mode
+                oracledb.init_oracle_client(
+                    config_dir=connect_args.get("config_dir", None)
+                )
+            connect_args = {} if not connect_args else connect_args
+            if user:
+                connect_args.update(
+                    {
+                        "host": host,
+                        "user": user,
+                        "password": password,
+                        "port": port,
+                        "service_name": database,
+                        "protocol": protocol,
+                    }
+                )
+            sa_url = "oracle+oracledb://@"
+        else:
+            connect_args = {} if not connect_args else connect_args
+            if thick_mode:
+                # Configuration explicitly requests thick_mode or user not specified, credentials in wallet - requires thick_mode
+                oracledb.init_oracle_client(
+                    config_dir=connect_args.get("config_dir", None)
+                )
+            sa_url = sa.engine.url.make_url(url)
 
         engine = sa.create_engine(
-            "oracle+oracledb://@",
+            sa_url,
             poolclass=sa.pool.StaticPool,
             arraysize=self.arraysize,
             # The hardcoding of 128 below is not great but is the simplest way of dealing with:

--- a/third_party/ibis/ibis_oracle/api.py
+++ b/third_party/ibis/ibis_oracle/api.py
@@ -29,6 +29,7 @@ def oracle_connect(
     thick_mode: bool = False,
     driver: Literal["oracledb"] = "oracledb",
     connect_args: str = None,
+    url: str = None,
 ):
     connect_args_dict = dvt_config_string_to_dict(connect_args) if connect_args else {}
     backend = OracleBackend()
@@ -42,5 +43,6 @@ def oracle_connect(
         thick_mode=thick_mode,
         driver=driver,
         connect_args=connect_args_dict,
+        url=url,
     )
     return backend


### PR DESCRIPTION
## Description of changes
As part of our switch from cx_Oracle to oracledb we disabled use of a SQLAlchemy URL for Oracle connections.

I recently found out that one of our larger customers makes extensive use of connections by url. They store the url, with username/password/service name as a secret in Secret Manager and pull the url at run time.

This PR reinstates connection to oracle via url and adds a test.

## Issues to be closed
Closes #1564


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


