### PR TITLE
fix: Fix BigQuery byte length expression

### DIFF
--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -402,6 +402,21 @@ def test_column_validation_oracle_to_postgres():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_column_validation_binary_to_bigquery():
+    """Oracle to BigQuery dvt_binary column validation."""
+    column_validation_test(
+        tables="pso_data_validator.dvt_binary",
+        tc="bq-conn",
+        count_cols="binary_id",
+        min_cols="binary_id",
+        sum_cols="binary_id",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_column_validation_large_decimals_to_bigquery():
     """Oracle to BigQuery dvt_large_decimals column validation."""
     cols = "col_dec_18,col_dec_38,col_dec_38_9,col_dec_38_30"

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -48,10 +48,7 @@ from ibis.backends.bigquery.client import (
     _LEGACY_TO_STANDARD as _BQ_LEGACY_TO_STANDARD,
 )
 from ibis.backends.bigquery.compiler import BigQueryExprTranslator
-from ibis.backends.bigquery.registry import (
-    STRFTIME_FORMAT_FUNCTIONS as BQ_STRFTIME_FORMAT_FUNCTIONS,
-    bigquery_cast,
-)
+from ibis.backends.bigquery.registry import bigquery_cast
 from ibis.backends.impala.compiler import ImpalaExprTranslator
 from ibis.backends.mssql.compiler import MsSqlExprTranslator
 from ibis.backends.mysql.compiler import MySQLExprTranslator
@@ -62,6 +59,7 @@ from ibis.expr.types import BinaryValue, NumericValue, StringValue, TemporalValu
 
 # Do not remove these lines, they trigger patching of Ibis code.
 import third_party.ibis.ibis_bigquery.api  # noqa
+from third_party.ibis.ibis_bigquery import registry as bigquery_registry
 import third_party.ibis.ibis_mysql.compiler  # noqa
 from third_party.ibis.ibis_mssql import registry as mssql_registry
 from third_party.ibis.ibis_postgres import registry as postgres_registry
@@ -154,24 +152,6 @@ def bigquery_cast_to_binary_generate(compiled_arg, from_, to):
     return f"FROM_HEX({compiled_arg})"
 
 
-def format_hash_bigquery(translator, op):
-    arg = translator.translate(op.arg)
-    if op.how == "farm_fingerprint":
-        return f"FARM_FINGERPRINT({arg})"
-    else:
-        raise ValueError(f"unexpected value for 'how': {op.how}")
-
-
-def format_hashbytes_bigquery(translator, op):
-    arg = translator.translate(op.arg)
-    if op.how == "sha256":
-        return f"TO_HEX(SHA256({arg}))"
-    elif op.how == "farm_fingerprint":
-        return f"FARM_FINGERPRINT({arg})"
-    else:
-        raise ValueError(f"unexpected value for 'how': {op.how}")
-
-
 def format_hashbytes_teradata(translator, op):
     arg = translator.translate(op.arg)
     if op.how == "sha256":
@@ -182,30 +162,6 @@ def format_hashbytes_teradata(translator, op):
         return f"rtrim(hash_md5({arg}))"
     else:
         raise ValueError(f"unexpected value for 'how': {op.how}")
-
-
-def strftime_bigquery(translator, op):
-    """Timestamp formatting."""
-    arg = op.arg
-    format_str = op.format_str
-    arg_type = arg.output_dtype
-    strftime_format_func_name = BQ_STRFTIME_FORMAT_FUNCTIONS[type(arg_type)]
-    fmt_string = translator.translate(format_str)
-    # Deal with issue 1181 due a GoogleSQL bug with dates before 1000 CE affects both date and timestamp types
-    if format_str.value.startswith("%Y"):
-        fmt_string = fmt_string.replace("%Y", "%E4Y", 1)
-    arg_formatted = translator.translate(arg)
-    if isinstance(arg_type, dt.Timestamp):
-        return "FORMAT_{}({}, {}({}), {!r})".format(
-            strftime_format_func_name,
-            fmt_string,
-            strftime_format_func_name,
-            arg_formatted,
-            arg_type.timezone if arg_type.timezone is not None else "UTC",
-        )
-    return "FORMAT_{}({}, {})".format(
-        strftime_format_func_name, fmt_string, arg_formatted
-    )
 
 
 def strftime_mysql(translator, op):
@@ -528,10 +484,10 @@ TemporalValue.to_char = compile_to_char
 # so we can piggy back Ibis code rather than writing metadata queries for all engines.
 BaseAlchemyBackend.dvt_list_tables = _dvt_list_tables
 
-BigQueryExprTranslator._registry[ops.HashBytes] = format_hashbytes_bigquery
+BigQueryExprTranslator._registry[ops.HashBytes] = bigquery_registry.format_hashbytes
 BigQueryExprTranslator._registry[RawSQL] = format_raw_sql
-BigQueryExprTranslator._registry[ops.Strftime] = strftime_bigquery
-BigQueryExprTranslator._registry[BinaryLength] = sa_format_binary_length
+BigQueryExprTranslator._registry[ops.Strftime] = bigquery_registry.strftime
+BigQueryExprTranslator._registry[BinaryLength] = bigquery_registry.format_binary_length
 
 AlchemyExprTranslator._registry[RawSQL] = format_raw_sql
 AlchemyExprTranslator._registry[ops.HashBytes] = format_hashbytes_alchemy
@@ -614,7 +570,7 @@ if Db2ExprTranslator:
     ]
 
 SpannerExprTranslator._registry[RawSQL] = format_raw_sql
