### PR TITLE
feat: Support ODBC driver in --query arg

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -109,7 +109,6 @@ CONNECTION_SOURCE_FIELDS = {
         ["password", "Password for supplied user"],
         ["database", "Database to connect to (default master)"],
         ["query", "Connection query parameters"],
-        ["odbc_driver", 'ODBC driver name (default "ODBC Driver 17 for SQL Server")'],
         ["url", "SQL Server SQLAlchemy connection URL"],
     ],
     consts.SOURCE_TYPE_MYSQL: [

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -109,6 +109,7 @@ CONNECTION_SOURCE_FIELDS = {
         ["password", "Password for supplied user"],
         ["database", "Database to connect to (default master)"],
         ["query", "Connection query parameters"],
+        ["odbc_driver", 'ODBC driver name (default "ODBC Driver 17 for SQL Server")'],
         ["url", "SQL Server SQLAlchemy connection URL"],
     ],
     consts.SOURCE_TYPE_MYSQL: [

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -264,7 +264,7 @@ Example with a specific ODBC driver name:
 ```sh
 data-validation connections add --connection-name sql_server_mydb MSSQL \
 --host=127.0.0.1 --database=mydb --user=usersecret --password=pwdsecret \
---odbc-driver="Microsoft ODBC Driver 18 for SQL Server"
+--odbc-driver="ODBC Driver 18 for SQL Server"
 ```
 
 ## Postgres

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -260,6 +260,13 @@ data-validation connections add
     [--query QUERY]                                     Connection query parameters i.e. '{"TrustServerCertificate": "yes"}'
 ```
 
+Example with a specific ODBC driver name:
+```sh
+data-validation connections add --connection-name sql_server_mydb MSSQL \
+--host=127.0.0.1 --database=mydb --user=usersecret --password=pwdsecret \
+--odbc-driver="Microsoft ODBC Driver 18 for SQL Server"
+```
+
 ## Postgres
 
 ```

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -263,7 +263,7 @@ Example with a specific ODBC driver name:
 ```sh
 data-validation connections add --connection-name sql_server_mydb MSSQL \
 --host=127.0.0.1 --database=mydb --user=usersecret --password=pwdsecret \
---odbc-driver='{"driver": "ODBC Driver 18 for SQL Server", "TrustServerCertificate": "yes"}'
+--query='{"driver": "ODBC Driver 18 for SQL Server", "TrustServerCertificate": "yes"}'
 ```
 
 ## Postgres

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -255,7 +255,6 @@ data-validation connections add
     --user USER                                         MSSQL user
     --password PASSWORD                                 MSSQL password
     --database DATABASE                                 MSSQL database
-    --odbc-driver ODBC_DRIVER                           ODBC driver name (default "ODBC Driver 17 for SQL Server")
     [--url URL]                                         SQLAlchemy connection URL
     [--query QUERY]                                     Connection query parameters i.e. '{"TrustServerCertificate": "yes"}'
 ```
@@ -264,7 +263,7 @@ Example with a specific ODBC driver name:
 ```sh
 data-validation connections add --connection-name sql_server_mydb MSSQL \
 --host=127.0.0.1 --database=mydb --user=usersecret --password=pwdsecret \
---odbc-driver="ODBC Driver 18 for SQL Server"
+--odbc-driver='{"driver": "ODBC Driver 18 for SQL Server", "TrustServerCertificate": "yes"}'
 ```
 
 ## Postgres

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -255,6 +255,7 @@ data-validation connections add
     --user USER                                         MSSQL user
     --password PASSWORD                                 MSSQL password
     --database DATABASE                                 MSSQL database
+    --odbc-driver ODBC_DRIVER                           ODBC driver name (default "ODBC Driver 17 for SQL Server")
     [--url URL]                                         SQLAlchemy connection URL
     [--query QUERY]                                     Connection query parameters i.e. '{"TrustServerCertificate": "yes"}'
 ```

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -23,6 +23,9 @@ from ibis.backends.mssql.datatypes import _type_from_result_set_info
 import json
 
 
+DEFAULT_DRIVER_NAME = "ODBC Driver 17 for SQL Server"
+
+
 # The MSSQL backend uses the Ibis MSSQL compiler, but overrides
 # the Backend class to use pyodbc instead of pymssql
 class Backend(BaseAlchemyBackend):
@@ -41,7 +44,7 @@ class Backend(BaseAlchemyBackend):
         database: str = None,
         url: str = None,
         driver: Literal["pyodbc"] = "pyodbc",
-        odbc_driver: str = "ODBC Driver 17 for SQL Server",
+        odbc_driver: str = DEFAULT_DRIVER_NAME,
         query: str = None,
     ) -> None:
         if url is None:
@@ -51,9 +54,11 @@ class Backend(BaseAlchemyBackend):
                 )
 
             if query:
-                query = json.loads(query)
+                query_dict = json.loads(query)
+                if "driver" not in query:
+                    query_dict["driver"] = odbc_driver or DEFAULT_DRIVER_NAME
             else:
-                query = {"driver": odbc_driver}
+                query_dict = {"driver": odbc_driver}
 
             alchemy_url = sa.engine.url.URL.create(
                 f"mssql+{driver}",
@@ -62,7 +67,7 @@ class Backend(BaseAlchemyBackend):
                 username=user,
                 password=password,
                 database=database,
-                query=query,
+                query=query_dict,
             )
         else:
             alchemy_url = sa.engine.url.make_url(url)


### PR DESCRIPTION
## Description of changes
Modify MSSQL connection code to pick up "driver" from `--query` arg. Without this option the only way to provide a driver name is via a URL which is not ideal.

## Issues to be closed
Closes #1607

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


