### PR TITLE
fix: Cast SQL Server len() expression to BIGINT

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -303,7 +303,9 @@ def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
-    _setup_session_requirements(session, extra_packages=["ibm-db-sa<0.4.2", "ibm-db<3.2.7"])
+    _setup_session_requirements(
+        session, extra_packages=["ibm-db-sa<0.4.2", "ibm-db<3.2.7"]
+    )
 
     expected_env_vars = [
         "PROJECT_ID",

--- a/noxfile.py
+++ b/noxfile.py
@@ -303,7 +303,7 @@ def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
-    _setup_session_requirements(session, extra_packages=["ibm-db-sa<0.4.2"])
+    _setup_session_requirements(session, extra_packages=["ibm-db-sa<0.4.2", "ibm-db<3.2.7"])
 
     expected_env_vars = [
         "PROJECT_ID",

--- a/noxfile.py
+++ b/noxfile.py
@@ -279,8 +279,10 @@ def integration_snowflake(session):
     """Run Snowflake integration tests.
     Ensure Snowflake validation is running as expected.
     """
+    # TODO Remove pinned version below when working on issue-1592.
     _setup_session_requirements(
-        session, extra_packages=["snowflake-sqlalchemy", "snowflake-connector-python"]
+        session,
+        extra_packages=["snowflake-sqlalchemy==1.7.6", "snowflake-connector-python"],
     )
 
     expected_env_vars = [
@@ -303,6 +305,7 @@ def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
+    # TODO Remove dependency "ibm-db<3.2.7" below when working on issue-1591.
     _setup_session_requirements(
         session, extra_packages=["ibm-db-sa<0.4.2", "ibm-db<3.2.7"]
     )

--- a/third_party/ibis/ibis_mssql/registry.py
+++ b/third_party/ibis/ibis_mssql/registry.py
@@ -90,14 +90,19 @@ def sa_format_string_length(translator, op):
     This uses len() rather than datalength() to give an output compatible with BigQuery.
     We need to protect trailing spaces due to an odd quirk in SQL Server len()
     behaviour that ignores them, so this is done by first replacing spaces with
-    underscores before passing the string to len()."""
+    underscores before passing the string to len().
+
+    The len expression is cast to BIGINT to prevent int overflow for large tables."""
     arg = translator.translate(op.arg)
-    return sa.func.len(sa.func.replace(arg, " ", "_"))
+    return sa.func.cast(sa.func.len(sa.func.replace(arg, " ", "_")), sa.BIGINT)
 
 
 def sa_format_binary_length(translator, op):
+    """Calculate SQL Server bytes/string length in bytes, not characters.
+
+    The len expression is cast to BIGINT to prevent int overflow for large tables."""
     arg = translator.translate(op.arg)
-    return sa.func.datalength(arg)
+    return sa.func.cast(sa.func.datalength(arg), sa.BIGINT)
 
 
 def sa_format_hashbytes(translator, op):


### PR DESCRIPTION
## Description of changes
Casts SQL Server len/datalength expressions to bigint to prevent column validations on large tables from overflowing the int data type.

## Issues to be closed

Closes #1589

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


