### PR TITLE
fix: Lower case schema.table find-tables keys (if possible) when matching names

### DIFF
--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -71,10 +71,10 @@ def _get_table_map_from_obj_list(table_objs: list) -> dict:
         }
 
     # Post process table_map and lower case table_keys, if possible.
-    for table_key in [_ for _ in table_map if _ != _.lower()]:
+    for table_key in [_ for _ in table_map if _ != _.casefold()]:
         if table_key.lower() not in table_map:
             # Only lower case the key if there isn't one already.
-            table_map[table_key.lower()] = table_map.pop(table_key)
+            table_map[table_key.casefold()] = table_map.pop(table_key)
 
     return table_map
 

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -72,7 +72,7 @@ def _get_table_map_from_obj_list(table_objs: list) -> dict:
 
     # Post process table_map and lower case table_keys, if possible.
     for table_key in [_ for _ in table_map if _ != _.casefold()]:
-        if table_key.lower() not in table_map:
+        if table_key.casefold() not in table_map:
             # Only lower case the key if there isn't one already.
             table_map[table_key.casefold()] = table_map.pop(table_key)
 

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -60,15 +60,9 @@ def _compare_match_tables(source_table_map, target_table_map, score_cutoff=0.8) 
     return table_configs
 
 
-def _get_table_map(
-    client: "ibis.backends.base.BaseBackend", allowed_schemas=None, include_views=False
-):
-    """Return dict with searchable keys for table matching."""
+def _get_table_map_from_obj_list(table_objs: list) -> dict:
+    """Convert list of schema, table tuples into dict with searchable keys for table matching."""
     table_map = {}
-    table_objs = clients.get_all_tables(
-        client, allowed_schemas=allowed_schemas, tables_only=(not include_views)
-    )
-
     for table_obj in table_objs:
         table_key = ".".join([t for t in table_obj if t])
         table_map[table_key] = {
@@ -76,7 +70,23 @@ def _get_table_map(
             consts.CONFIG_TABLE_NAME: table_obj[1],
         }
 
+    # Post process table_map and lower case table_keys, if possible.
+    for table_key in [_ for _ in table_map if _ != _.lower()]:
+        if table_key.lower() not in table_map:
+            # Only lower case the key if there isn't one already.
+            table_map[table_key.lower()] = table_map.pop(table_key)
+
     return table_map
+
+
+def _get_table_map(
+    client: "ibis.backends.base.BaseBackend", allowed_schemas=None, include_views=False
+) -> dict:
+    """Return dict with searchable keys for table matching."""
+    table_objs = clients.get_all_tables(
+        client, allowed_schemas=allowed_schemas, tables_only=(not include_views)
+    )
+    return _get_table_map_from_obj_list(table_objs)
 
 
 def get_mapped_table_configs(

--- a/tests/unit/test_find_tables.py
+++ b/tests/unit/test_find_tables.py
@@ -158,3 +158,52 @@ def test_expand_tables_of_asterisk(
             tables_list, mock.Mock(), mock.Mock()
         )
         assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    ("table_list,expected_result"),
+    (
+        (
+            # Test upper case names are coerced to lower case when possible.
+            [
+                ("own", "tab1"),
+                # This table will remain upper case because there's already a lower case one.
+                ("own", "TAB1"),
+                # The key for this will be successfully lower cased.
+                ("own", "TAB3"),
+                # This table will remain upper case because there's already a lower case one, even though it is later in the list.
+                ("own", "TAB4"),
+                ("own", "tab4"),
+            ],
+            {
+                "own.tab1": {
+                    "schema_name": "own",
+                    "table_name": "tab1",
+                },
+                "own.TAB1": {
+                    "schema_name": "own",
+                    "table_name": "TAB1",
+                },
+                "own.tab3": {
+                    "schema_name": "own",
+                    "table_name": "TAB3",
+                },
+                "own.tab4": {
+                    "schema_name": "own",
+                    "table_name": "tab4",
+                },
+                "own.TAB4": {
+                    "schema_name": "own",
+                    "table_name": "TAB4",
+                },
+            },
+        ),
+    ),
+)
+def test__get_table_map_from_obj_list_mixed_case(
+    module_under_test, table_list: list, expected_result: dict
+):
+    """Test matching tables from source and target."""
+    table_configs = module_under_test._get_table_map_from_obj_list(table_list)
+
+    assert table_configs == expected_result


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to DVT!

Please ensure that your pull request title matches the conventional commits
specification: https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md#conventional-commits
-->

## Description of changes
This PR lower cases the key used to match names in `find-tables` when no lower cased key already exists. This is useful when names in source/target systems have different cases. Below is an example of the output when this is the case:
```
[{"schema_name": "dvt_test", "table_name": "TAB_UPPER", "target_schema_name": "dvt_test", "target_table_name": "tab_upper"}]
```

## Issues to be closed

Closes #1600

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


