### PR TITLE
fix: Ensure we use BigQuery data project when prefixing tables

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -16,7 +16,7 @@
 from contextlib import contextmanager
 import copy
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 import warnings
 
 import google.oauth2.service_account
@@ -97,8 +97,8 @@ except ImportError:
 def get_google_bigquery_client(
     project_id: str,
     credentials=None,
-    api_endpoint: str = None,
-    quota_project_id: str = None,
+    api_endpoint: Optional[str] = None,
+    quota_project_id: Optional[str] = None,
 ):
     info = client_info.get_http_client_info()
     job_config = bigquery.QueryJobConfig(
@@ -121,7 +121,9 @@ def get_google_bigquery_client(
 
 
 def _get_google_bqstorage_client(
-    credentials=None, api_endpoint: str = None, quota_project_id: str = None
+    credentials=None,
+    api_endpoint: Optional[str] = None,
+    quota_project_id: Optional[str] = None,
 ):
     options = None
     if api_endpoint or quota_project_id:
@@ -141,9 +143,9 @@ def get_bigquery_client(
     project_id: str,
     dataset_id: str = "",
     credentials=None,
-    api_endpoint: str = None,
-    storage_api_endpoint: str = None,
-    client_project_id: str = None,
+    api_endpoint: Optional[str] = None,
+    storage_api_endpoint: Optional[str] = None,
+    client_project_id: Optional[str] = None,
 ):
     google_client = get_google_bigquery_client(
         project_id,
@@ -159,10 +161,8 @@ def get_bigquery_client(
             quota_project_id=client_project_id,
         )
 
-    billing_project = client_project_id if client_project_id else project_id
-
     return bigquery_connect(
-        project_id=billing_project,
+        project_id=project_id or client_project_id,
         dataset_id=dataset_id,
         credentials=credentials,
         bigquery_client=google_client,

--- a/third_party/ibis/ibis_bigquery/__init__.py
+++ b/third_party/ibis/ibis_bigquery/__init__.py
@@ -22,12 +22,12 @@ from pydata_google_auth import cache
 from ibis.backends.bigquery import (
     Backend as BigQueryBackend,
     _create_client_info,
-    parse_project_and_dataset,
     CLIENT_ID,
     CLIENT_SECRET,
     EXTERNAL_DATA_SCOPES,
     SCOPES,
 )
+from ibis.backends.bigquery.client import parse_project_and_dataset
 
 if TYPE_CHECKING:
     import google.cloud.bigquery_storage_v1
@@ -53,9 +53,12 @@ class Backend(BigQueryBackend):
         bqstorage_client: "google.cloud.bigquery_storage_v1.BigQueryReadClient" = None,
     ):
         """Copy of Ibis v5 BigQuery do_connect() customized for DVT, see original method for docs."""
-        default_project_id = ""
+        client_project_id = (
+            bigquery_client.project if bigquery_client is not None else None
+        )
+        default_project_id = None
 
-        if credentials is None:
+        if bigquery_client is None and credentials is None:
             scopes = SCOPES
             if auth_external_data:
                 scopes = EXTERNAL_DATA_SCOPES
@@ -83,14 +86,11 @@ class Backend(BigQueryBackend):
                 credentials_cache=credentials_cache,
                 use_local_webserver=auth_local_webserver,
             )
+            project_id = project_id or default_project_id
 
-        project_id = project_id or default_project_id
-
-        (
-            self.data_project,
-            self.billing_project,
-            self.dataset,
-        ) = parse_project_and_dataset(project_id, dataset_id)
+        self.billing_project = client_project_id or project_id
+        self.data_project = project_id or self.billing_project
+        self.dataset = None
 
         if bigquery_client is None:
             self.client = bq.Client(
@@ -132,6 +132,16 @@ class Backend(BigQueryBackend):
         finally:
             query_result._project = orig_project
         return arrow_obj
+
+    def _parse_project_and_dataset(self, dataset) -> tuple[str, str]:
+        """Copied from Ibis code and modified to use self.data_project."""
+        if not dataset and not self.dataset:
+            raise ValueError("Unable to determine BigQuery dataset.")
+        project, _, dataset = parse_project_and_dataset(
+            self.data_project,
+            dataset or f"{self.data_project}.{self.dataset}",
+        )
+        return project, dataset
 
     def list_primary_key_columns(self, database: str, table: str) -> list:
         """Return a list of primary key column names."""


### PR DESCRIPTION
## Description of changes
When BigQuery execution project needs to be different to the data project we were not prefixing tables with the correct project.

This PR adds `self.data_project_id` to the BigQuery `Backend` to ensure correct prefixing when there are two projects in play. This is similar to in more recent Ibis versions but not quite the same because Ibis expects the dataset to define the project but we (DVT) don't expect users to prefix BigQuery datasets with the project. Plus `find-tables` does not include the data project.

Tested with schema, column and row validation across 3 projects. One billing/execution project and two data projects.

Custom query is not relevant because the user must prefix datasets with the project if they are anything other than the default.

## Issues to be closed

Closes #1631


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


