### PR TITLE
feat: Improve generate-table-partitions for custom queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ data-validation
                         Directory Path to store YAML Config Files
                         GCS: Provide a full gs:// path of the target directory. Eg: `gs://<BUCKET>/partitions_dir`
                         Local: Provide a relative path of the target directory. Eg: `partitions_dir`
-                        If invoked with -tbls parameter, the validations are stored in a directory named <schema>.<table>, otherwise the directory is named `custom.<random_string>`
+                        For custom queries, the yaml files are stored in CONFIG_DIR and, for tables the yamls are stored in a directory named <source_schema>.<table> within CONFIG_DIR.
   --partition-num INT, -pn INT
                         Number of partitions into which the table should be split, e.g. 1000 or 10000
                         In case this value exceeds the row count of the source/target table, it will be decreased to max(source_row_count, target_row_count)

--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -409,14 +409,7 @@ class PartitionBuilder:
             if config_manager.source_table:
                 dir_name = config_manager.full_source_table
             else:
-                dir_name = (
-                    "custom."
-                    + base64.b64encode(
-                        hashlib.sha256(
-                            config_manager.source_query.encode("utf-8")
-                        ).digest()
-                    ).decode("ascii")[:5]
-                )
+                dir_name = ""
             filter_list = partition_filters[ind]
 
             if src_config_dict.get(dir_name) is None:

--- a/data_validation/partition_builder.py
+++ b/data_validation/partition_builder.py
@@ -18,8 +18,6 @@ import pandas
 import logging
 import re
 import datetime
-import hashlib
-import base64
 from typing import List, Dict, TYPE_CHECKING
 
 from data_validation import cli_tools, consts, util

--- a/tests/unit/test_partition_builder.py
+++ b/tests/unit/test_partition_builder.py
@@ -788,7 +788,7 @@ def test_create_partition_query_yaml(module_under_test):
     builder = module_under_test.PartitionBuilder(config_managers, mock_args)
     yaml_configs_list = builder._add_partition_filters(master_filter_list)
 
-    assert yaml_configs_list[0]["target_folder_name"] == ''
+    assert yaml_configs_list[0]["target_folder_name"] == ""
     assert len(yaml_configs_list[0]["yaml_files"]) == 2
     # 5 validations in the first file
     assert len(yaml_configs_list[0]["yaml_files"][0]["yaml_config"]["validations"]) == 5

--- a/tests/unit/test_partition_builder.py
+++ b/tests/unit/test_partition_builder.py
@@ -788,7 +788,7 @@ def test_create_partition_query_yaml(module_under_test):
     builder = module_under_test.PartitionBuilder(config_managers, mock_args)
     yaml_configs_list = builder._add_partition_filters(master_filter_list)
 
-    assert yaml_configs_list[0]["target_folder_name"].startswith("custom.")
+    assert yaml_configs_list[0]["target_folder_name"] == ''
     assert len(yaml_configs_list[0]["yaml_files"]) == 2
     # 5 validations in the first file
     assert len(yaml_configs_list[0]["yaml_files"][0]["yaml_config"]["validations"]) == 5


### PR DESCRIPTION

## Description of changes
Simplifies usage og `generate-table-partitions` for custom queries. The parameter `--config-dir` refers to the directory where the yamls are stored. A directory called `custom.<source_query_hash>` is no longer created.

## Issues to be closed

Closes #1428 

<!--
For example, if your pull requests resolves multiple issues, such as 1000 and 2000 write:
* Closes #1000
* Closes #2000
-->

## Checklist

- [X] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated any relevant documentation to reflect my changes, if applicable
- [X] I have added unit and/or integration tests relevant to my change as needed
- [X] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [X] I have manually executed end-to-end testing (E2E) with the affected databases/engines


