### PR TITLE
fix: Db2 GROUP BY support in column validation

### DIFF
--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -124,8 +124,7 @@ def test_column_validation_core_types():
         min_cols=cols,
         max_cols=cols,
         filters="id>0 AND col_int8>0",
-        # TODO When issue-1295 is complete uncomment --grouped_columns parameter below.
-        # grouped_columns="col_varchar_30",
+        grouped_columns="col_varchar_30",
     )
 
 

--- a/third_party/ibis/ibis_db2/compiler.py
+++ b/third_party/ibis/ibis_db2/compiler.py
@@ -29,3 +29,4 @@ rewrites = Db2ExprTranslator.rewrites
 
 class Db2Compiler(AlchemyCompiler):
     translator_class = Db2ExprTranslator
+    supports_indexed_grouping_keys = False


### PR DESCRIPTION
## Description of changes
Fixes error when trying to use --grouped-columns for Db2 column validation.

## Issues to be closed

Closes #1295

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


