### PR TITLE
feat: Add --use-random-row for custom-query row validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,10 @@ data-validation
                         Comma-separated key value pair labels for the run.
   [--format or -fmt FORMAT]
                         Format for stdout output. Supported formats are (text, csv, json, table). Defaults to table.
+  [--use-random-row or -rr]
+                        Finds a set of random rows of the first primary key supplied.
+  [--random-row-batch-size or -rbs]
+                        Row batch size used for random row filters (default 10,000).
   [--filter-status or -fs STATUSES_LIST]
                         Comma separated list of statuses to filter the validation results. Supported statuses are (success, fail). If no list is provided, all statuses are returned.
   [--case-insensitive-match, -cim]

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -16,7 +16,7 @@
 # Copied from https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/.kokoro/build.sh
 #
 
-PYTHON="python3.9"
+PYTHON="python3.11"
 if [[ -n "$1" && "$1" =~ python.* ]]; then
     PYTHON=$1
 fi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -99,7 +99,8 @@ steps:
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_oracle
-  name: 'gcr.io/pso-kokoro-resources/python-multi-oracle-21client'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  #name: 'gcr.io/pso-kokoro-resources/python-multi-oracle-21client'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_oracle'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -100,7 +100,6 @@ steps:
   waitFor: ['-']
 - id: integration_oracle
   name: 'gcr.io/cloud-devrel-public-resources/python-multi'
-  #name: 'gcr.io/pso-kokoro-resources/python-multi-oracle-21client'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_oracle'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,10 +30,10 @@ steps:
   - 'NOX_SESSION=unit'
   waitFor: ['-']
 - id: unit-alpine
-  name: 'python:3.10-alpine'
+  name: 'python:3.11-alpine'
   script: |
     apk add bash
-    bash ./ci/build.sh python3.10
+    bash ./ci/build.sh python3.11
   env:
   - 'NOX_SESSION=unit_default_python'
   waitFor: ['-']

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -663,7 +663,7 @@ def _configure_row_parser(
         ),
     )
     # Generate-table-partitions and custom-query does not support random row
