### PR TITLE
fix: Db2 find-tables by schema fix

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -289,7 +289,7 @@ def list_tables(client, schema_name, tables_only=True):
         if tables_only and client.name != "pandas"
         else client.list_tables
     )
-    if client.name in ["db2", "redshift", "snowflake", "pandas"]:
+    if client.name in ["redshift", "snowflake", "pandas"]:
         return fn()
     return fn(database=schema_name)
 

--- a/tests/resources/db2_test_tables.sql
+++ b/tests/resources/db2_test_tables.sql
@@ -14,9 +14,10 @@
 
 connect to testdb
 
+CREATE SCHEMA pso_data_validator;
+
 -- Core data types test table, to be kept in sync with same table in other SQL engines
-DROP TABLE db2inst1.dvt_core_types;
-CREATE TABLE db2inst1.dvt_core_types
+CREATE TABLE IF NOT EXISTS pso_data_validator.dvt_core_types
 (   id              INTEGER NOT NULL PRIMARY KEY
 ,   col_int8        SMALLINT
 ,   col_int16       SMALLINT
@@ -34,21 +35,21 @@ CREATE TABLE db2inst1.dvt_core_types
 ,   col_datetime    TIMESTAMP(3)
 ,   col_tstz        TIMESTAMP(3) -- Unable to create col_tstz with time zone on our test database therefore test data is adjusted.
 );
-COMMENT ON TABLE db2inst1.dvt_core_types IS 'Core data types integration test table';
+COMMENT ON TABLE pso_data_validator.dvt_core_types IS 'Core data types integration test table';
 
-INSERT INTO db2inst1.dvt_core_types VALUES
+INSERT INTO pso_data_validator.dvt_core_types VALUES
 (1,1,1,1,1
 ,12345678901234567890,1234567890123456789012345,123.11,123456.1,12345678.1
 ,'Hello DVT','A ','Hello DVT'
 ,DATE'1970-01-01',TIMESTAMP'1970-01-01 00:00:01'
 ,TIMESTAMP'1969-12-31 23:23:01');
-INSERT INTO db2inst1.dvt_core_types VALUES
+INSERT INTO pso_data_validator.dvt_core_types VALUES
 (2,2,2,2,2
 ,12345678901234567890,1234567890123456789012345,123.22,123456.2,12345678.2
 ,'Hello DVT','B','Hello DVT'
 ,DATE'1970-01-02',TIMESTAMP'1970-01-02 00:00:02'
 ,TIMESTAMP'1970-01-01 22:23:02');
