### PR TITLE
fix: Accurate string length when casting numbers to string in Db2

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,13 +18,13 @@ options:
     name: 'projects/pso-kokoro-resources/locations/us-central1/workerPools/private-pool'
 steps:
 - id: lint
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=lint'
   waitFor: ['-']
 - id: unit
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=unit'
@@ -38,11 +38,11 @@ steps:
   - 'NOX_SESSION=unit_default_python'
   waitFor: ['-']
 - id: proxy-install
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/install_cloud_proxy.sh']
   waitFor: ["-"]
 - id: integration_mysql
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_mysql'
@@ -51,7 +51,7 @@ steps:
   waitFor: ['proxy-install']
   secretEnv: ['MYSQL_PASSWORD']
 - id: integration_postgres
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_postgres'
@@ -60,7 +60,7 @@ steps:
   secretEnv: ['POSTGRES_PASSWORD']
   waitFor: ['proxy-install']
 - id: integration_sql_server
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_sql_server'
@@ -69,21 +69,21 @@ steps:
   secretEnv: ['SQL_SERVER_PASSWORD']
   waitFor: ['proxy-install']
 - id: integration_bigquery
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_bigquery'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_spanner
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_spanner'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_teradata
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_teradata'
@@ -92,14 +92,14 @@ steps:
   secretEnv: ['TERADATA_PASSWORD']
   waitFor: ['-']
 - id: integration_state
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_state'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_oracle
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_oracle'
@@ -109,7 +109,7 @@ steps:
   secretEnv: ['ORACLE_PASSWORD', 'POSTGRES_PASSWORD']
   waitFor: ['proxy-install']
 - id: integration_hive
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_hive'
@@ -117,7 +117,7 @@ steps:
   - 'HIVE_HOST=10.128.15.219'
   waitFor: ['-']
 - id: integration_snowflake
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_snowflake'
@@ -125,7 +125,7 @@ steps:
   secretEnv: ['SNOWFLAKE_ACCOUNT', 'SNOWFLAKE_USER', 'SNOWFLAKE_PASSWORD']
   waitFor: ['-']
 - id: integration_db2
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_db2'
@@ -134,14 +134,14 @@ steps:
   secretEnv: ['DB2_PASSWORD']
   waitFor: ['-']
 - id: integration_filesystem
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_filesystem'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_impala
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_impala'
@@ -149,7 +149,7 @@ steps:
   - 'IMPALA_HOST=10.128.0.118'
   waitFor: ['-']
 - id: integration_sybase
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-3380185c3bdc0a98ce7d02ac5fbf6908f8da461464b62f32b48f197ca56cf510'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_sybase'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,13 +18,13 @@ options:
     name: 'projects/pso-kokoro-resources/locations/us-central1/workerPools/private-pool'
 steps:
 - id: lint
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=lint'
   waitFor: ['-']
 - id: unit
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=unit'
@@ -38,11 +38,11 @@ steps:
   - 'NOX_SESSION=unit_default_python'
   waitFor: ['-']
 - id: proxy-install
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/install_cloud_proxy.sh']
   waitFor: ["-"]
 - id: integration_mysql
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_mysql'
@@ -51,7 +51,7 @@ steps:
   waitFor: ['proxy-install']
   secretEnv: ['MYSQL_PASSWORD']
 - id: integration_postgres
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_postgres'
@@ -60,7 +60,7 @@ steps:
   secretEnv: ['POSTGRES_PASSWORD']
   waitFor: ['proxy-install']
 - id: integration_sql_server
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_sql_server'
@@ -69,21 +69,21 @@ steps:
   secretEnv: ['SQL_SERVER_PASSWORD']
   waitFor: ['proxy-install']
 - id: integration_bigquery
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_bigquery'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_spanner
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_spanner'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_teradata
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_teradata'
@@ -92,14 +92,14 @@ steps:
   secretEnv: ['TERADATA_PASSWORD']
   waitFor: ['-']
 - id: integration_state
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_state'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_oracle
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_oracle'
@@ -109,7 +109,7 @@ steps:
   secretEnv: ['ORACLE_PASSWORD', 'POSTGRES_PASSWORD']
   waitFor: ['proxy-install']
 - id: integration_hive
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_hive'
@@ -117,7 +117,7 @@ steps:
   - 'HIVE_HOST=10.128.15.219'
   waitFor: ['-']
 - id: integration_snowflake
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_snowflake'
@@ -125,7 +125,7 @@ steps:
   secretEnv: ['SNOWFLAKE_ACCOUNT', 'SNOWFLAKE_USER', 'SNOWFLAKE_PASSWORD']
   waitFor: ['-']
 - id: integration_db2
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_db2'
@@ -134,14 +134,14 @@ steps:
   secretEnv: ['DB2_PASSWORD']
   waitFor: ['-']
 - id: integration_filesystem
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_filesystem'
   - 'PROJECT_ID=pso-kokoro-resources'
   waitFor: ['-']
 - id: integration_impala
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_impala'
@@ -149,7 +149,7 @@ steps:
   - 'IMPALA_HOST=10.128.0.118'
   waitFor: ['-']
 - id: integration_sybase