-    if not (is_generate_partitions or is_custom_query):
+    if not is_generate_partitions:
         optional_arguments.add_argument(
             "--use-random-row",
             "-rr",
@@ -675,17 +675,18 @@ def _configure_row_parser(
             "-rbs",
             help="Row batch size used for random row filters (default 10,000).",
         )
-        # Generate table partitions follows a new argument spec where either the table names or queries can be provided, but not both.
-        # that is specified in configure_partition_parser. If we use the same spec for row and column validation, the custom query commands
-        # may get subsumed by validate and validate commands by specifying tables name or queries. Until this -tbls will be
-        # a required argument for validate row, validate column and validate schema.
-        required_arguments.add_argument(
-            "--tables-list",
-            "-tbls",
-            default=None,
-            required=True,
-            help="Comma separated tables list in the form 'schema.table=target_schema.target_table'",
-        )
+        if not is_custom_query:
+            # Generate table partitions follows a new argument spec where either the table names or queries can be provided, but not both.
+            # that is specified in configure_partition_parser. If we use the same spec for row and column validation, the custom query commands
+            # may get subsumed by validate and validate commands by specifying tables name or queries. Until this -tbls will be
+            # a required argument for validate row, validate column and validate schema.
+            required_arguments.add_argument(
+                "--tables-list",
+                "-tbls",
+                default=None,
+                required=True,
+                help="Comma separated tables list in the form 'schema.table=target_schema.target_table'",
+            )
 
     # Group for mutually exclusive required arguments. Either must be supplied
     mutually_exclusive_arguments = required_arguments.add_mutually_exclusive_group(

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -662,7 +662,7 @@ def _configure_row_parser(
                 defaults, so most users do not need to use this option unless they encounter errors."""
         ),
     )
-    # Generate-table-partitions and custom-query does not support random row
+    # Generate-table-partitions does not support random row
     if not is_generate_partitions:
         optional_arguments.add_argument(
             "--use-random-row",

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,14 +27,11 @@ import random
 import nox
 
 # Python version used for linting.
-# DEFAULT_PYTHON_VERSION = "3.10"
-DEFAULT_PYTHON_VERSION = "3.11"
+DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing.
-# PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
-PYTHON_VERSIONS = ["3.11"]
-# PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
-PYTHON_VERSIONS_ORACLE = ["3.11"]
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
 
 BLACK_PATHS = (
     "data_validation",

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,8 +32,9 @@ DEFAULT_PYTHON_VERSION = "3.11"
 # Python versions used for testing.
 #PYTHON_VERSIONS = ["3.10", "3.11"]
 PYTHON_VERSIONS = ["3.11"]
-#PYTHON_VERSIONS_ORACLE = ["3.10"]
-PYTHON_VERSIONS_ORACLE = ["3.11"]
+# As of 2026-02-05 gcr.io/pso-kokoro-resources/python-multi-oracle-21client only
+# has Python 3.10.
+PYTHON_VERSIONS_ORACLE = ["3.10"]
 
 BLACK_PATHS = (
     "data_validation",

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,11 +27,14 @@ import random
 import nox
 
 # Python version used for linting.
-DEFAULT_PYTHON_VERSION = "3.10"
+# DEFAULT_PYTHON_VERSION = "3.10"
+DEFAULT_PYTHON_VERSION = "3.11"
 
 # Python versions used for testing.
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
-PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
+# PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+PYTHON_VERSIONS = ["3.11"]
+# PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
+PYTHON_VERSIONS_ORACLE = ["3.11"]
 
 BLACK_PATHS = (
     "data_validation",

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,12 +27,12 @@ import random
 import nox
 
 # Python version used for linting.
-DEFAULT_PYTHON_VERSION = "3.10"
+DEFAULT_PYTHON_VERSION = "3.11"
 
 # Python versions used for testing.
-#PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+#PYTHON_VERSIONS = ["3.10", "3.11"]
 PYTHON_VERSIONS = ["3.11"]
-#PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
+#PYTHON_VERSIONS_ORACLE = ["3.10"]
 PYTHON_VERSIONS_ORACLE = ["3.11"]
 
 BLACK_PATHS = (

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,8 @@ DEFAULT_PYTHON_VERSION = "3.11"
 PYTHON_VERSIONS = ["3.11"]
 # As of 2026-02-05 gcr.io/pso-kokoro-resources/python-multi-oracle-21client only
 # has Python 3.10.
-PYTHON_VERSIONS_ORACLE = ["3.10"]
+#PYTHON_VERSIONS_ORACLE = ["3.10"]
+PYTHON_VERSIONS_ORACLE = ["3.11"]
 
 BLACK_PATHS = (
     "data_validation",

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,8 +30,10 @@ import nox
 DEFAULT_PYTHON_VERSION = "3.10"
 
 # Python versions used for testing.
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
-PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
+#PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+PYTHON_VERSIONS = ["3.11"]
+#PYTHON_VERSIONS_ORACLE = ["3.9", "3.10"]
+PYTHON_VERSIONS_ORACLE = ["3.11"]
 
 BLACK_PATHS = (
     "data_validation",

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,12 +30,10 @@ import nox
 DEFAULT_PYTHON_VERSION = "3.11"
 
 # Python versions used for testing.
-#PYTHON_VERSIONS = ["3.10", "3.11"]
+# As of 2026-02-06 the only valid Python versions on python-multi image
+# are Python 3.11-3.14. DVT only supports 3.9-3.11 so 3.11 is the only
+# version we can currently test on.
 PYTHON_VERSIONS = ["3.11"]
-# As of 2026-02-05 gcr.io/pso-kokoro-resources/python-multi-oracle-21client only
-# has Python 3.10.
-#PYTHON_VERSIONS_ORACLE = ["3.10"]
-PYTHON_VERSIONS_ORACLE = ["3.11"]
 
 BLACK_PATHS = (
     "data_validation",
@@ -253,7 +251,7 @@ def integration_state(session):
     session.run("pytest", test_path, *session.posargs)
 
 
-@nox.session(python=random.choice(PYTHON_VERSIONS_ORACLE), venv_backend="venv")
+@nox.session(python=random.choice(PYTHON_VERSIONS), venv_backend="venv")
 def integration_oracle(session):
     """Run Oracle integration tests.
     Ensure Oracle validation is running as expected.

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -450,7 +450,7 @@ def row_validation_test(
     primary_keys: Optional[str] = "id",
     comp_fields: Optional[str] = None,
     concat: Optional[str] = None,
-    use_randow_row=False,
+    use_random_row=False,
     random_row_batch_size=None,
     result_handler: Optional[str] = None,
 ):
@@ -472,7 +472,7 @@ def row_validation_test(
         f"--primary-keys={primary_keys}" if primary_keys else None,
         col_option,
         f"--filter-status={filter_status}" if filter_status else None,
-        "--use-random-row" if use_randow_row else None,
+        "--use-random-row" if use_random_row else None,
         (
             f"--random-row-batch-size={random_row_batch_size}"
             if random_row_batch_size
@@ -495,7 +495,7 @@ def id_column_row_validation_test(
     hash: str = "id,other_data",
     comp_fields: Optional[str] = None,
     concat: Optional[str] = None,
-    use_randow_row: bool = True,
+    use_random_row: bool = True,
 ):
     """Specific row validation test for primary key data type tests"""
     parser = cli_tools.configure_arg_parser()
@@ -513,8 +513,8 @@ def id_column_row_validation_test(
         f"-tbls={tables}",
         "--primary-keys=id",
         col_option,
-        "--use-random-row" if use_randow_row else None,
-        "--random-row-batch-size=5" if use_randow_row else None,
+        "--use-random-row" if use_random_row else None,
+        "--random-row-batch-size=5" if use_random_row else None,
     ]
     cli_arg_list = [_ for _ in cli_arg_list if _]
     args = parser.parse_args(cli_arg_list)
@@ -717,6 +717,7 @@ def custom_query_validation_test(
     source_query="select * from pso_data_validator.dvt_core_types",
     target_query="select * from pso_data_validator.dvt_core_types",
     filters=None,
+    filter_status: str = "fail",
     count_cols=None,
     min_cols=None,
     max_cols=None,
@@ -726,6 +727,8 @@ def custom_query_validation_test(
     hash="*",
     concat=None,
     assert_df_not_empty=False,
+    use_random_row=False,
+    random_row_batch_size=None,
 ):
     """Generic custom-query validation test.
 
@@ -740,7 +743,7 @@ def custom_query_validation_test(
         f"-tc={tc}",
         f"--source-query={source_query}",
         f"--target-query={target_query}",
-        "--filter-status=fail",
+        f"--filter-status={filter_status}" if filter_status else None,
         f"--filters={filters}" if filters else None,
         # Column validation parameters
         f"--count={count_cols}" if count_cols else None,
@@ -762,6 +765,11 @@ def custom_query_validation_test(
         else:
             cli_arg_list.append(f"--hash={hash}")
 
+        if use_random_row:
+            cli_arg_list.append("--use-random-row")
+            if random_row_batch_size:
+                cli_arg_list.append(f"--random-row-batch-size={random_row_batch_size}")
+
     args = parser.parse_args(cli_arg_list)
     df = run_test_from_cli_args(args)
     if assert_df_not_empty:
@@ -770,6 +778,7 @@ def custom_query_validation_test(
     else:
         # With filter on failures the data frame should be empty
         assert len(df) == 0
+    return df
 
 
 def raw_query_rows(

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -311,7 +311,7 @@ def test_row_validation_large_decimals_to_bigquery():
         tables="pso_data_validator.dvt_large_decimals",
         tc="bq-conn",
         hash="col_dec_18",
-        use_randow_row=True,
+        use_random_row=True,
         random_row_batch_size=5,
     )
 

--- a/tests/system/data_sources/test_mysql.py
+++ b/tests/system/data_sources/test_mysql.py
@@ -454,10 +454,10 @@ def test_varchar_pk_query_row_validation_to_bigquery():
 )
 def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns"""
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
-        use_randow_row=False,
+        use_random_row=False,
     )
 
 

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -825,6 +825,26 @@ def test_custom_query_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_custom_query_row_validation_random_rows():
+    """Oracle to BigQuery dvt_core_types custom-query row comparison-fields validation"""
+    df = custom_query_validation_test(
+        validation_type="row",
+        source_query="select * from pso_data_validator.dvt_core_types",
+        target_query="select * from pso_data_validator.dvt_core_types",
+        concat="id,col_varchar_30,col_date",
+        use_random_row=True,
+        random_row_batch_size=2,
+        filter_status=None,
+        assert_df_not_empty=True,
+    )
+    # There should only be 2 rows in the result set due to random row sampling.
+    assert len(df) == 2
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_custom_query_row_hash_validation_core_types_to_bigquery():
     """Oracle to BigQuery dvt_core_types custom-query row hash validation"""
     custom_query_validation_test(

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -545,7 +545,7 @@ def test_row_validation_core_types_to_bigquery():
     row_validation_test(
         tc="bq-conn",
         hash=cols,
-        use_randow_row=True,
+        use_random_row=True,
         random_row_batch_size=5,
     )
 
@@ -646,7 +646,7 @@ def test_row_validation_large_decimals_to_bigquery():
         tables="pso_data_validator.dvt_large_decimals",
         tc="bq-conn",
         hash="id,col_data,col_dec_18,col_dec_38,col_dec_38_9,col_dec_38_30",
-        # use_randow_row=True,
+        # use_random_row=True,
         # random_row_batch_size=5,
     )
 
@@ -734,10 +734,10 @@ def test_varchar_pk_query_row_validation_to_bigquery():
 )
 def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns"""
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
-        use_randow_row=False,
+        use_random_row=False,
     )
 
 
@@ -1220,7 +1220,7 @@ def test_row_validation_uuid_rr_oracle_to_postgres():
         tables="pso_data_validator.dvt_uuid_id",
         tc="pg-conn",
         hash="*",
-        use_randow_row=True,
+        use_random_row=True,
     )
 
 

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -923,10 +923,10 @@ def test_varchar_pk_query_row_validation_to_bigquery():
 )
 def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns"""
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
-        use_randow_row=False,
+        use_random_row=False,
     )
 
 

--- a/tests/system/data_sources/test_snowflake.py
+++ b/tests/system/data_sources/test_snowflake.py
@@ -429,10 +429,10 @@ def test_row_validation_char_pk_to_bigquery():
     pytest.skip(
         "Skipping test_row_validation_char_pk_to_bigquery because of Snowflake CHAR semantics"
     )
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "PSO_DATA_VALIDATOR.PUBLIC.DVT_CHAR_ID=pso_data_validator.dvt_char_id",
-        use_randow_row=False,
+        use_random_row=False,
     )
 
 
@@ -442,10 +442,10 @@ def test_row_validation_char_pk_to_bigquery():
 )
 def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns"""
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "PSO_DATA_VALIDATOR.PUBLIC.DVT_DATETIME_ID=pso_data_validator.dvt_datetime_id",
-        use_randow_row=False,
+        use_random_row=False,
     )
 
 

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -698,10 +698,10 @@ def test_row_validation_comp_fields_binary_values_to_bigquery():
 )
 def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns"""
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
-        use_randow_row=False,
+        use_random_row=False,
     )
 
 

