### PR TITLE
fix: Support Time data type as primary key for generate-table-partitions, Teradata

### DIFF
--- a/third_party/ibis/ibis_teradata/registry.py
+++ b/third_party/ibis/ibis_teradata/registry.py
@@ -352,6 +352,8 @@ def _literal(t, op):
     dtype = op.output_dtype
     if dtype.is_string():
         return _string_literal_format(t, op)
+    elif dtype.is_time():  # The base backend does not have a renderer for TIME Literals
+        return f"TIME '{op.value.isoformat()}'"
     else:
         return ibis_literal(t, op)
 


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to DVT!

Please ensure that your pull request title matches the conventional commits
specification: https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md#conventional-commits
-->

## Description of changes
This fix supports Time Data Type as a primary key for generate-table-partitions, for Teradata

## Issues to be closed
Closes #1576 
<!--
For example, if your pull requests resolves multiple issues, such as 1000 and 2000 write:
* Closes #1000
* Closes #2000
-->

## Checklist

- [X] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated any relevant documentation to reflect my changes, if applicable
- [X] I have added unit and/or integration tests relevant to my change as needed
- [X] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [X] I have manually executed end-to-end testing (E2E) with the affected databases/engines


