### PR TITLE
fix: add no schema binding for support for external schemas

### DIFF
--- a/third_party/ibis/ibis_redshift/__init__.py
+++ b/third_party/ibis/ibis_redshift/__init__.py
@@ -93,7 +93,7 @@ class Backend(BaseAlchemyBackend):
         if self.inspector.has_table(query):
             query = f"TABLE {query}"
         with self.begin() as con:
-            con.exec_driver_sql(f"CREATE VIEW {name} AS {query}")
+            con.exec_driver_sql(f"CREATE VIEW {name} AS {query} WITH NO SCHEMA BINDING")
             type_info = con.execute(
                 sa.text(type_info_sql).bindparams(raw_name=raw_name)
             )


### PR DESCRIPTION
Closes #1650 
Adds syntax 'WITH NO SCHEMA BINDING' which allows support for external schemas on Redshift.

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


