### PR TITLE
fix: Ensure we use casefold column name in raw data type map

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -934,8 +934,8 @@ class ConfigManager(object):
             raise ValueError(f"Unsupported column type: {column_type}")
 
         calculated_config = self.build_and_append_pre_agg_calc_config(
-            source_casefold_column,
-            target_casefold_column,
+            source_column,
+            target_column,
             calc_func,
             column_position,
             cast_type=cast_type,

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -828,19 +828,19 @@ class ConfigManager(object):
 
     def build_and_append_pre_agg_calc_config(
         self,
-        source_casefold_column: str,
-        target_casefold_column: str,
-        calc_func: str,
-        column_position: int,
+        source_column,
+        target_column,
+        calc_func,
+        column_position,
         cast_type: str = None,
         depth: int = 0,
     ):
         """Create calculated field config used as a pre-aggregation step. Appends to calculated fields if does not already exist and returns created config."""
         calculated_config = {
-            consts.CONFIG_CALCULATED_SOURCE_COLUMNS: [source_casefold_column],
-            consts.CONFIG_CALCULATED_TARGET_COLUMNS: [target_casefold_column],
+            consts.CONFIG_CALCULATED_SOURCE_COLUMNS: [source_column],
+            consts.CONFIG_CALCULATED_TARGET_COLUMNS: [target_column],
             consts.CONFIG_FIELD_ALIAS: self._prefix_calc_col_name(
-                source_casefold_column, calc_func, column_position
+                source_column, calc_func, column_position
             ),
             consts.CONFIG_TYPE: calc_func,
             consts.CONFIG_DEPTH: depth,
@@ -849,7 +849,7 @@ class ConfigManager(object):
         if calc_func == consts.CONFIG_CAST and cast_type is not None:
             calculated_config[consts.CONFIG_DEFAULT_CAST] = cast_type
             calculated_config[consts.CONFIG_FIELD_ALIAS] = self._prefix_calc_col_name(
-                source_casefold_column, f"{calc_func}_{cast_type}", column_position
+                source_column, f"{calc_func}_{cast_type}", column_position
             )
 
         existing_calc_fields = [
@@ -862,8 +862,8 @@ class ConfigManager(object):
 
     def append_pre_agg_calc_field(
         self,
-        source_casefold_column: str,
-        target_casefold_column: str,
+        source_column: str,
+        target_column: str,
         agg_type: str,
         column_type: str,
         target_column_type: str,
@@ -876,8 +876,8 @@ class ConfigManager(object):
         if any(_ in ["json", "!json"] for _ in [column_type, target_column_type]):
             # JSON data which needs casting to string before we apply a length function.
             pre_calculated_config = self.build_and_append_pre_agg_calc_config(
-                source_casefold_column,
-                target_casefold_column,
+                source_column,
+                target_column,
                 consts.CONFIG_CAST,
                 column_position,
                 cast_type="string",
@@ -890,7 +890,7 @@ class ConfigManager(object):
             calc_func = consts.CALC_FIELD_LENGTH
 
         elif column_type in ["string", "!string"]:
-            if self._is_sql_server_text(source_casefold_column, target_casefold_column):
+            if self._is_sql_server_text(source_column, target_column):
                 calc_func = consts.CALC_FIELD_BYTE_LENGTH
             else:
                 calc_func = consts.CALC_FIELD_LENGTH
@@ -908,8 +908,8 @@ class ConfigManager(object):
                 or self.target_client.name == "bigquery"
             ):
                 pre_calculated_config = self.build_and_append_pre_agg_calc_config(
-                    source_casefold_column,
-                    target_casefold_column,
+                    source_column,
+                    target_column,
                     consts.CONFIG_CAST,
                     column_position,
                     cast_type="timestamp",
@@ -1028,8 +1028,8 @@ class ConfigManager(object):
         """Return list of aggregate objects of given agg_type."""
 
         def require_pre_agg_calc_field(
-            source_casefold_column: str,
-            target_casefold_column: str,
+            source_column: str,
+            target_column: str,
             column_type: str,
             target_column_type: str,
             agg_type: str,
@@ -1044,10 +1044,8 @@ class ConfigManager(object):
                     # Oracle LOBs & SQL Server TEXT need a length before the count().
                     # TODO As does Sybase TEXT, see issue-1675.
                     return self._is_oracle_lob(
-                        source_casefold_column, target_casefold_column
-                    ) or self._is_sql_server_text(
-                        source_casefold_column, target_casefold_column
-                    )
+                        source_column, target_column
+                    ) or self._is_sql_server_text(source_column, target_column)
                 else:
                     return True
             elif self._is_uuid(column_type, target_column_type):
@@ -1057,9 +1055,7 @@ class ConfigManager(object):
                     # Oracle BLOB is invalid for use with SQL COUNT function.
                     # The expression below returns True if client is Oracle which
                     # has the effect of triggering use of byte_length transformation.
-                    return self._is_oracle_lob(
-                        source_casefold_column, target_casefold_column
-                    )
+                    return self._is_oracle_lob(source_column, target_column)
                 else:
                     # Convert to length for any min/max/sum on binary columns.
                     return True
@@ -1154,16 +1150,16 @@ class ConfigManager(object):
                 continue
 
             if require_pre_agg_calc_field(
-                column,
-                column,
+                casefold_source_columns[column],
+                casefold_target_columns[column],
                 column_type,
                 target_column_type,
                 agg_type,
                 cast_to_bigint,
             ):
                 aggregate_config = self.append_pre_agg_calc_field(
-                    column,
-                    column,
+                    casefold_source_columns[column],
+                    casefold_target_columns[column],
                     agg_type,
                     column_type,
                     target_column_type,

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -731,16 +731,19 @@ class ConfigManager(object):
         """Returns True when either source or target column is of a client & type."""
         raw_source_types = self.get_source_raw_data_types()
         raw_target_types = self.get_target_raw_data_types()
+        # Raw data type map uses casefold column name as the key.
         return bool(
             (
                 self.source_client.name == client_name
                 and raw_source_types
-                and raw_source_types.get(source_column_name, [None])[0] in type_list
+                and raw_source_types.get(source_column_name.casefold(), [None])[0]
+                in type_list
             )
             or (
                 self.target_client.name == client_name
                 and raw_target_types
-                and raw_target_types.get(target_column_name, [None])[0] in type_list
+                and raw_target_types.get(target_column_name.casefold(), [None])[0]
+                in type_list
             )
         )
 

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -828,19 +828,19 @@ class ConfigManager(object):
 
     def build_and_append_pre_agg_calc_config(
         self,
-        source_column,
-        target_column,
-        calc_func,
-        column_position,
+        source_casefold_column: str,
+        target_casefold_column: str,
+        calc_func: str,
+        column_position: int,
         cast_type: str = None,
         depth: int = 0,
     ):
         """Create calculated field config used as a pre-aggregation step. Appends to calculated fields if does not already exist and returns created config."""
         calculated_config = {
-            consts.CONFIG_CALCULATED_SOURCE_COLUMNS: [source_column],
-            consts.CONFIG_CALCULATED_TARGET_COLUMNS: [target_column],
+            consts.CONFIG_CALCULATED_SOURCE_COLUMNS: [source_casefold_column],
+            consts.CONFIG_CALCULATED_TARGET_COLUMNS: [target_casefold_column],
             consts.CONFIG_FIELD_ALIAS: self._prefix_calc_col_name(
-                source_column, calc_func, column_position
+                source_casefold_column, calc_func, column_position
             ),
             consts.CONFIG_TYPE: calc_func,
             consts.CONFIG_DEPTH: depth,
@@ -849,7 +849,7 @@ class ConfigManager(object):
         if calc_func == consts.CONFIG_CAST and cast_type is not None:
             calculated_config[consts.CONFIG_DEFAULT_CAST] = cast_type
             calculated_config[consts.CONFIG_FIELD_ALIAS] = self._prefix_calc_col_name(
-                source_column, f"{calc_func}_{cast_type}", column_position
+                source_casefold_column, f"{calc_func}_{cast_type}", column_position
             )
 
         existing_calc_fields = [
@@ -862,8 +862,8 @@ class ConfigManager(object):
 
     def append_pre_agg_calc_field(
         self,
-        source_column: str,
-        target_column: str,
+        source_casefold_column: str,
+        target_casefold_column: str,
         agg_type: str,
         column_type: str,
         target_column_type: str,
@@ -876,8 +876,8 @@ class ConfigManager(object):
         if any(_ in ["json", "!json"] for _ in [column_type, target_column_type]):
             # JSON data which needs casting to string before we apply a length function.
             pre_calculated_config = self.build_and_append_pre_agg_calc_config(
-                source_column,
-                target_column,
+                source_casefold_column,
+                target_casefold_column,
                 consts.CONFIG_CAST,
                 column_position,
                 cast_type="string",
@@ -890,7 +890,7 @@ class ConfigManager(object):
             calc_func = consts.CALC_FIELD_LENGTH
 
         elif column_type in ["string", "!string"]:
-            if self._is_sql_server_text(source_column, target_column):
+            if self._is_sql_server_text(source_casefold_column, target_casefold_column):
                 calc_func = consts.CALC_FIELD_BYTE_LENGTH
             else:
                 calc_func = consts.CALC_FIELD_LENGTH
@@ -908,8 +908,8 @@ class ConfigManager(object):
                 or self.target_client.name == "bigquery"
             ):
                 pre_calculated_config = self.build_and_append_pre_agg_calc_config(
-                    source_column,
-                    target_column,
+                    source_casefold_column,
+                    target_casefold_column,
                     consts.CONFIG_CAST,
                     column_position,
                     cast_type="timestamp",
@@ -1028,8 +1028,8 @@ class ConfigManager(object):
         """Return list of aggregate objects of given agg_type."""
 
         def require_pre_agg_calc_field(
-            source_column: str,
-            target_column: str,
+            source_casefold_column: str,
+            target_casefold_column: str,
             column_type: str,
             target_column_type: str,
             agg_type: str,
@@ -1044,8 +1044,10 @@ class ConfigManager(object):
                     # Oracle LOBs & SQL Server TEXT need a length before the count().
                     # TODO As does Sybase TEXT, see issue-1675.
                     return self._is_oracle_lob(
-                        source_column, target_column
-                    ) or self._is_sql_server_text(source_column, target_column)
+                        source_casefold_column, target_casefold_column
+                    ) or self._is_sql_server_text(
+                        source_casefold_column, target_casefold_column
+                    )
                 else:
                     return True
             elif self._is_uuid(column_type, target_column_type):
@@ -1055,7 +1057,9 @@ class ConfigManager(object):
                     # Oracle BLOB is invalid for use with SQL COUNT function.
                     # The expression below returns True if client is Oracle which
                     # has the effect of triggering use of byte_length transformation.
-                    return self._is_oracle_lob(source_column, target_column)
+                    return self._is_oracle_lob(
+                        source_casefold_column, target_casefold_column
+                    )
                 else:
                     # Convert to length for any min/max/sum on binary columns.
                     return True
@@ -1150,16 +1154,16 @@ class ConfigManager(object):
                 continue
 
             if require_pre_agg_calc_field(
-                casefold_source_columns[column],
-                casefold_target_columns[column],
+                column,
+                column,
                 column_type,
                 target_column_type,
                 agg_type,
                 cast_to_bigint,
             ):
                 aggregate_config = self.append_pre_agg_calc_field(
-                    casefold_source_columns[column],
-                    casefold_target_columns[column],
+                    column,
+                    column,
                     agg_type,
                     column_type,
                     target_column_type,

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -934,8 +934,8 @@ class ConfigManager(object):
             raise ValueError(f"Unsupported column type: {column_type}")
 
         calculated_config = self.build_and_append_pre_agg_calc_config(
-            source_column,
-            target_column,
+            source_casefold_column,
+            target_casefold_column,
             calc_func,
             column_position,
             cast_type=cast_type,

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -16,6 +16,7 @@
 
 - Requires the `pyodbc` package to be installed as an extra dependency plus an OS level ODBC driver manager and client.
 - SQL Server does not have a function to "right trim" all whitespace, only spaces, therefore any validations relying on removal of trailing white space may encounter issues.
+- The `text` and `ntext` data types are incompatible with the `len()` therefore the `datalength()` function ius used in it's place which will give different results for multibyte characters.
 - The `image` data type is not currently supported, these columns are skipped when validated. See (issue-1578)[https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1578] for details.
 
 ## Sybase ASE

--- a/tests/resources/sqlserver_test_tables.sql
+++ b/tests/resources/sqlserver_test_tables.sql
@@ -770,6 +770,7 @@ CREATE TABLE pso_data_validator.[DvtCamelCase]
 ,   [ColDec]       decimal(10,2)
 ,   [ColStr]       varchar(30)
 ,   [ColDate]      date
+,   [ColText]      text
 );
 EXECUTE sp_addextendedproperty 'Comment', 'SQL Server with CamelCase naming.', 'SCHEMA', 'pso_data_validator', 'table', 'DvtCamelCase';
 INSERT INTO pso_data_validator.[DvtCamelCase] VALUES
@@ -784,6 +785,7 @@ CREATE TABLE pso_data_validator.dvt_camel_case_lower
 ,   coldec       decimal(10,2)
 ,   colstr       varchar(30)
 ,   coldate      date
+,   coltext      text
 );
 EXECUTE sp_addextendedproperty 'Comment', 'SQL Server table to compare with DvtCamelCase.', 'SCHEMA', 'pso_data_validator', 'table', 'dvt_camel_case_lower';
 INSERT INTO pso_data_validator.dvt_camel_case_lower

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -980,10 +980,7 @@ def test_row_validation_camel_case_auto_pk():
 def test_row_validation_camel_case_pk_option():
     """Compares a source table with camel case identifiers with a target with lower case identifiers.
 
-    The table name part of this test is a bit disingenuous because we just tell DVT the two names. Really
-    table name testing should be part of find-tables testing.
-    Regarding column names: DVT tends to lower case all column names and this test confirms name matching
-    and any recursive SQL is valid.
+    This test is primarily concerned with passing the --primary-keys option for a CamelCase column.
     """
     row_validation_test(
         tables="pso_data_validator.DvtCamelCase=pso_data_validator.dvt_camel_case_lower",

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -958,7 +958,7 @@ def test_row_validation_uuid_hash_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
-def test_row_validation_camel_case():
+def test_row_validation_camel_case_auto_pk():
     """Compares a source table with camel case identifiers with a target with lower case identifiers.
 
     The table name part of this test is a bit disingenuous because we just tell DVT the two names. Really
@@ -970,6 +970,26 @@ def test_row_validation_camel_case():
         tables="pso_data_validator.DvtCamelCase=pso_data_validator.dvt_camel_case_lower",
         tc="sql-conn",
         hash="*",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_row_validation_camel_case_pk_option():
+    """Compares a source table with camel case identifiers with a target with lower case identifiers.
+
+    The table name part of this test is a bit disingenuous because we just tell DVT the two names. Really
+    table name testing should be part of find-tables testing.
+    Regarding column names: DVT tends to lower case all column names and this test confirms name matching
+    and any recursive SQL is valid.
+    """
+    row_validation_test(
+        tables="pso_data_validator.DvtCamelCase=pso_data_validator.dvt_camel_case_lower",
+        tc="sql-conn",
+        hash="*",
+        primary_keys="id",
     )
 
 


### PR DESCRIPTION
## Description of changes
This PR fixes a bug where SQL Server CamelCase column names were bypassing raw data type checks.

I can't actually add the new test columns until after this PR is approved. I have manually tested but, after approval I'll add the columns and kick off a final test run before hitting merge.

I also documented a related SQL Server limitation.

## Issues to be closed

Closes #1683


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


