### PR TITLE
feat: Enable --grouped-columns for validate custom-query column

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ data-validation
                         Either --target-query or --target-query-file must be provided
   --target-query-file TARGET_QUERY_FILE, -tqf TARGET_QUERY_FILE
                         File containing the target sql command. Supports GCS and local paths.
+  [--grouped-columns or -gc GROUPED_COLUMNS]
+                        Comma separated list of columns for Group By i.e col_a,col_b
   [--count COLUMNS]     Comma separated list of columns for count or * for all columns
   [--sum COLUMNS]       Comma separated list of columns for sum or * for all numeric
   [--min COLUMNS]       Comma separated list of columns for min or * for all numeric

--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -294,10 +294,7 @@ def build_config_from_args(args: "Namespace", config_manager: ConfigManager):
         and args.custom_query_type == consts.COLUMN_VALIDATION.lower()
     ):
         config_manager.append_aggregates(get_aggregate_config(args, config_manager))
-        if (
-            config_manager.validation_type == consts.COLUMN_VALIDATION
-            and args.grouped_columns  # grouped_columns not supported in custom queries - at least now.
-        ):
+        if args.grouped_columns:
             grouped_columns = cli_tools.get_arg_list(args.grouped_columns)
             config_manager.append_query_groups(
                 config_manager.build_column_configs(grouped_columns)

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -949,6 +949,11 @@ def _configure_custom_query_column_parser(custom_query_column_parser):
                 unreliable results.""",
     )
     optional_arguments.add_argument(
+        "--grouped-columns",
+        "-gc",
+        help="Comma separated list of columns to group results by, e.g. 'col_a,col_b'. Applies to column validations, including custom-query column.",
+    )
+    optional_arguments.add_argument(
         "--exclude-columns",
         "-ec",
         action="store_true",

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -1343,7 +1343,9 @@ def test_row_validation_core_types_auto_pks(mock_conn):
 )
 def test_custom_query_validation_core_types(mock_conn):
     """BigQuery to BigQuery dvt_core_types custom-query validation"""
-    custom_query_validation_test(tc="mock-conn", count_cols="*")
+    custom_query_validation_test(
+        tc="mock-conn", count_cols="*", grouped_columns="col_varchar_30"
+    )
 
 
 @mock.patch(

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -1059,6 +1059,15 @@ def test_arg_parser_validate_custom_query_row_help(capsys):
     assert "--primary-keys" in captured.out
 
 
+def test_arg_parser_validate_custom_query_column_help(capsys):
+    """Test validate custom-query column --help arg."""
+    parser = cli_tools.configure_arg_parser()
+    with pytest.raises(SystemExit):
+        _ = parser.parse_args(["validate", "custom-query", "column", "--help"])
+    captured = capsys.readouterr()
+    assert "--grouped-columns" in captured.out
+
+
 def test_arg_parser_generate_table_partitions_help(capsys):
     """Test generate-table-partitions --help arg."""
     parser = cli_tools.configure_arg_parser()

--- a/tests/unit/test_validation_builder.py
+++ b/tests/unit/test_validation_builder.py
@@ -188,32 +188,35 @@ def test_validation_add_groups(module_under_test):
 
 
 def test_custom_query_validation_add_groups(module_under_test):
-      mock_config_manager = ConfigManager(
-          CUSTOM_QUERY_VALIDATION_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
-      )
+    mock_config_manager = ConfigManager(
+        CUSTOM_QUERY_VALIDATION_CONFIG,
+        MockIbisClient(),
+        MockIbisClient(),
+        verbose=False,
+    )
   
-      custom_query_groups = [
-          {
-              consts.CONFIG_FIELD_ALIAS: "col1",
-              consts.CONFIG_SOURCE_COLUMN: "col1",
-              consts.CONFIG_TARGET_COLUMN: "col1",
-              consts.CONFIG_CAST: None,
-          },
-          {
-              consts.CONFIG_FIELD_ALIAS: "col2",
-              consts.CONFIG_SOURCE_COLUMN: "col2",
-              consts.CONFIG_TARGET_COLUMN: "col2",
-              consts.CONFIG_CAST: None,
-          },
-      ]
+    custom_query_groups = [
+        {
+            consts.CONFIG_FIELD_ALIAS: "col1",
+            consts.CONFIG_SOURCE_COLUMN: "col1",
+            consts.CONFIG_TARGET_COLUMN: "col1",
+            consts.CONFIG_CAST: None,
+        },
+        {
+            consts.CONFIG_FIELD_ALIAS: "col2",
+            consts.CONFIG_SOURCE_COLUMN: "col2",
+            consts.CONFIG_TARGET_COLUMN: "col2",
+            consts.CONFIG_CAST: None,
+        },
+    ]
   
-      builder = module_under_test.ValidationBuilder(mock_config_manager)
-      mock_config_manager.append_query_groups(custom_query_groups)
-      builder.add_config_query_groups()
+    builder = module_under_test.ValidationBuilder(mock_config_manager)
+    mock_config_manager.append_query_groups(custom_query_groups)
+    builder.add_config_query_groups()
   
-      assert list(builder.get_group_aliases()) == ["col1", "col2"]
-      assert builder.get_grouped_alias_source_column("col1") == "col1"
-      assert builder.get_grouped_alias_target_column("col2") == "col2"
+    assert list(builder.get_group_aliases()) == ["col1", "col2"]
+    assert builder.get_grouped_alias_source_column("col1") == "col1"
+    assert builder.get_grouped_alias_target_column("col2") == "col2"
 
 
 def test_column_validation_calculate(module_under_test):

--- a/tests/unit/test_validation_builder.py
+++ b/tests/unit/test_validation_builder.py
@@ -187,6 +187,35 @@ def test_validation_add_groups(module_under_test):
     assert list(builder.get_group_aliases()) == ["start_alias"]
 
 
+def test_custom_query_validation_add_groups(module_under_test):
+      mock_config_manager = ConfigManager(
+          CUSTOM_QUERY_VALIDATION_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False
+      )
+  
+      custom_query_groups = [
+          {
+              consts.CONFIG_FIELD_ALIAS: "col1",
+              consts.CONFIG_SOURCE_COLUMN: "col1",
+              consts.CONFIG_TARGET_COLUMN: "col1",
+              consts.CONFIG_CAST: None,
+          },
+          {
+              consts.CONFIG_FIELD_ALIAS: "col2",
+              consts.CONFIG_SOURCE_COLUMN: "col2",
+              consts.CONFIG_TARGET_COLUMN: "col2",
+              consts.CONFIG_CAST: None,
+          },
+      ]
+  
+      builder = module_under_test.ValidationBuilder(mock_config_manager)
+      mock_config_manager.append_query_groups(custom_query_groups)
+      builder.add_config_query_groups()
+  
+      assert list(builder.get_group_aliases()) == ["col1", "col2"]
+      assert builder.get_grouped_alias_source_column("col1") == "col1"
+      assert builder.get_grouped_alias_target_column("col2") == "col2"
+
+
 def test_column_validation_calculate(module_under_test):
     mock_config_manager = ConfigManager(
         COLUMN_VALIDATION_CONFIG, MockIbisClient(), MockIbisClient(), verbose=False

--- a/tests/unit/test_validation_builder.py
+++ b/tests/unit/test_validation_builder.py
@@ -194,7 +194,7 @@ def test_custom_query_validation_add_groups(module_under_test):
         MockIbisClient(),
         verbose=False,
     )
-  
+
     custom_query_groups = [
         {
             consts.CONFIG_FIELD_ALIAS: "col1",
@@ -209,11 +209,11 @@ def test_custom_query_validation_add_groups(module_under_test):
             consts.CONFIG_CAST: None,
         },
     ]
-  
+
     builder = module_under_test.ValidationBuilder(mock_config_manager)
     mock_config_manager.append_query_groups(custom_query_groups)
     builder.add_config_query_groups()
-  
+
     assert list(builder.get_group_aliases()) == ["col1", "col2"]
     assert builder.get_grouped_alias_source_column("col1") == "col1"
     assert builder.get_grouped_alias_target_column("col2") == "col2"


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to DVT!

Please ensure that your pull request title matches the conventional commits
specification: https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md#conventional-commits
-->

## Description of changes
_Write a description of the changes you have made in this PR. Extremely small changes such as fixing typos do not need a description._

`--grouped-columns` into the custom-query column parser and accept comma-separated values. and, some unit tests 🤗 

cc. @nj1973 

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1439

<!--
For example, if your pull requests resolves multiple issues, such as 1000 and 2000 write:
* Closes #1000
* Closes #2000
-->

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


