### PR TITLE
test: Fix test data for SQL Server varbinary columns

### DIFF
--- a/tests/resources/sqlserver_test_tables.sql
+++ b/tests/resources/sqlserver_test_tables.sql
@@ -214,9 +214,6 @@ INSERT INTO pso_data_validator.dvt_large_decimals VALUES
 ,12345678.123456789012345678901234567890
 ,987654321012345678,12345678901234567.1);
 
--- We have to use the exact length for the varbinary column
--- because SQL Server right pads values to the length, not
--- very "var"!
 DROP TABLE pso_data_validator.dvt_binary;
 CREATE TABLE pso_data_validator.dvt_binary
 (   binary_id       varbinary(9) NOT NULL PRIMARY KEY
@@ -225,11 +222,11 @@ CREATE TABLE pso_data_validator.dvt_binary
 );
 CREATE UNIQUE INDEX dvt_binary_int_id_uk ON pso_data_validator.dvt_binary (int_id);
 EXECUTE sp_addextendedproperty 'Comment', 'Integration test table used to test both binary pk matching and binary hash/concat comparisons', 'SCHEMA', 'pso_data_validator', 'table', 'dvt_binary';
-INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-1' AS binary), 1, 'Row 1');
-INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-2' AS binary), 2, 'Row 2');
-INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-3' AS binary), 3, 'Row 3');
-INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-4' AS binary), 4, 'Row 4');
-INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-5' AS binary), 5, 'Row 5');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-1' AS varbinary), 1, 'Row 1');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-2' AS varbinary), 2, 'Row 2');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-3' AS varbinary), 3, 'Row 3');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-4' AS varbinary), 4, 'Row 4');
+INSERT INTO pso_data_validator.dvt_binary VALUES (CAST('DVT-key-5' AS varbinary), 5, 'Row 5');
 
 DROP TABLE IF EXISTS pso_data_validator.dvt_fixed_char_id;
 CREATE TABLE pso_data_validator.dvt_fixed_char_id

--- a/tests/resources/sqlserver_test_tables.sql
+++ b/tests/resources/sqlserver_test_tables.sql
@@ -145,7 +145,7 @@ INSERT INTO pso_data_validator.dvt_sql_server_types VALUES
 ,'Hello DVT','A ','Hello DVT','A ','Hello DVT','Hello DVT'
 ,'1970-01-01','1970-01-01 00:00:01','1970-01-01 00:00:01','1970-01-01 01:00:00'
 ,cast('1970-01-01 00:00:01 -01:00' as datetimeoffset(3)),'00:00:01.123'
-,CAST('A' AS binary),CAST('A' AS binary),CAST('A' AS binary),'TRUE',CAST('A' AS binary)
+,CAST('A' AS binary),CAST('A' AS varbinary),CAST('A' AS varbinary),'TRUE',CAST('A' AS varbinary)
 );
 INSERT INTO pso_data_validator.dvt_sql_server_types VALUES
 (2,210,22222,2000000000,223456789012345678
@@ -153,7 +153,7 @@ INSERT INTO pso_data_validator.dvt_sql_server_types VALUES
 ,'Trailing space length 25 ','B ','Trailing space length 25 ','B ','Trailing space length 25 ','Trailing space length 25 '
 ,'1970-02-02','1970-02-02 00:00:02','1970-02-02 00:00:02','1970-02-02 02:00:00'
 ,cast('1970-02-02 00:00:01 -02:00' as datetimeoffset(3)),'00:00:02.123'
-,CAST('B' AS binary),CAST('B' AS binary),CAST('B' AS binary),'FALSE',CAST('A' AS binary)
+,CAST('B' AS binary),CAST('B' AS varbinary),CAST('B' AS varbinary),'FALSE',CAST('A' AS varbinary)
 );
 
 DROP TABLE pso_data_validator.dvt_null_not_null;

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -492,10 +492,6 @@ def test_column_validation_ss_types_to_bigquery():
             "col_money",
             "col_smallmoney",
             "col_ntext",
-            # binary columns are excluded below because SQL Server right pads varbinary
-            # values to the length. Not very VARbinary!
-            "col_varbinary",
-            "col_varbinary_max",
         )
     ]
     # TODO Include col_int1 in max_cols when working on issue-1585.
@@ -703,10 +699,6 @@ def test_row_validation_comp_fields_ss_types_to_bigquery():
                 # TODO Remove money types from exclude list when working on - issue-1582
                 "col_money",
                 "col_smallmoney",
-                # binary columns are excluded below because SQL Server right pads varbinary
-                # values to the length. Not very VARbinary!
-                "col_varbinary",
-                "col_varbinary_max",
             )
         ]
     )
@@ -735,10 +727,6 @@ def test_row_validation_ss_types_to_bigquery():
                 # TODO Remove money types from exclude list when working on - issue-1582
                 "col_money",
                 "col_smallmoney",
-                # binary columns are excluded below because SQL Server right pads varbinary
-                # values to the length. Not very VARbinary!
-                "col_varbinary",
-                "col_varbinary_max",
             )
         ]
     )


### PR DESCRIPTION
## Description of changes
I thought we had a DVT issue but, after investigation, it turned out we had a test data problem. This PR fixes the data and adds varbinary columns back into our tests.

## Issues to be closed

Closes #1682

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