-SpannerExprTranslator._registry[ops.HashBytes] = format_hashbytes_bigquery
+SpannerExprTranslator._registry[ops.HashBytes] = bigquery_registry.format_hashbytes
 SpannerExprTranslator._registry[BinaryLength] = sa_format_binary_length
 
 if TeradataExprTranslator:

--- a/third_party/ibis/ibis_bigquery/registry.py
+++ b/third_party/ibis/ibis_bigquery/registry.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ibis.backends.bigquery.registry import (
+    STRFTIME_FORMAT_FUNCTIONS as BQ_STRFTIME_FORMAT_FUNCTIONS,
+)
+import ibis.expr.datatypes as dt
+
+
+def format_hashbytes(translator, op):
+    arg = translator.translate(op.arg)
+    if op.how == "sha256":
+        return f"TO_HEX(SHA256({arg}))"
+    elif op.how == "farm_fingerprint":
+        return f"FARM_FINGERPRINT({arg})"
+    else:
+        raise ValueError(f"unexpected value for 'how': {op.how}")
+
+
+def strftime(translator, op):
+    """Timestamp formatting."""
+    arg = op.arg
+    format_str = op.format_str
+    arg_type = arg.output_dtype
+    strftime_format_func_name = BQ_STRFTIME_FORMAT_FUNCTIONS[type(arg_type)]
+    fmt_string = translator.translate(format_str)
+    # Deal with issue 1181 due a GoogleSQL bug with dates before 1000 CE affects both date and timestamp types
+    if format_str.value.startswith("%Y"):
+        fmt_string = fmt_string.replace("%Y", "%E4Y", 1)
+    arg_formatted = translator.translate(arg)
+    if isinstance(arg_type, dt.Timestamp):
+        return "FORMAT_{}({}, {}({}), {!r})".format(
+            strftime_format_func_name,
+            fmt_string,
+            strftime_format_func_name,
+            arg_formatted,
+            arg_type.timezone if arg_type.timezone is not None else "UTC",
+        )
+    return "FORMAT_{}({}, {})".format(
+        strftime_format_func_name, fmt_string, arg_formatted
+    )
+
+
+def format_binary_length(translator, op):
+    arg = translator.translate(op.arg)
+    return f"LENGTH({arg})"

--- a/third_party/ibis/ibis_db2/__init__.py
+++ b/third_party/ibis/ibis_db2/__init__.py
@@ -104,7 +104,7 @@ class Backend(BaseAlchemyBackend):
 
     def raw_column_metadata_not_implemented(
         self, database: str = None, table: str = None, query: str = None
-    ) -> list[Tuple]:
+    ) -> list:
         """Define this method to allow DVT to test if backend specific transformations may be needed for comparison.
         Partner method to _metadata that retains raw data type information instead of converting
         to Ibis types.  This works in the same way as _metadata by running a query over the DVT
@@ -117,7 +117,7 @@ class Backend(BaseAlchemyBackend):
             list: A list of tuples containing the standard 7 DB API fields:
                   https://peps.python.org/pep-0249/#description
         """
-        return ()
+        return []
 
     def is_char_type_padded(self, char_type: Tuple) -> bool:
         """Define this method if the backend supports character/string types that are padded and returns


### PR DESCRIPTION
## Description of changes
Fixes the byte length expression for BigQuery.

I discovered this while doing some SQL Server testing but felt it should be fixed in an independent issue.

I also took the opportunity to move some BigQuery code out of `operations.py` and into a specific BigQuery `registry.py`.

## Issues to be closed

Closes #1580

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


