### PR TITLE
fix: Remove logging.error call when Db2 driver is missing

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -69,20 +69,20 @@ def _raise_missing_client_error(msg):
 # Teradata requires teradatasql and licensing
 try:
     from third_party.ibis.ibis_teradata.api import teradata_connect
-except Exception:
+except ImportError:
     msg = "pip install teradatasql (requires Teradata licensing)"
     teradata_connect = _raise_missing_client_error(msg)
 
 # Oracle requires python-oracldb driver
 try:
     from third_party.ibis.ibis_oracle.api import oracle_connect
-except Exception:
+except ImportError:
     oracle_connect = _raise_missing_client_error("pip install oracledb")
 
 # Snowflake requires snowflake-connector-python and snowflake-sqlalchemy
 try:
     from third_party.ibis.ibis_snowflake.api import snowflake_connect
-except Exception:
+except ImportError:
     snowflake_connect = _raise_missing_client_error(
         "pip install snowflake-connector-python && pip install snowflake-sqlalchemy"
     )
@@ -90,8 +90,7 @@ except Exception:
 # DB2 requires ibm_db_sa
 try:
     from third_party.ibis.ibis_db2.api import db2_connect
-except Exception as e:
-    logging.error(f"Exception {str(e)} while importing db2_connect")
+except ImportError:
     db2_connect = _raise_missing_client_error("pip install ibm_db_sa")
 
 


### PR DESCRIPTION
## Description of changes
This PR removes a logging.error call when Db2 driver is missing. All customers were seeing this message whether they intended to use Db2 or not so we decided it is better not to see it.

## Issues to be closed

Closes #1566

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


