### PR TITLE
fix: Db2 DECFLOAT data type and add tests

### DIFF
--- a/tests/resources/db2_test_tables.sql
+++ b/tests/resources/db2_test_tables.sql
@@ -56,6 +56,37 @@ INSERT INTO db2inst1.dvt_core_types VALUES
 ,TIMESTAMP'1970-01-02 21:23:03');
 COMMIT;
 
+-- Db2 data types test table (data types not covered by core types).
+DROP TABLE db2inst1.dvt_db2_types;
+CREATE TABLE db2inst1.dvt_db2_types
+(   id              INTEGER NOT NULL PRIMARY KEY
+,   col_smallint    SMALLINT
+,   col_int         INTEGER
+,   col_bigint      BIGINT
+,   col_decfloat_16 DECFLOAT(16)
+,   col_decfloat_32 DECFLOAT(34)
+,   col_clob        CLOB
+,   col_nvarchar_30 NVARCHAR(30)
+,   col_nchar_2     NCHAR(2)
+,   col_nclob       NCLOB
+,   col_blob        BLOB
+,   col_char_bit    CHAR(5) FOR BIT DATA
+,   col_varchar_bit VARCHAR(5) FOR BIT DATA
+,   col_graphic     GRAPHIC(3)
+,   col_vargraphic  VARGRAPHIC(3)
+,   col_time        TIME
+,   col_xml         XML
+);
+COMMENT ON TABLE db2inst1.dvt_core_types IS 'Db2 data types integration test table';
+
+INSERT INTO db2inst1.dvt_db2_types VALUES
+(1,123,12345,1123456789,123.456,123456.789
+,'Hello CLOB','Hello NVARCHAR','A ','Hello NCLOB'
+,CAST('Hello BLOB' AS BLOB),'ABC','DEF','GHI','JKL'
+,TIME'00:00:01'
+,'<xml></xml>');
+COMMIT;
+
 DROP TABLE db2inst1.dvt_null_not_null;
 CREATE TABLE db2inst1.dvt_null_not_null
 (   col_nn             TIMESTAMP(0) NOT NULL

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -19,6 +19,7 @@ import pytest
 
 from data_validation import cli_tools, consts
 from tests.system.data_sources.common_functions import (
+    DVT_CORE_TYPES_COLUMNS,
     schema_validation_test,
     column_validation_test,
     run_test_from_cli_args,
@@ -62,7 +63,7 @@ def mock_get_connection_config(*args):
     new=mock_get_connection_config,
 )
 def test_schema_validation_core_types():
-    """DB2 to DB2 dvt_core_types schema validation"""
+    """Db2 to Db2 dvt_core_types schema validation"""
     schema_validation_test(
         tables="db2inst1.dvt_core_types",
         tc="mock-conn",
@@ -74,7 +75,7 @@ def test_schema_validation_core_types():
     new=mock_get_connection_config,
 )
 def test_schema_validation_core_types_to_bigquery():
-    """DB2 to BigQuery dvt_core_types schema validation"""
+    """Db2 to BigQuery dvt_core_types schema validation"""
     schema_validation_test(
         tables="db2inst1.dvt_core_types=pso_data_validator.dvt_core_types",
         tc="bq-conn",
@@ -148,7 +149,7 @@ def test_column_validation_core_types():
 def test_column_validation_core_types_to_bigquery():
     """DB2 to BigQuery dvt_core_types column validation"""
     # Excluded col_float32 because BigQuery does not have an exact same type and float32/64 are lossy and cannot be compared.
-    # Excluded col_tstz since it is not possible to set time zone at this column on DB2
+    # Excluded col_tstz since it is not possible to set time zone at this column on Db2
     cols = "col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime"
     column_validation_test(
         tc="bq-conn",
@@ -166,12 +167,38 @@ def test_column_validation_core_types_to_bigquery():
     new=mock_get_connection_config,
 )
 def test_row_validation_core_types():
-    """DB2 to DB2 dvt_core_types row validation"""
+    """Db2 to Db2 dvt_core_types row validation"""
+    # Exclude col_string because it is unbound and causes overflow error for HEX function.
+    # TODO: When issue-1296 is complete remove col_date,col_datetime,col_tstz from exclusion list below.
+    # TODO: When issue-1638 is complete remove col_char_2 from exclusion list below.
+    # TODO: When issue-1634 is complete remove columns tagged with issue-1634 from exclusion list below.
+    cols = ",".join(
+        [
+            _
+            for _ in DVT_CORE_TYPES_COLUMNS
+            if _
+            not in (
+                "id",
+                "col_int8",  # issue-1634
+                "col_int16",  # issue-1634
+                "col_int32",  # issue-1634
+                "col_dec_20",  # issue-1634
+                "col_dec_38",  # issue-1634
+                "col_dec_10_2",  # issue-1634
+                "col_float32",  # issue-1634
+                "col_float64",  # issue-1634
+                "col_char_2",
+                "col_string",
+                "col_date",
+                "col_datetime",
+                "col_tstz",
+            )
+        ]
+    )
     row_validation_test(
         tables="db2inst1.dvt_core_types",
         tc="mock-conn",
-        # OBS: Only passing this column because SYSIBM.HEX function accepts a max length of 16336 bytes (https://www.ibm.com/docs/en/db2/11.5?topic=functions-hex)
-        hash="col_string",
+        hash=cols,
         filters="id>0 AND col_int8>0",
     )
 
@@ -195,13 +222,40 @@ def test_row_validation_core_types_auto_pks():
     new=mock_get_connection_config,
 )
 def test_row_validation_core_types_to_bigquery():
-    """DB2 to BigQuery dvt_core_types row validation"""
+    """Db2 to BigQuery dvt_core_types row validation"""
+    # Excluded col_float32 because BigQuery does not have an exact same type and
+    # float32/64 are lossy and cannot be compared.
+    # Exclude col_string because it is unbound and causes overflow error for HEX function.
+    # TODO: When issue-1296 is complete remove col_date,col_datetime,col_tstz from exclusion list below.
+    # TODO: When issue-1638 is complete remove col_char_2 from exclusion list below.
+    # TODO: When issue-1634 is complete remove columns tagged with issue-1634 from exclusion list below.
+    cols = ",".join(
+        [
+            _
+            for _ in DVT_CORE_TYPES_COLUMNS
+            if _
+            not in (
+                "id",
+                "col_int8",  # issue-1634
+                "col_int16",  # issue-1634
+                "col_int32",  # issue-1634
+                "col_dec_20",  # issue-1634
+                "col_dec_38",  # issue-1634
+                "col_dec_10_2",  # issue-1634
+                "col_float32",
+                "col_float64",  # issue-1634
+                "col_char_2",
+                "col_string",
+                "col_date",
+                "col_datetime",
+                "col_tstz",
+            )
+        ]
+    )
     row_validation_test(
         tables="db2inst1.dvt_core_types=pso_data_validator.dvt_core_types",
         tc="bq-conn",
-        # OBS: Only passing this column because SYSIBM.HEX function accepts a max length of 16336 bytes (https://www.ibm.com/docs/en/db2/11.5?topic=functions-hex)
-        # TODO: When issue-1296 is complete change to col_date,col_datetime,col_tstz instead
-        hash="col_string",
+        hash=cols,
     )
 
 

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -93,6 +93,18 @@ def test_schema_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_schema_validation_db2_types():
+    """Db2 to Db2 dvt_db2_types schema validation"""
+    schema_validation_test(
+        tables="db2inst1.dvt_db2_types",
+        tc="mock-conn",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_schema_validation_not_null_vs_nullable():
     """Compares a source table with a BigQuery target and ensure we match/fail on not null/nullable correctly."""
     parser = cli_tools.configure_arg_parser()

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -252,14 +252,6 @@ def sa_format_hashbytes_mysql(translator, op):
     return hash_func
 
 
-def sa_format_hashbytes_db2(translator, op):
-    compiled_arg = translator.translate(op.arg)
-    hash_func = sa.func.hash(compiled_arg, sa.sql.literal_column("2"))
-    # OBS: SYSIBM.HEX function accepts a max length of 16336 bytes (https://www.ibm.com/docs/en/db2/11.5?topic=functions-hex)
-    hex_func = sa.func.hex(hash_func)
-    return sa.func.lower(hex_func)
-
-
 def sa_format_hashbytes_redshift(translator, op):
     arg = translator.translate(op.arg)
     return sa.sql.literal_column(f"sha2({arg}, 256)")
@@ -567,7 +559,6 @@ RedShiftExprTranslator._registry[PaddedCharLength] = RedShiftExprTranslator._reg
 ]
 
 if Db2ExprTranslator:
-    Db2ExprTranslator._registry[ops.HashBytes] = sa_format_hashbytes_db2
     Db2ExprTranslator._registry[RawSQL] = sa_format_raw_sql
     Db2ExprTranslator._registry[BinaryLength] = sa_format_binary_length
     Db2ExprTranslator._registry[ops.Strftime] = strftime_db2

--- a/third_party/ibis/ibis_db2/datatypes.py
+++ b/third_party/ibis/ibis_db2/datatypes.py
@@ -11,11 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sqlalchemy as sa
+
 import ibm_db_dbi
 
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy.datatypes import ibis_type_to_sqla
+from ibm_db_sa.ibm_db import DB2Dialect_ibm_db
+import sqlalchemy as sa
+import sqlalchemy.types as sat
+
 
 # Types from https://github.com/ibmdb/python-ibmdb/blob/master/IBM_DB/ibm_db/ibm_db_dbi.py
 _type_mapping = {
@@ -34,6 +38,8 @@ _type_mapping = {
 }
 
 ibis_type_to_sqla[dt.String] = sa.sql.sqltypes.String(length=3000)
+
+DB2Dialect_ibm_db.ischema_names["DECFLOAT"] = sat.DOUBLE
 
 
 def _get_type(typename) -> dt.DataType:

--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -462,6 +462,14 @@ def _day_of_week_name(t, op):
     return sa.func.dayname(sa_arg)
 
 
+def sa_format_hashbytes_db2(translator, op):
+    compiled_arg = translator.translate(op.arg)
+    hash_func = sa.func.hash(compiled_arg, sa.sql.literal_column("2"))
+    # OBS: SYSIBM.HEX function accepts a max length of 16336 bytes (https://www.ibm.com/docs/en/db2/11.5?topic=functions-hex)
+    hex_func = sa.func.hex(hash_func)
+    return sa.func.lower(hex_func)
+
+
 operation_registry.update(
     {
         ops.Literal: _literal,
@@ -488,6 +496,7 @@ operation_registry.update(
         ops.Translate: fixed_arity("translate", 3),
         ops.RegexExtract: _regex_extract,
         ops.StringJoin: _string_join,
+        ops.HashBytes: sa_format_hashbytes_db2,
         # math
         ops.Log: _log,
         ops.Log2: unary(lambda x: sa.func.log(2, x)),


### PR DESCRIPTION
## Description of changes
This PR was to preempt some customer testing by adding tests for Db2 data types not covered by dvt_core_types.

While doing this I noticed our existing tests only tested with a single column! So I extended that as best I could, documenting issues for each column that failed validation.

I also took to opportunity to move `sa_format_hashbytes_db2()` from `operations.py` into Db2 `registry.py`

## Issues to be closed

Closes #1643


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