--- a/tests/system/data_sources/test_sybase.py
+++ b/tests/system/data_sources/test_sybase.py
@@ -409,7 +409,7 @@ def test_row_validation_core_types_to_bigquery():
         ]
     )
     row_validation_test(
-        tc="bq-conn", concat=cols, use_randow_row=True, random_row_batch_size=5
+        tc="bq-conn", concat=cols, use_random_row=True, random_row_batch_size=5
     )
 
 
@@ -540,10 +540,10 @@ def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns.
 
     Sybase does not have a SHA256 hash function therefore this test uses concat."""
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "pso_data_validator.dvt_datetime_id",
-        use_randow_row=False,
+        use_random_row=False,
         concat="id,other_data",
     )
 

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -687,10 +687,10 @@ def test_varchar_pk_query_row_validation_to_bigquery():
 )
 def test_row_validation_datetime_pk_to_bigquery():
     """Test datetime primary key join columns"""
-    # TODO Remove use_randow_row option below when issue-1445 is actioned.
+    # TODO Remove use_random_row option below when issue-1445 is actioned.
     id_column_row_validation_test(
         "udf.dvt_datetime_id=pso_data_validator.dvt_datetime_id",
-        use_randow_row=False,
+        use_random_row=False,
     )
 
 

--- a/third_party/ibis/ibis_sybase/__init__.py
+++ b/third_party/ibis/ibis_sybase/__init__.py
@@ -112,7 +112,6 @@ class Backend(BaseAlchemyBackend):
     def _handle_failed_column_type_inference(
         self, table: sa.Table, nulltype_cols: Iterable[str]
     ) -> sa.Table:
-        breakpoint()
         return dvt_handle_failed_column_type_inference(self, table, nulltype_cols)
 
     def _metadata(self, query) -> Iterable[Tuple[str, dt.DataType]]:

--- a/third_party/ibis/ibis_sybase/datatypes.py
+++ b/third_party/ibis/ibis_sybase/datatypes.py
@@ -77,7 +77,6 @@ def type_from_result_set_info(
     """Construct an ibis type from Sybase result set description."""
     typ = _type_mapping.get(type_name)
     if typ is None:
-        breakpoint()
         raise NotImplementedError(f"Sybase type {type_name} is not supported")
 
     if type_name == "decimal":


### PR DESCRIPTION
## Description of changes
This PR adds the options `--use-random-row` and `--random-row-batch-size` for custom-query row validations.

This PR also restricts the tested Python version to 3.11 because 3.9 and 3.10 are no longer available on the python-multi image. We'll need to prioritise the Ibis upgrade issue soon.

There are a good number of test file edits which were me fixing a typo, `use_randow_row` to `use_random_row`.

## Issues to be closed

Closes #1448

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


