### PR TITLE
fix: Skip SQL Server columns of type image

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1094,10 +1094,9 @@ class ConfigManager(object):
                     )
                 continue
             elif self._is_sql_server_image(column, column):
-                if self.verbose:
-                    logging.info(
-                        f"Skipping {agg_type} on {column} due to SQL Server image data type"
-                    )
+                logging.info(
+                    f"Skipping {agg_type} on {column} due to SQL Server image data type"
+                )
                 continue
 
             if require_pre_agg_calc_field(

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1275,7 +1275,24 @@ class ConfigManager(object):
             raise ValueError(
                 "Exclude columns flag cannot be present with column list '*'"
             )
+
         return casefold_columns
+
+    def _filter_columns_by_data_type(
+        self, source_columns: dict, target_columns: dict
+    ) -> tuple:
+        """Filter out columns with a data type that is incompatible with DVT."""
+        result_source_columns = source_columns.copy()
+        result_target_columns = target_columns.copy()
+        for source_column, target_column in zip(source_columns, target_columns):
+            if self._is_sql_server_image(source_column, target_column):
+                logging.info(
+                    f"Skipping column {source_column} due to SQL Server image data type"
+                )
+                result_source_columns.pop(source_column)
+                result_target_columns.pop(target_column)
+
+        return result_source_columns, result_target_columns
 
     def build_dependent_aliases(self, calc_type: str, col_list=None) -> List[Dict]:
         """This is a utility function for determining the required depth of all fields"""
@@ -1290,6 +1307,12 @@ class ConfigManager(object):
         )
         casefold_target_columns = self._filter_columns_by_column_list(
             casefold_target_columns, col_list
+        )
+
+        casefold_source_columns, casefold_target_columns = (
+            self._filter_columns_by_data_type(
+                casefold_source_columns, casefold_target_columns
+            )
         )
 
         column_aliases = {}
@@ -1347,6 +1370,9 @@ class ConfigManager(object):
         casefold_source_columns = {_.casefold(): str(_) for _ in source_table.columns}
         casefold_source_columns = self._filter_columns_by_column_list(
             casefold_source_columns, col_list, exclude_cols=exclude_cols
+        )
+        casefold_source_columns, _ = self._filter_columns_by_data_type(
+            casefold_source_columns, casefold_source_columns
         )
         return casefold_source_columns
 

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -671,20 +671,38 @@ class ConfigManager(object):
 
         This is because SQL Server text does not support the len() function to get the length in characters.
         Instead we must fall back to using ByteLength."""
+        return self._is_sql_server_type(
+            source_column_name, target_column_name, ["text", "ntext"]
+        )
+
+    def _is_sql_server_image(
+        self, source_column_name: str, target_column_name: str
+    ) -> bool:
+        """Returns True when either source or target column is of SQL Server image data type.
+
+        This is because SQL Server image is deprecated and not supported by a number of SQL functions.
+        """
+        return self._is_sql_server_type(
+            source_column_name, target_column_name, ["image"]
+        )
+
+    def _is_sql_server_type(
+        self, source_column_name: str, target_column_name: str, type_list: List[str]
+    ) -> bool:
+        """Returns True when either source or target column is of a SQL Server type listed in type_list."""
 
         raw_source_types = self.get_source_raw_data_types()
         raw_target_types = self.get_target_raw_data_types()
-        text_types = ("text", "ntext")
         return bool(
             (
                 self.source_client.name == "mssql"
                 and raw_source_types
-                and raw_source_types.get(source_column_name, [None])[0] in text_types
+                and raw_source_types.get(source_column_name, [None])[0] in type_list
             )
             or (
                 self.target_client.name == "mssql"
                 and raw_target_types
-                and raw_target_types.get(target_column_name, [None])[0] in text_types
+                and raw_target_types.get(target_column_name, [None])[0] in type_list
             )
         )
 
@@ -1073,6 +1091,12 @@ class ConfigManager(object):
                 if self.verbose:
                     logging.info(
                         f"Skipping {agg_type} on {column} due to data type: {column_type}"
+                    )
+                continue
+            elif self._is_sql_server_image(column, column):
+                if self.verbose:
+                    logging.info(
+                        f"Skipping {agg_type} on {column} due to SQL Server image data type"
                     )
                 continue
 

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1309,10 +1309,11 @@ class ConfigManager(object):
             casefold_target_columns, col_list
         )
 
-        casefold_source_columns, casefold_target_columns = (
-            self._filter_columns_by_data_type(
-                casefold_source_columns, casefold_target_columns
-            )
+        (
+            casefold_source_columns,
+            casefold_target_columns,
+        ) = self._filter_columns_by_data_type(
+            casefold_source_columns, casefold_target_columns
         )
 
         column_aliases = {}

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -98,8 +98,7 @@ DVT_SS2BQ_COLUMNS = [
     "col_varbinary",
     "col_varbinary_max",
     "col_bit",
-    # TODO uncomment line below when working on issue-1578.
-    # "col_image",
+    "col_image",
 ]
 
 


### PR DESCRIPTION
## Description of changes
This PR adds code to skip SQL Server image columns.

From SQL Server docs (https://learn.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver17):
```
The ntext, text, and image data types will be removed in a future version of SQL Server. Avoid using these data
types in new development work, and plan to modify applications that currently use them. Use nvarchar(max),
varchar(max), and varbinary(max) instead.
```
For this reason it's probably not worth investing a lot of effort into supporting image. Any easy wins can be implemented but it would also be okay to skip them.

The changes in this PR may end up being temporary if we decide to revisit the issue (which I'll leave open). But probably, due to image being deprecated for many years, we'll just leave it as a limitation.

## Issues to be closed
None, I'm leaving the issue open in case we decide to revisit in the future.

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


