### PR TITLE
test: Add DDL for PostgreSQL test tables and move them to pso_data_validator schema

### DIFF
--- a/data_validation/__init__.py
+++ b/data_validation/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 
-__version__ = get_distribution("google-pso-data-validator").version
+__version__ = version("google-pso-data-validator")
 __all__ = ["__version__"]

--- a/tests/resources/postgresql_test_tables.sql
+++ b/tests/resources/postgresql_test_tables.sql
@@ -16,6 +16,45 @@
 CREATE SCHEMA IF NOT EXISTS pso_data_validator_results;
 -- Schema containing ONLY integration test tables.
 CREATE SCHEMA IF NOT EXISTS pso_data_validator;
+
+DROP TABLE IF EXISTS pso_data_validator.entries CASCADE;
+CREATE TABLE pso_data_validator.entries
+( guestname character varying(255)
+, content   character varying(255)
+, entryid   integer NOT NULL);
+INSERT INTO pso_data_validator.entries VALUES
+ ('Madeline','Arrived',1)
+,('Annie','Me too!',2)
+,('Bob','More data coming',3)
+,('Joe','Me too!',4)
+,('John','Here!',5)
+,('Alex','Me too!',6)
+,('Zoe','Same!',7);
+
+DROP TABLE IF EXISTS pso_data_validator.test_data_types_postgres_row;
+CREATE TABLE pso_data_validator.test_data_types_postgres_row
+( serial_col    serial PRIMARY KEY
+, int_col       integer
+, text_col      text
+, char_col      character(1)
+, varchar_col   character varying
+, float_col     double precision
+, numeric_col   numeric(5,2)
+, timestamp_col timestamp without time zone
+, date_col      date);
+
+INSERT INTO pso_data_validator.test_data_types_postgres_row VALUES
+(1,10,'row1_text',1,'row1_varchar',10.1,10.10,'2016-06-22 19:10:25','2020-01-01'),
+(2,20,'row2_text',2,'row2_varchar',20.2,20.20,'2016-06-22 19:20:25','2020-02-02'),
+(3,30,'row3_text',3,'row3_varchar',30.2,30.20,'2016-06-22 19:30:25','2020-03-03'),
+(4,40,'row4_text',4,'row4_varchar',40.2,40.40,'2016-06-22 19:30:45','2020-04-04'),
+(5,50,'row5_text',5,'row5_varchar',50.2,50.40,'2016-06-22 19:50:44','2020-05-05'),
+(6,60,'row6_text',6,'row6_varchar',60.2,60.40,'2016-01-22 19:51:44','2020-06-06'),
+(7,70,'row7_text',7,'row7_varchar',70.2,70.40,'2017-01-22 19:51:44','2020-06-07'),
+(8,80,'row8_text',8,'row8_varchar',80.2,80.40,'2018-01-22 19:51:44','2020-06-08'),
+(9,90,'row9_text',9,'row9_varchar',90.2,90.40,'2019-01-22 19:51:44','2020-06-09'),
+(10,100,'row10_text',1,'row10_varchar',100.2,100.40,'2020-01-22 19:51:44','2021-06-09');
+
 DROP TABLE IF EXISTS pso_data_validator.dvt_core_types CASCADE;
 CREATE TABLE pso_data_validator.dvt_core_types
 (   id              int NOT NULL PRIMARY KEY

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -47,7 +47,8 @@ from tests.system.result_handlers.test_bigquery import create_bigquery_results_t
 
 
 PROJECT_ID = os.environ["PROJECT_ID"]
-os.environ[consts.ENV_DIRECTORY_VAR] = f"gs://{PROJECT_ID}/integration_tests/"
+TEST_BUCKET = os.environ.get("TEST_BUCKET", PROJECT_ID)
+os.environ[consts.ENV_DIRECTORY_VAR] = f"gs://{TEST_BUCKET}/integration_tests/"
 BQ_CONN = {consts.SOURCE_TYPE: consts.SOURCE_TYPE_BIGQUERY, "project_id": PROJECT_ID}
 CONFIG_COUNT_VALID = {
     # BigQuery Specific Connection Name
@@ -247,7 +248,7 @@ CONFIG_NUMERIC_AGG_VALID = {
 
 BQ_CONN_NAME = "bq-integration-test"
 CLI_CONFIG_FILE = "example_test.yaml"
-CLI_CONFIG_FILE_GCS = "gs://" + PROJECT_ID + "/system_test/example_test.yaml"
+CLI_CONFIG_FILE_GCS = f"gs://{TEST_BUCKET}/system_test/example_test.yaml"
 
 BQ_CONN_ARGS = [
     "connections",
@@ -539,7 +540,7 @@ def test_cli_store_yaml_then_run_local():
 )
 def test_cli_store_yaml_then_run_directory_gcs(mock_conn):
     """Test storing, retrieving, and executing two validation YAMLs in a provided GCS directory path."""
-    bucket_name = f"gs://{PROJECT_ID}"
+    bucket_name = f"gs://{TEST_BUCKET}"
     yaml_file_name1 = "system_test/test_dir/example_dir1.yaml"
     yaml_file_name2 = "system_test/test_dir/example_dir2.yaml"
 
@@ -576,7 +577,7 @@ def test_cli_store_yaml_then_run_directory_gcs(mock_conn):
             "configs",
             "run",
             "--config-dir",
-            "gs://pso-kokoro-resources/system_test/test_dir",
+            f"gs://{TEST_BUCKET}/system_test/test_dir",
         ]
     )
     main.config_runner(run_config_args)

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -162,7 +162,7 @@ def test_postgres_count(cloud_sql):
         # Validation Type
         consts.CONFIG_TYPE: "Column",
         # Configuration Required Depending on Validator Type
-        consts.CONFIG_SCHEMA_NAME: "public",
+        consts.CONFIG_SCHEMA_NAME: "pso_data_validator",
         consts.CONFIG_TABLE_NAME: "entries",
         consts.CONFIG_AGGREGATES: [
             {
@@ -206,7 +206,7 @@ def test_postgres_row(cloud_sql):
         # Validation Type
         consts.CONFIG_TYPE: "Row",
         # Configuration Required Depending on Validator Type
-        consts.CONFIG_SCHEMA_NAME: "public",
+        consts.CONFIG_SCHEMA_NAME: "pso_data_validator",
         consts.CONFIG_TABLE_NAME: "test_data_types_postgres_row",
         consts.CONFIG_COMPARISON_FIELDS: [
             {
@@ -582,7 +582,7 @@ def test_schema_validation(cloud_sql):
         consts.CONFIG_SOURCE_CONN: CONN,
         consts.CONFIG_TARGET_CONN: CONN,
         consts.CONFIG_TYPE: "Schema",
-        consts.CONFIG_SCHEMA_NAME: "public",
+        consts.CONFIG_SCHEMA_NAME: "pso_data_validator",
         consts.CONFIG_TABLE_NAME: "entries",
         consts.CONFIG_FORMAT: consts.FORMAT_TYPE_TABLE,
         consts.CONFIG_FILTER_STATUS: None,


### PR DESCRIPTION
## Description of changes
Adding some missing test table DDL that was preventing me from running tests in my own project.

Also parameterized the bucket used in BigQuery tests.

Also changed version identification code in `__init__.py` to prevent a warning from using a deprecated package.

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1574


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


