### PR TITLE
fix: Fix formatting of bit columns in row validations

### DIFF
--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -585,8 +585,6 @@ def test_row_validation_ss_types_to_bigquery():
                 "id",
                 # Excluded col_float32 because BigQuery does not have a float32 type.
                 "col_float32",
-                # TODO Remove col_bit from exclude list when working on - issue-1583
-                "col_bit",
                 # TODO Remove money types from exclude list when working on - issue-1582
                 "col_money",
                 "col_smallmoney",

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -574,6 +574,38 @@ def test_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_row_validation_comp_fields_ss_types_to_bigquery():
+    """SQL Server to BigQuery extended data type row validation using comparison fields"""
+    cols = ",".join(
+        [
+            _
+            for _ in DVT_SS2BQ_COLUMNS
+            if _
+            not in (
+                "id",
+                # Excluded col_float32 because BigQuery does not have a float32 type.
+                "col_float32",
+                # TODO Remove money types from exclude list when working on - issue-1582
+                "col_money",
+                "col_smallmoney",
+                # binary columns are excluded below because SQL Server right pads varbinary
+                # values to the length. Not very VARbinary!
+                "col_varbinary",
+                "col_varbinary_max",
+            )
+        ]
+    )
+    row_validation_test(
+        tables="pso_data_validator.dvt_sql_server_types",
+        tc="bq-conn",
+        comp_fields=cols,
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_row_validation_ss_types_to_bigquery():
     """SQL Server to BigQuery extended data type row validation"""
     cols = ",".join(

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -585,6 +585,8 @@ def test_row_validation_comp_fields_ss_types_to_bigquery():
                 "id",
                 # Excluded col_float32 because BigQuery does not have a float32 type.
                 "col_float32",
+                # TODO Include col_int1 in max_cols when working on issue-1585.
+                "col_int1",
                 # TODO Remove money types from exclude list when working on - issue-1582
                 "col_money",
                 "col_smallmoney",

--- a/third_party/ibis/ibis_mssql/registry.py
+++ b/third_party/ibis/ibis_mssql/registry.py
@@ -141,6 +141,12 @@ def sa_cast_mssql(t, op):
         formatted_value = sa.func.format(sa_arg, format_string)
         # Replace trailing '.0' with ''
         return sa.func.replace(formatted_value, ".0", "")
+    elif arg_dtype.is_boolean() and typ.is_string():
+        return sa.case(
+            (sa_arg == 0, sa.literal_column("'false'")),
+            (sa_arg == 1, sa.literal_column("'true'")),
+            else_=sa.null(),
+        )
 
     # Follow the original Ibis code path.
     return sa_fixed_cast(t, op)


### PR DESCRIPTION
## Description of changes
SQL Server bit is not converted to "true"/"false" in row validation when comparing with bool.

This PR fixes that issue and adds a comparison fields test to ensure it does not introduce a regression.

## Issues to be closed

Closes #1583


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


