### PR TITLE
feat: support role and warehouse params

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -127,6 +127,8 @@ CONNECTION_SOURCE_FIELDS = {
         ["password", "Password for authentication of user"],
         ["account", "Snowflake account to connect to"],
         ["database", "Database in snowflake to connect to"],
+        ["warehouse", "Warehouse in snowflake to connect to"],
+        ["role", "Role in snowflake to connect as"],
         ["connect_args", "(Optional) Additional connection argument mapping"],
     ],
     consts.SOURCE_TYPE_POSTGRES: [

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -443,6 +443,8 @@ data-validation connections add
     --password PASSWORD                                 Snowflake password
     --account ACCOUNT                                   Snowflake account
     --database DATABASE/SCHEMA                          Snowflake database and schema, separated by a `/`
+    [--warehouse WAREHOUSE]                             Snowflake warehouse
+    [--role ROLE]                                       Snowflake role
     [--connect-args CONNECT_ARGS]                       Additional connection args, JSON String dict, default {}
 ```
 

--- a/third_party/ibis/ibis_snowflake/api.py
+++ b/third_party/ibis/ibis_snowflake/api.py
@@ -35,38 +35,17 @@ def snowflake_connect(
 ):
     if connect_args:
         connect_args = dvt_config_string_to_dict(connect_args)
-    if role and warehouse:
-        return ibis.snowflake.connect(
-            user=user,
-            password=password,
-            account=account,
-            database=database,
-            connect_args=connect_args,
-            role=role,
-            warehouse=warehouse,
-        )
-    elif role:
-        return ibis.snowflake.connect(
-            user=user,
-            password=password,
-            account=account,
-            database=database,
-            connect_args=connect_args,
-            role=role,
-        )
-    elif warehouse:
-        return ibis.snowflake.connect(
-            user=user,
-            password=password,
-            account=account,
-            database=database,
-            connect_args=connect_args,
-            warehouse=warehouse,
-        )
-    return ibis.snowflake.connect(
-        user=user,
-        password=password,
-        account=account,
-        database=database,
-        connect_args=connect_args,
-    )
+
+    client_args = {
+        "user": user,
+        "password": password,
+        "account": account,
+        "database": database,
+        "connect_args": connect_args,
+    }
+    if role:
+        client_args["role"] = role
+    if warehouse:
+        client_args["warehouse"] = warehouse
+
+    return ibis.snowflake.connect(**client_args)

--- a/third_party/ibis/ibis_snowflake/api.py
+++ b/third_party/ibis/ibis_snowflake/api.py
@@ -29,10 +29,40 @@ def snowflake_connect(
     password: str,
     account: str,
     database: str,
+    warehouse: str = None,
+    role: str = None,
     connect_args: str = None,
 ):
     if connect_args:
         connect_args = dvt_config_string_to_dict(connect_args)
+    if role and warehouse:
+        return ibis.snowflake.connect(
+            user=user,
+            password=password,
+            account=account,
+            database=database,
+            connect_args=connect_args,
+            role=role,
+            warehouse=warehouse,
+        )
+    elif role:
+        return ibis.snowflake.connect(
+            user=user,
+            password=password,
+            account=account,
+            database=database,
+            connect_args=connect_args,
+            role=role,
+        )
+    elif warehouse:
+        return ibis.snowflake.connect(
+            user=user,
+            password=password,
+            account=account,
+            database=database,
+            connect_args=connect_args,
+            warehouse=warehouse,
+        )
     return ibis.snowflake.connect(
         user=user,
         password=password,


### PR DESCRIPTION
Adds optional fields of role and warehouse as **kwargs that the `ibis.snowflake.connect()` method supports. Needed for customer. Tested on Snowflake instance.

Closes #1659 

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