-  name: 'gcr.io/cloud-devrel-public-resources/python-multi'
+  name: 'gcr.io/cloud-devrel-public-resources/python-multi:deprecated-public-image-6088fe053e1b18f5b27fbe6e3c41f81f8bb4e5e2140f6f2f65da3ad30b66f2f0'
   args: ['bash', './ci/build.sh']
   env:
   - 'NOX_SESSION=integration_sybase'

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -292,10 +292,11 @@ def test_row_validation_large_decimals_to_bigquery():
     This is testing large decimals for the primary key join column plus the hash columns.
     Only includes decimal(18) columns due to Db2 maximum precision for DECIMAL of 31 digits.
     """
+    # Add col_data into hash value below once issue-1634 has been fixed.
     row_validation_test(
         tables="pso_data_validator.dvt_large_decimals",
         tc="bq-conn",
-        hash="id,col_data,col_dec_18",
+        hash="id,col_dec_18",
         use_random_row=True,
         random_row_batch_size=5,
     )

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -267,7 +267,6 @@ def test_row_validation_core_types_to_bigquery():
     # float32/64 are lossy and cannot be compared.
     # Exclude col_string because it is unbound and causes overflow error for HEX function.
     # TODO: When issue-1638 is complete remove col_char_2 from exclusion list below.
-    # TODO: When issue-1634 is complete remove columns tagged with issue-1634 from exclusion list below.
     cols = ",".join(
         [
             _
@@ -275,14 +274,8 @@ def test_row_validation_core_types_to_bigquery():
             if _
             not in (
                 "id",
-                "col_int8",  # issue-1634
-                "col_int16",  # issue-1634
-                "col_int32",  # issue-1634
-                "col_dec_20",  # issue-1634
-                "col_dec_38",  # issue-1634
-                "col_dec_10_2",  # issue-1634
                 "col_float32",
-                "col_float64",  # issue-1634
+                "col_float64",
                 "col_char_2",
                 "col_string",
                 "col_tstz",

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -214,7 +214,6 @@ def test_row_validation_core_types():
     """Db2 to Db2 dvt_core_types row validation"""
     # Exclude col_string because it is unbound and causes overflow error for HEX function.
     # TODO: When issue-1638 is complete remove col_char_2 from exclusion list below.
-    # TODO: When issue-1634 is complete remove columns tagged with issue-1634 from exclusion list below.
     cols = ",".join(
         [
             _
@@ -222,14 +221,6 @@ def test_row_validation_core_types():
             if _
             not in (
                 "id",
-                "col_int8",  # issue-1634
-                "col_int16",  # issue-1634
-                "col_int32",  # issue-1634
-                "col_dec_20",  # issue-1634
-                "col_dec_38",  # issue-1634
-                "col_dec_10_2",  # issue-1634
-                "col_float32",  # issue-1634
-                "col_float64",  # issue-1634
                 "col_char_2",
                 "col_string",
             )
@@ -267,6 +258,7 @@ def test_row_validation_core_types_to_bigquery():
     # float32/64 are lossy and cannot be compared.
     # Exclude col_string because it is unbound and causes overflow error for HEX function.
     # TODO: When issue-1638 is complete remove col_char_2 from exclusion list below.
+    # TODO: When issue-1669 is complete remove col_dec_10_2 from exclusion list below.
     cols = ",".join(
         [
             _
@@ -274,6 +266,7 @@ def test_row_validation_core_types_to_bigquery():
             if _
             not in (
                 "id",
+                "col_dec_10_2",
                 "col_float32",
                 "col_float64",
                 "col_char_2",
@@ -299,11 +292,10 @@ def test_row_validation_large_decimals_to_bigquery():
     This is testing large decimals for the primary key join column plus the hash columns.
     Only includes decimal(18) columns due to Db2 maximum precision for DECIMAL of 31 digits.
     """