-INSERT INTO db2inst1.dvt_core_types VALUES
+INSERT INTO pso_data_validator.dvt_core_types VALUES
 (3,3,3,3,3
 ,12345678901234567890,1234567890123456789012345,123.3,123456.3,12345678.3
 ,'Hello DVT','C ','Hello DVT'
@@ -57,8 +58,7 @@ INSERT INTO db2inst1.dvt_core_types VALUES
 COMMIT;
 
 -- Db2 data types test table (data types not covered by core types).
-DROP TABLE db2inst1.dvt_db2_types;
-CREATE TABLE db2inst1.dvt_db2_types
+CREATE TABLE IF NOT EXISTS pso_data_validator.dvt_db2_types
 (   id              INTEGER NOT NULL PRIMARY KEY
 ,   col_smallint    SMALLINT
 ,   col_int         INTEGER
@@ -77,9 +77,9 @@ CREATE TABLE db2inst1.dvt_db2_types
 ,   col_time        TIME
 ,   col_xml         XML
 );
-COMMENT ON TABLE db2inst1.dvt_core_types IS 'Db2 data types integration test table';
+COMMENT ON TABLE pso_data_validator.dvt_core_types IS 'Db2 data types integration test table';
 
-INSERT INTO db2inst1.dvt_db2_types VALUES
+INSERT INTO pso_data_validator.dvt_db2_types VALUES
 (1,123,12345,1123456789,123.456,123456.789
 ,'Hello CLOB','Hello NVARCHAR','A ','Hello NCLOB'
 ,CAST('Hello BLOB' AS BLOB),'ABC','DEF','GHI','JKL'
@@ -87,17 +87,15 @@ INSERT INTO db2inst1.dvt_db2_types VALUES
 ,'<xml></xml>');
 COMMIT;
 
-DROP TABLE db2inst1.dvt_null_not_null;
-CREATE TABLE db2inst1.dvt_null_not_null
+CREATE TABLE IF NOT EXISTS pso_data_validator.dvt_null_not_null
 (   col_nn             TIMESTAMP(0) NOT NULL
 ,   col_nullable       TIMESTAMP(0)
 ,   col_src_nn_trg_n   TIMESTAMP(0) NOT NULL
 ,   col_src_n_trg_nn   TIMESTAMP(0)
 );
-COMMENT ON TABLE db2inst1.dvt_null_not_null IS 'Nullable integration test table, DB2 is assumed to be a DVT source (not target).';
+COMMENT ON TABLE pso_data_validator.dvt_null_not_null IS 'Nullable integration test table, DB2 is assumed to be a DVT source (not target).';
 
-DROP TABLE db2inst1.dvt_large_decimals;
-CREATE TABLE db2inst1.dvt_large_decimals
+CREATE TABLE IF NOT EXISTS pso_data_validator.dvt_large_decimals
 (   id                DECIMAL(31) NOT NULL PRIMARY KEY
 ,   col_data          VARCHAR(10)
 ,   col_dec_18        DECIMAL(18)
@@ -108,30 +106,30 @@ CREATE TABLE db2inst1.dvt_large_decimals
 ,   col_dec_18_fail   DECIMAL(18)
 ,   col_dec_18_1_fail DECIMAL(18,1)
 );
-COMMENT ON TABLE db2inst1.dvt_large_decimals IS 'Large decimals integration test table';
+COMMENT ON TABLE pso_data_validator.dvt_large_decimals IS 'Large decimals integration test table';
 
-/* INSERT INTO db2inst1.dvt_large_decimals VALUES
+/* INSERT INTO pso_data_validator.dvt_large_decimals VALUES
 (123456789012345678901234567890,'Row 1'
 ,987654321012345678
 ,1234567890123456789012345678901
 ,12345678901234567890123456789.123456
 ,12345678.123456789012345678901234567890
 ,987654321012345678,12345678901234567.1);
-INSERT INTO db2inst1.dvt_large_decimals VALUES
+INSERT INTO pso_data_validator.dvt_large_decimals VALUES
 (223456789012345678901234567890,'Row 2'
 ,987654321012345678
 ,1234567890123456789012345678901
 ,12345678901234567890123456789.123456789
 ,12345678.123456789012345678901234567890
 ,987654321012345678,12345678901234567.1);
-INSERT INTO db2inst1.dvt_large_decimals VALUES
+INSERT INTO pso_data_validator.dvt_large_decimals VALUES
 (323456789012345678901234567890,'Row 3'
 ,987654321012345678
 ,1234567890123456789012345678901
 ,12345678901234567890123456789.123456789
 ,12345678.123456789012345678901234567890
 ,987654321012345678,12345678901234567.1);
-INSERT INTO db2inst1.dvt_large_decimals VALUES
+INSERT INTO pso_data_validator.dvt_large_decimals VALUES
 (423456789012345678901234567890,'Row 4'
 ,987654321012345678
 ,1234567890123456789012345678901
@@ -146,18 +144,17 @@ INSERT INTO db2inst1.dvt_large_decimals VALUES
 ,987654321012345678,12345678901234567.1);
 COMMIT; */
 
-DROP TABLE db2inst1.dvt_binary;
-CREATE TABLE db2inst1.dvt_binary
+CREATE TABLE IF NOT EXISTS pso_data_validator.dvt_binary
 (   binary_id       VARBINARY(16) NOT NULL PRIMARY KEY
 ,   int_id          INTEGER NOT NULL
 ,   other_data      VARCHAR(100)
 );
-CREATE UNIQUE INDEX db2inst1.dvt_binary_int_id_uk ON dvt_binary (int_id);
-COMMENT ON TABLE db2inst1.dvt_binary IS 'Integration test table used to test both binary pk matching and binary hash/concat comparisons.';
-INSERT INTO db2inst1.dvt_binary VALUES (CAST('DVT-key-1' AS VARBINARY(16)), 1, 'Row 1');
-INSERT INTO db2inst1.dvt_binary VALUES (CAST('DVT-key-2' AS VARBINARY(16)), 2, 'Row 2');
-INSERT INTO db2inst1.dvt_binary VALUES (CAST('DVT-key-3' AS VARBINARY(16)), 3, 'Row 3');
-INSERT INTO db2inst1.dvt_binary VALUES (CAST('DVT-key-4' AS VARBINARY(16)), 4, 'Row 4');
-INSERT INTO db2inst1.dvt_binary VALUES (CAST('DVT-key-5' AS VARBINARY(16)), 5, 'Row 5');
+CREATE UNIQUE INDEX pso_data_validator.dvt_binary_int_id_uk ON dvt_binary (int_id);
+COMMENT ON TABLE pso_data_validator.dvt_binary IS 'Integration test table used to test both binary pk matching and binary hash/concat comparisons.';
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-1' AS VARBINARY(16)), 1, 'Row 1');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-2' AS VARBINARY(16)), 2, 'Row 2');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-3' AS VARBINARY(16)), 3, 'Row 3');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-4' AS VARBINARY(16)), 4, 'Row 4');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-5' AS VARBINARY(16)), 5, 'Row 5');
 COMMIT;
 

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -20,6 +20,7 @@ import pytest
 from data_validation import cli_tools, consts
 from tests.system.data_sources.common_functions import (
     DVT_CORE_TYPES_COLUMNS,
+    find_tables_test,
     schema_validation_test,
     column_validation_test,
     run_test_from_cli_args,
@@ -65,7 +66,7 @@ def mock_get_connection_config(*args):
 def test_schema_validation_core_types():
     """Db2 to Db2 dvt_core_types schema validation"""
     schema_validation_test(
-        tables="db2inst1.dvt_core_types",
+        tables="pso_data_validator.dvt_core_types",
         tc="mock-conn",
     )
 
@@ -77,7 +78,7 @@ def test_schema_validation_core_types():
 def test_schema_validation_core_types_to_bigquery():
     """Db2 to BigQuery dvt_core_types schema validation"""
     schema_validation_test(
-        tables="db2inst1.dvt_core_types=pso_data_validator.dvt_core_types",
+        tables="pso_data_validator.dvt_core_types",
         tc="bq-conn",
         allow_list=(
             # SMALLINT, INTEGER is equivalent to BigQuery INT64.
@@ -97,7 +98,7 @@ def test_schema_validation_core_types_to_bigquery():
 def test_schema_validation_db2_types():
     """Db2 to Db2 dvt_db2_types schema validation"""
     schema_validation_test(
-        tables="db2inst1.dvt_db2_types",
+        tables="pso_data_validator.dvt_db2_types",
         tc="mock-conn",
     )
 
@@ -115,7 +116,7 @@ def test_schema_validation_not_null_vs_nullable():
             "schema",
             "-sc=db2-conn",
             "-tc=bq-conn",
-            "-tbls=db2inst1.dvt_null_not_null=pso_data_validator.dvt_null_not_null",
+            "-tbls=pso_data_validator.dvt_null_not_null",
         ]
     )
     df = run_test_from_cli_args(args)
@@ -131,7 +132,7 @@ def test_column_validation_core_types():
     cols = "col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float32,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime,col_tstz"
     column_validation_test(
         tc="mock-conn",
-        tables="db2inst1.dvt_core_types",
+        tables="pso_data_validator.dvt_core_types",
         count_cols=cols,
         sum_cols=cols,
         min_cols=cols,
@@ -152,7 +153,7 @@ def test_column_validation_core_types_to_bigquery():
     cols = "col_int8,col_int16,col_int32,col_int64,col_dec_20,col_dec_38,col_dec_10_2,col_float64,col_varchar_30,col_char_2,col_string,col_date,col_datetime"
     column_validation_test(
         tc="bq-conn",
-        tables="db2inst1.dvt_core_types=pso_data_validator.dvt_core_types",
+        tables="pso_data_validator.dvt_core_types",
         sum_cols=cols,
         min_cols=cols,
         max_cols=cols,
@@ -195,7 +196,7 @@ def test_row_validation_core_types():
         ]
     )
     row_validation_test(
-        tables="db2inst1.dvt_core_types",
+        tables="pso_data_validator.dvt_core_types",
         tc="mock-conn",
         hash=cols,
         filters="id>0 AND col_int8>0",
@@ -209,7 +210,7 @@ def test_row_validation_core_types():
 def test_row_validation_core_types_auto_pks():
     """Test auto population of -pks from DB2 defined constraint."""
     row_validation_test(
-        tables="db2inst1.dvt_core_types",
+        tables="pso_data_validator.dvt_core_types",
         tc="mock-conn",
         hash="col_string",
         primary_keys=None,
@@ -252,7 +253,7 @@ def test_row_validation_core_types_to_bigquery():
         ]
     )
     row_validation_test(
-        tables="db2inst1.dvt_core_types=pso_data_validator.dvt_core_types",
+        tables="pso_data_validator.dvt_core_types",
         tc="bq-conn",
         hash=cols,
     )
@@ -265,7 +266,7 @@ def test_row_validation_core_types_to_bigquery():
 def test_custom_query_column_validation_core_types_to_bigquery():
     """DB2 to BigQuery dvt_core_types custom-query column validation"""
     custom_query_validation_test(
-        source_query="select * from db2inst1.dvt_core_types", count_cols="*"
+        source_query="select * from pso_data_validator.dvt_core_types", count_cols="*"
     )
 
 
@@ -277,7 +278,7 @@ def test_custom_query_row_validation_core_types_to_bigquery():
     """DB2 to BigQuery dvt_core_types custom-query row comparison-fields validation"""
     custom_query_validation_test(
         validation_type="row",
-        source_query="select id,col_int64,col_varchar_30 from db2inst1.dvt_core_types",
+        source_query="select id,col_int64,col_varchar_30 from pso_data_validator.dvt_core_types",
         target_query="select id,col_int64,col_varchar_30 from pso_data_validator.dvt_core_types",
         comp_fields="col_int64,col_varchar_30",
     )
@@ -287,6 +288,15 @@ def test_custom_query_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_find_tables():
+    """Oracle to BigQuery test of find-tables command."""
+    find_tables_test()
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
-    raw_query_test(capsys, table="db2inst1.dvt_core_types")
+    raw_query_test(capsys, table="pso_data_validator.dvt_core_types")


### PR DESCRIPTION
## Description of changes

This PR:

- Creates test tables in a dedicated schema, different from the admin user.
- Adds find-tables integration test
- Fixes a bug that only finds tables if they are created in the same account as that connected to the database

## Issues to be closed

Closes #1646


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


