### PR TITLE
fix: Remove implicit "connections" subdirectory from GCS connections path (PSO_DV_CONN_HOME)

### DIFF
--- a/data_validation/state_manager.py
+++ b/data_validation/state_manager.py
@@ -107,10 +107,7 @@ class StateManager(object):
 
     def _get_connections_directory(self) -> str:
         """Returns the connections directory path."""
-        if self.file_system == FileSystem.LOCAL:
-            return self.file_system_root_path
-
-        return os.path.join(self.file_system_root_path, "connections/")
+        return self.file_system_root_path
 
     def _get_connection_path(self, name: str) -> str:
         """Returns the full path to a connection.

--- a/tests/system/test_state_manager.py
+++ b/tests/system/test_state_manager.py
@@ -17,7 +17,7 @@ import pytest
 from data_validation import consts, gcs_helper, state_manager
 
 PROJECT_ID = os.getenv("PROJECT_ID")
-GCS_STATE_PATH = f"gs://{PROJECT_ID}/state/"
+GCS_STATE_PATH = f"gs://{PROJECT_ID}/state/connections/"
 TEST_CONN_NAME = "example"
 TEST_CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_BIGQUERY,

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -75,3 +75,12 @@ def test_create_unknown_filepath(capsys, fs):
     file_path = manager._get_connection_path(TEST_CONN_NAME)
     expected_file_path = files_directory + f"{TEST_CONN_NAME}.connection.json"
     assert file_path == expected_file_path
+
+
+def test_get_connections_directory_gcs(monkeypatch, fs):
+    # Avoid running setup_gcs in unit test
+    monkeypatch.setattr(state_manager.StateManager, "setup_gcs", lambda x: None)
+
+    manager = state_manager.StateManager("gs://some/path/")
+    conn_dir = manager._get_connections_directory()
+    assert conn_dir == "gs://some/path/"


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to DVT!

Please ensure that your pull request title matches the conventional commits
specification: https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md#conventional-commits
-->

## Description of changes
Always return file_system_root_path when resolving connections directory (remove special case for `LOCAL`)

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1596

<!--
For example, if your pull requests resolves multiple issues, such as 1000 and 2000 write:
* Closes #1000
* Closes #2000
-->

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


