### PR TITLE
chore: Drop Python 3.8 support

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -21,14 +21,14 @@ set -eo pipefail
 export PYTHONUNBUFFERED=1
 
 # Install nox
-python3.8 -m pip install --upgrade --quiet nox pip
-python3.8 -m nox --version
+python3.9 -m pip install --upgrade --quiet nox pip
+python3.9 -m nox --version
 
 # When NOX_SESSION is set, it only runs the specified session
 if [[ -n "${NOX_SESSION:-}" &&  ( "$NOX_SESSION" == "integration_postgres" || "$NOX_SESSION" == "integration_sql_server" || "$NOX_SESSION" == "integration_mysql" || "$NOX_SESSION" =~ integration_oracle.* ) ]]; then
-    ./cloud_sql_proxy -instances="$CLOUD_SQL_CONNECTION" & python3.8 -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
+    ./cloud_sql_proxy -instances="$CLOUD_SQL_CONNECTION" & python3.9 -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
 elif [[ -n "${NOX_SESSION:-}" ]]; then
-    python3.8 -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
+    python3.9 -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
 else
     echo "NOX_SESSION env var not set"
     exit 1

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ This tool can be installed locally on your machine or can be containerized and r
 
 ## Prerequisites
 
-- Any machine with Python 3.9+ installed. (Note: Support for Python 3.8 is deprecated since [PR #894](https://github.com/GoogleCloudPlatform/professional-services-data-validator/pull/894))
+- Any machine with Python 3.9+ installed. (Note: Support for Python 3.8 is deprecated since [PR #1621](https://github.com/GoogleCloudPlatform/professional-services-data-validator/pull/1621))
 
 ## Deploy Data Validation CLI on your machine
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,11 +7,11 @@ This tool can be installed locally on your machine or can be containerized and r
 
 ## Prerequisites
 
-- Any machine with Python 3.8+ installed. (Note: Support for Python 3.7 is deprecated since [PR #894](https://github.com/GoogleCloudPlatform/professional-services-data-validator/pull/894))
+- Any machine with Python 3.9+ installed. (Note: Support for Python 3.8 is deprecated since [PR #894](https://github.com/GoogleCloudPlatform/professional-services-data-validator/pull/894))
 
 ## Deploy Data Validation CLI on your machine
 
-The Data Validation tooling requires Python 3.8+.
+The Data Validation tooling requires Python 3.9+.
 
 ```
 sudo apt-get install python3

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,8 +30,8 @@ import nox
 DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing.
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
-PYTHON_VERSIONS_ORACLE = ["3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
 
 BLACK_PATHS = (
     "data_validation",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", "r") as fh:
 
 dependencies = [
     "Flask>=2.2",  # Some versions of airflow such as 2.9.1 depend on flask<2.3 and >=2.2
-    "fsspec!=2025.3.1",  # Version 2025.3.1 was breaking Python 3.8 support.
+    "fsspec",
     "google-api-python-client>=2.144.0",
     "google-cloud-bigquery>=3.25.0",
     "google-cloud-bigquery-storage>=2.26.0",
@@ -36,7 +36,7 @@ dependencies = [
     "ibis-framework==5.1.0",  # Pinned to 5.1.0, significant work to bump to 7.1.0
     "impyla>=0.19.0",
     "jellyfish>=1.1.0",
-    "pandas==2.0.3",  # 2.03 is the highest version that still supports python 3.8
+    "pandas",
     "parsy>=2.1",
     "psycopg2-binary>=2.9.9",
     "pyarrow==14.0.1",  # ibis-framework 7.1.0 depends on pyarrow<15 and >=2
@@ -84,12 +84,12 @@ setuptools.setup(
         release_status,
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=dependencies,
     extras_require=extras_require,
     entry_points={

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -14,7 +14,7 @@
 
 import json
 import string
-from typing import TYPE_CHECKING, Optional, Tuple  # Build is still on Python 3.8
+from typing import TYPE_CHECKING, Optional, Tuple
 import pathlib
 
 from data_validation import __main__ as main


### PR DESCRIPTION
## Description of changes
Python 3.8 has been deprecated by many of our dependencies but also appears to have been dropped by infrastructure we use for testing. This PR removes DVT support for Python 3.8 and removes it from our testing.

Instead of dropping Python 3.8 support I could have just changed testing to be >=3.9. Happy to rewind some of this if there are objections to dropping 3.8.

## Issues to be closed
Closes #1615

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