-    # Add id,col_data into hash value below once issue-1634 has been fixed.
     row_validation_test(
         tables="pso_data_validator.dvt_large_decimals",
         tc="bq-conn",
-        hash="col_dec_18",
+        hash="id,col_data,col_dec_18",
         use_random_row=True,
         random_row_batch_size=5,
     )

--- a/tests/unit/ibis_addon/test_api.py
+++ b/tests/unit/ibis_addon/test_api.py
@@ -61,3 +61,21 @@ def test_db2_type_string_length_integer(dtype, expected):
 def test_db2_type_string_length_other():
     dtype = dt.Float64()
     assert api.db2_type_string_length(dtype, []) is None
+
+
+@pytest.mark.parametrize(
+    "dtype, expected",
+    [
+        (dt.Int64(), 20),
+        (dt.Int32(), 11),
+        (dt.Int16(), 6),
+        (dt.Int8(), 4),
+    ],
+)
+def test_ibis_integer_string_length(dtype, expected):
+    assert api.ibis_integer_string_length(dtype) == expected
+
+
+def test_ibis_integer_string_length_other():
+    dtype = dt.Float64()
+    assert api.ibis_integer_string_length(dtype) is None

--- a/third_party/ibis/ibis_addon/api.py
+++ b/third_party/ibis/ibis_addon/api.py
@@ -173,6 +173,14 @@ def db2_type_string_length(
         # Timestamp when converted to string will be at least 19 characters (YYYY-MM-DD HH:MI:SS).
         return 19
     elif ibis_column.is_integer():
+        return ibis_integer_string_length(ibis_column)
+    else:
+        return None
+
+
+def ibis_integer_string_length(ibis_column: dt.DataType) -> Optional[int]:
+    """Return the maximum string length of an integer column, including minus sign."""
+    if ibis_column.is_integer():
         if isinstance(ibis_column, dt.Int64):
             return 20
         elif isinstance(ibis_column, dt.Int32):
@@ -181,7 +189,8 @@ def db2_type_string_length(
             return 6
         elif isinstance(ibis_column, dt.Int8):
             return 4
-        return 20
+        # Safe catch all length.
+        return 38
     else:
         return None
 

--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -33,6 +33,9 @@ from ibis.backends.base.sql.alchemy import (
 )
 from ibis.backends.base.sql.alchemy.registry import variance_reduction
 
+from third_party.ibis.ibis_addon.api import ibis_integer_string_length
+
+
 operation_registry = sqlalchemy_operation_registry.copy()
 operation_registry.update(sqlalchemy_window_functions_registry)
 
@@ -121,9 +124,18 @@ def _cast(t, op):
 
     sa_arg = t.translate(arg)
 
-    # specialize going from an integer type to a timestamp
-    if arg_dtype.is_integer() and typ.is_timestamp():
-        return t.integer_to_timestamp(sa_arg, tz=typ.timezone)
+    if arg_dtype.is_integer():
+        if typ.is_timestamp():
+            # specialize going from an integer type to a timestamp
+            return t.integer_to_timestamp(sa_arg, tz=typ.timezone)
+        elif typ.is_string():
+            string_length = ibis_integer_string_length(arg_dtype)
+            if string_length:
+                # Restring target string length to appropriate length for integer size.
+                return sa.cast(sa_arg, sa.String(string_length))
+    elif arg_dtype.is_decimal() and typ.is_string():
+        # Max expected precision 38 plus 2 for minus sign and decimal place.
+        return sa.cast(sa_arg, sa.String(40))
 
     if arg_dtype.is_binary() and typ.is_string():
         # Binary to string cast is a "to hex" conversion for DVT.


### PR DESCRIPTION
## Description of changes
This PR will use a string cast expression more appropriate to the source numeric size instead of a catch all length.

For example, before this PR we were getting these expressions:
```
 CAST(t5.col_int8 AS VARCHAR(3000)) AS cast__col_int8,
 CAST(t5.col_int16 AS VARCHAR(3000)) AS cast__col_int16,
 CAST(t5.col_int32 AS VARCHAR(3000)) AS cast__col_int32,
 CAST(t5.col_int64 AS VARCHAR(3000)) AS cast__col_int64
```

After the PR we will get:
```
 CAST(t5.col_int8 AS VARCHAR(6)) AS cast__col_int8,
 CAST(t5.col_int16 AS VARCHAR(6)) AS cast__col_int16,
 CAST(t5.col_int32 AS VARCHAR(11)) AS cast__col_int32,
 CAST(t5.col_int64 AS VARCHAR(20)) AS cast__col_int64
```

This is important to avoid us overflowing Db2's hex/hash functions.

## Issues to be closed

Closes #1668


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


