### PR TITLE
chore: Remove version limit for pyarrow

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 # Copied from https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/.kokoro/build.sh
+#
+
+PYTHON="python3.9"
+if [[ -n "$1" && "$1" =~ "python.*" ]]; then
+    PYTHON=$1
+fi
 
 set -eo pipefail
 
@@ -21,14 +27,14 @@ set -eo pipefail
 export PYTHONUNBUFFERED=1
 
 # Install nox
-python3.9 -m pip install --upgrade --quiet nox pip
-python3.9 -m nox --version
+${PYTHON} -m pip install --upgrade --quiet nox pip
+${PYTHON} -m nox --version
 
 # When NOX_SESSION is set, it only runs the specified session
 if [[ -n "${NOX_SESSION:-}" &&  ( "$NOX_SESSION" == "integration_postgres" || "$NOX_SESSION" == "integration_sql_server" || "$NOX_SESSION" == "integration_mysql" || "$NOX_SESSION" =~ integration_oracle.* ) ]]; then
-    ./cloud_sql_proxy -instances="$CLOUD_SQL_CONNECTION" & python3.9 -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
+    ./cloud_sql_proxy -instances="$CLOUD_SQL_CONNECTION" & ${PYTHON} -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
 elif [[ -n "${NOX_SESSION:-}" ]]; then
-    python3.9 -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
+    ${PYTHON} -m nox --error-on-missing-interpreters -s "${NOX_SESSION:-}"
 else
     echo "NOX_SESSION env var not set"
     exit 1

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,7 +17,7 @@
 #
 
 PYTHON="python3.9"
-if [[ -n "$1" && "$1" =~ "python.*" ]]; then
+if [[ -n "$1" && "$1" =~ python.* ]]; then
     PYTHON=$1
 fi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,7 +31,9 @@ steps:
   waitFor: ['-']
 - id: unit-alpine
   name: 'python:3.10-alpine'
-  args: ['bash', './ci/build.sh', 'python3.10']
+  script: |
+    apk install bash
+    bash ./ci/build.sh python3.10
   env:
   - 'NOX_SESSION=unit_default_python'
   waitFor: ['-']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
 - id: unit-alpine
   name: 'python:3.10-alpine'
   script: |
-    apk install bash
+    apk add bash
     bash ./ci/build.sh python3.10
   env:
   - 'NOX_SESSION=unit_default_python'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,6 +29,12 @@ steps:
   env:
   - 'NOX_SESSION=unit'
   waitFor: ['-']
+- id: unit-alpine
+  name: 'python:3.10-alpine'
+  args: ['bash', './ci/build.sh', 'python3.10']
+  env:
+  - 'NOX_SESSION=unit_default_python'
+  waitFor: ['-']
 - id: proxy-install
   name: 'gcr.io/cloud-devrel-public-resources/python-multi'
   args: ['bash', './ci/install_cloud_proxy.sh']

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,6 +82,11 @@ def unit_small(session):
     unit(session)
 
 
+@nox.session(python=DEFAULT_PYTHON_VERSION, venv_backend="venv")
+def unit_default_python(session):
+    unit(session)
+
+
 @nox.session(python=PYTHON_VERSIONS, venv_backend="venv")
 def samples(session):
     """Run the snippets test suite."""

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dependencies = [
     "pandas",
     "parsy>=2.1",
     "psycopg2-binary>=2.9.9",
-    "pyarrow==14.0.1",  # ibis-framework 7.1.0 depends on pyarrow<15 and >=2
+    "pyarrow",
     "pydata-google-auth>=1.8.2",
     "PyMySQL>=1.1.1",
     "PyYAML>=6.0.2",


### PR DESCRIPTION
## Description of changes
Installing DVT in Linux Alpine distribution is difficult because PyArrow version < 20 are built from source and require installation of PyArrow C++ libraries. It has been difficult to find a way to do it, especially in a Dockerfile.

I noticed that (prior to this PR) we pin PyArrow to version 14 but I'm not aware of a specific reason why. So I removed the pinned version. From this comment https://github.com/ibis-project/ibis/issues/10492#issuecomment-2476531888 it seems that the upper limit was precautionary rather than necessary.

I've run integration tests twice and all pass. I know the BigQuery client uses Arrow (via Pandas) so I tested that manually at volume (both reading and result hander writes) and it worked as expected.

## Issues to be closed
None
Not closing #1627 because once this has been merged I want to add a sample SQL Server Dockerfile for Alpine Linux.

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


