### PR TITLE
feat: Add support for differing source/target schema names to find-tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,14 +659,18 @@ target. The `find-tables` command:
 -   Pulls all tables in the source (applying a supplied `allowed-schemas` filter)
 -   Pulls all tables from the target
 -   Uses Jaro Similarity algorithm to match tables
+-   (Optional) Translates source schema names using a supplied `schema-map` before matching
 -   Finally, it prints a JSON list of tables which can be a reference for the
     validation run config.
 
 Note that our default value for the `score-cutoff` parameter is 1 and it seeks for identical matches. If no matches occur, reduce this value as deemed necessary. By using smaller numbers such as 0.7, 0.65 etc you can get more matches. For reference, we make use of [this jaro_similarity method](https://jamesturk.github.io/jellyfish/functions/#jaro-similarity) for the string comparison.
 
+If your source and target environments have different schema names (e.g., `prod_raw` vs `dwh_raw`), you can use the `--schema-map` flag to provide a mapping. This translates the source schema name to the target schema name before the matching algorithm is run.
+
 ```shell
 data-validation find-tables --source-conn source --target-conn target \
-    --allowed-schemas pso_data_validator \
+    --allowed-schemas prod_raw \
+    --schema-map prod_raw=dwh_raw \
     --score-cutoff 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -659,18 +659,24 @@ target. The `find-tables` command:
 -   Pulls all tables in the source (applying a supplied `allowed-schemas` filter)
 -   Pulls all tables from the target
 -   Uses Jaro Similarity algorithm to match tables
--   (Optional) Translates source schema names using a supplied `schema-map` before matching
+-   Optionally translates source schema names using mappings supplied in `allowed-schemas` before matching
 -   Finally, it prints a JSON list of tables which can be a reference for the
     validation run config.
 
 Note that our default value for the `score-cutoff` parameter is 1 and it seeks for identical matches. If no matches occur, reduce this value as deemed necessary. By using smaller numbers such as 0.7, 0.65 etc you can get more matches. For reference, we make use of [this jaro_similarity method](https://jamesturk.github.io/jellyfish/functions/#jaro-similarity) for the string comparison.
 
-If your source and target environments have different schema names (e.g., `prod_raw` vs `dwh_raw`), you can use the `--schema-map` flag to provide a mapping. This translates the source schema name to the target schema name before the matching algorithm is run.
 
 ```shell
 data-validation find-tables --source-conn source --target-conn target \
-    --allowed-schemas prod_raw \
-    --schema-map prod_raw=dwh_raw \
+    --allowed-schemas pso_data_validator \
+    --score-cutoff 1
+```
+
+If your source and target environments have different schema names (e.g., `prod_raw` vs `dwh_raw`), you can provide a mapping directly in the `--allowed-schemas` flag using the `source_schema=target_schema` syntax.
+
+```shell
+data-validation find-tables --source-conn source --target-conn target \
+    --allowed-schemas prod=dwh \
     --score-cutoff 1
 ```
 

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -419,6 +419,13 @@ def _configure_find_tables(subparsers):
         type=float,
         help="The minimum distance score allowed to match tables (0 to 1).",
     )
+    find_tables_parser.add_argument(
+        "--schema-map",
+        "-sm",
+        type=get_schema_map,
+        default={},
+        help="Mapping of source schema to target schema. 'source_schema=target_schema'",
+    )
 
 
 def _configure_raw_query(subparsers):
@@ -1263,18 +1270,28 @@ def print_validations_in_dir(config_dir="./"):
         logging.info(validation_name)
 
 
-def get_labels(arg_labels):
-    """Return list of tuples representing key-value label pairs."""
-    labels = []
-    if arg_labels:
-        pairs = arg_labels.split(",")
+def _get_kv_pairs(arg_value, arg_name):
+    """Return list of tuples representing key-value pairs."""
+    kv_pairs = []
+    if arg_value:
+        pairs = arg_value.split(",")
         for pair in pairs:
             kv = pair.split("=")
             if len(kv) == 2:
-                labels.append((kv[0], kv[1]))
+                kv_pairs.append((kv[0], kv[1]))
             else:
-                raise ValueError("Labels must be comma-separated key-value pairs.")
-    return labels
+                raise ValueError(f"{arg_name} must be comma-separated key-value pairs.")
+    return kv_pairs
+
+
+def get_labels(arg_labels):
+    """Return list of tuples representing key-value label pairs."""
+    return _get_kv_pairs(arg_labels, "Labels")
+
+
+def get_schema_map(arg_schema_map):
+    """Return dict representing source to target schema mapping."""
+    return dict(_get_kv_pairs(arg_schema_map, "Schema map"))
 
 
 def get_filters(filter_value: str) -> List[Dict]:

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -404,7 +404,9 @@ def _configure_find_tables(subparsers):
         "--target-conn", "-tc", help="Target connection name."
     )
     find_tables_parser.add_argument(
-        "--allowed-schemas", "-as", help="List of source schemas to match."
+        "--allowed-schemas",
+        "-as",
+        help="List of source schemas to match. Can include mappings like 'source_schema=target_schema'.",
     )
     find_tables_parser.add_argument(
         "--include-views",
@@ -418,13 +420,6 @@ def _configure_find_tables(subparsers):
         "-score",
         type=float,
         help="The minimum distance score allowed to match tables (0 to 1).",
-    )
-    find_tables_parser.add_argument(
-        "--schema-map",
-        "-sm",
-        type=get_schema_map,
-        default={},
-        help="Mapping of source schema to target schema. 'source_schema=target_schema'",
     )
 
 
@@ -1289,9 +1284,6 @@ def get_labels(arg_labels):
     return _get_kv_pairs(arg_labels, "Labels")
 
 
-def get_schema_map(arg_schema_map):
-    """Return dict representing source to target schema mapping."""
-    return dict(_get_kv_pairs(arg_schema_map, "Schema map"))
 
 
 def get_filters(filter_value: str) -> List[Dict]:

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -1265,25 +1265,18 @@ def print_validations_in_dir(config_dir="./"):
         logging.info(validation_name)
 
 
-def _get_kv_pairs(arg_value, arg_name):
-    """Return list of tuples representing key-value pairs."""
-    kv_pairs = []
-    if arg_value:
-        pairs = arg_value.split(",")
+def get_labels(arg_labels):
+    """Return list of tuples representing key-value label pairs."""
+    labels = []
+    if arg_labels:
+        pairs = arg_labels.split(",")
         for pair in pairs:
             kv = pair.split("=")
             if len(kv) == 2:
-                kv_pairs.append((kv[0], kv[1]))
+                labels.append((kv[0], kv[1]))
             else:
-                raise ValueError(f"{arg_name} must be comma-separated key-value pairs.")
-    return kv_pairs
-
-
-def get_labels(arg_labels):
-    """Return list of tuples representing key-value label pairs."""
-    return _get_kv_pairs(arg_labels, "Labels")
-
-
+                raise ValueError("Labels must be comma-separated key-value pairs.")
+    return labels
 
 
 def get_filters(filter_value: str) -> List[Dict]:

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -44,7 +44,9 @@ def _compare_match_tables(
         source_schema = source_table_map[source_key][consts.CONFIG_SCHEMA_NAME]
         source_table = source_table_map[source_key][consts.CONFIG_TABLE_NAME]
 
-        # Apply schema mapping if it exists
+        # Apply schema mapping if it exists, when there is a mapping
+        # lookup_key is {mapped_schema}.{source_name} which should then
+        # find a match in target_keys.
         lookup_schema = schema_map.get(source_schema, source_schema)
         lookup_key = f"{lookup_schema}.{source_table}".casefold()
 

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -28,26 +28,35 @@ if TYPE_CHECKING:
     import ibis
 
 
-def _compare_match_tables(source_table_map, target_table_map, score_cutoff=0.8) -> list:
+def _compare_match_tables(
+    source_table_map: dict,
+    target_table_map: dict,
+    score_cutoff: float = 0.8,
+    schema_map: dict = None,
+) -> list:
     """Return dict config object from matching tables."""
     # TODO(dhercher): evaluate if improved comparison and score cutoffs should be used.
     table_configs = []
+    schema_map = schema_map or {}
 
     target_keys = target_table_map.keys()
     for source_key in source_table_map:
+        source_schema = source_table_map[source_key][consts.CONFIG_SCHEMA_NAME]
+        source_table = source_table_map[source_key][consts.CONFIG_TABLE_NAME]
+
+        # Apply schema mapping if it exists
+        lookup_schema = schema_map.get(source_schema, source_schema)
+        lookup_key = f"{lookup_schema}.{source_table}".casefold()
+
         target_key = jellyfish_distance.extract_closest_match(
-            source_key, target_keys, score_cutoff=score_cutoff
+            lookup_key, target_keys, score_cutoff=score_cutoff
         )
         if target_key is None:
             continue
 
         table_config = {
-            consts.CONFIG_SCHEMA_NAME: source_table_map[source_key][
-                consts.CONFIG_SCHEMA_NAME
-            ],
-            consts.CONFIG_TABLE_NAME: source_table_map[source_key][
-                consts.CONFIG_TABLE_NAME
-            ],
+            consts.CONFIG_SCHEMA_NAME: source_schema,
+            consts.CONFIG_TABLE_NAME: source_table,
             consts.CONFIG_TARGET_SCHEMA_NAME: target_table_map[target_key][
                 consts.CONFIG_SCHEMA_NAME
             ],
@@ -95,6 +104,7 @@ def get_mapped_table_configs(
     allowed_schemas: list = None,
     include_views: bool = False,
     score_cutoff: int = 1,
+    schema_map: dict = None,
 ) -> list:
     """Get table list from each client and match them together into a single list of dicts."""
     source_table_map = _get_table_map(
@@ -102,7 +112,10 @@ def get_mapped_table_configs(
     )
     target_table_map = _get_table_map(target_client, include_views=include_views)
     return _compare_match_tables(
-        source_table_map, target_table_map, score_cutoff=score_cutoff
+        source_table_map,
+        target_table_map,
+        score_cutoff=score_cutoff,
+        schema_map=schema_map,
     )
 
 
@@ -121,6 +134,7 @@ def find_tables_using_string_matching(args) -> str:
         allowed_schemas=allowed_schemas,
         include_views=args.include_views,
         score_cutoff=score_cutoff,
+        schema_map=args.schema_map,
     )
     return json.dumps(table_configs)
 

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -127,14 +127,22 @@ def find_tables_using_string_matching(args) -> str:
     source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
     target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
 
-    allowed_schemas = cli_tools.get_arg_list(args.allowed_schemas)
+    allowed_schemas_raw = cli_tools.get_arg_list(args.allowed_schemas)
+    allowed_schemas = []
+    schema_map = {}
+    for schema in allowed_schemas_raw:
+        if "=" in schema:
+            schema, target_schema = schema.split("=", 1)
+            schema_map[schema] = target_schema
+        allowed_schemas.append(schema)
+
     table_configs = get_mapped_table_configs(
         source_client,
         target_client,
         allowed_schemas=allowed_schemas,
         include_views=args.include_views,
         score_cutoff=score_cutoff,
-        schema_map=args.schema_map,
+        schema_map=schema_map,
     )
     return json.dumps(table_configs)
 

--- a/data_validation/find_tables.py
+++ b/data_validation/find_tables.py
@@ -129,7 +129,7 @@ def find_tables_using_string_matching(args) -> str:
     source_client = clients.get_data_client(mgr.get_connection_config(args.source_conn))
     target_client = clients.get_data_client(mgr.get_connection_config(args.target_conn))
 
-    allowed_schemas_raw = cli_tools.get_arg_list(args.allowed_schemas)
+    allowed_schemas_raw = cli_tools.get_arg_list(args.allowed_schemas) or []
     allowed_schemas = []
     schema_map = {}
     for schema in allowed_schemas_raw:

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -458,36 +458,6 @@ def test_get_labels_err(test_input):
 
 @pytest.mark.parametrize(
     "test_input,expected",
-    [
-        ("s1=t1", {"s1": "t1"}),
-        ("s1=t1,s2=t2", {"s1": "t1", "s2": "t2"}),
-        ("", {}),
-        (None, {}),
-    ],
-)
-def test_get_schema_map(test_input, expected):
-    """Test get schema map."""
-    res = cli_tools.get_schema_map(test_input)
-    assert res == expected
-
-
-@pytest.mark.parametrize(
-    "test_input",
-    [
-        ("s1==t1"),
-        ("s1=t1,s2"),
-        ("s1"),
-        (","),
-    ],
-)
-def test_get_schema_map_err(test_input):
-    """Ensure that Value Error is raised when incorrect schema map argument is provided."""
-    with pytest.raises(ValueError):
-        cli_tools.get_schema_map(test_input)
-
-
-@pytest.mark.parametrize(
-    "test_input,expected",
     [(0, 0.0), (50, 50.0), (100, 100.0)],
 )
 def test_threshold_float(test_input, expected):

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -458,6 +458,36 @@ def test_get_labels_err(test_input):
 
 @pytest.mark.parametrize(
     "test_input,expected",
+    [
+        ("s1=t1", {"s1": "t1"}),
+        ("s1=t1,s2=t2", {"s1": "t1", "s2": "t2"}),
+        ("", {}),
+        (None, {}),
+    ],
+)
+def test_get_schema_map(test_input, expected):
+    """Test get schema map."""
+    res = cli_tools.get_schema_map(test_input)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        ("s1==t1"),
+        ("s1=t1,s2"),
+        ("s1"),
+        (","),
+    ],
+)
+def test_get_schema_map_err(test_input):
+    """Ensure that Value Error is raised when incorrect schema map argument is provided."""
+    with pytest.raises(ValueError):
+        cli_tools.get_schema_map(test_input)
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
     [(0, 0.0), (50, 50.0), (100, 100.0)],
 )
 def test_threshold_float(test_input, expected):

--- a/tests/unit/test_find_tables.py
+++ b/tests/unit/test_find_tables.py
@@ -66,6 +66,63 @@ def test__compare_match_tables(module_under_test):
 
 
 @pytest.mark.parametrize(
+    "source_table_map,target_table_map,schema_map,expected",
+    [
+        # Test matching with a valid schema mapping.
+        (
+            {
+                "prod.table1": {
+                    consts.CONFIG_SCHEMA_NAME: "prod",
+                    consts.CONFIG_TABLE_NAME: "table1",
+                }
+            },
+            {
+                "test.table1": {
+                    consts.CONFIG_SCHEMA_NAME: "test",
+                    consts.CONFIG_TABLE_NAME: "table1",
+                }
+            },
+            {"prod": "test"},
+            [
+                {
+                    "schema_name": "prod",
+                    "table_name": "table1",
+                    "target_schema_name": "test",
+                    "target_table_name": "table1",
+                }
+            ],
+        ),
+        # Test that no match is found without a schema mapping.
+        (
+            {
+                "prod.table1": {
+                    consts.CONFIG_SCHEMA_NAME: "prod",
+                    consts.CONFIG_TABLE_NAME: "table1",
+                }
+            },
+            {
+                "test.table1": {
+                    consts.CONFIG_SCHEMA_NAME: "test",
+                    consts.CONFIG_TABLE_NAME: "table1",
+                }
+            },
+            {},
+            [],
+        ),
+    ],
+)
+def test_compare_match_tables_with_mapping(
+    module_under_test, source_table_map, target_table_map, schema_map, expected
+):
+    """Test matching tables from source and target with schema mapping."""
+    table_configs = module_under_test._compare_match_tables(
+        source_table_map, target_table_map, schema_map=schema_map
+    )
+
+    assert table_configs == expected
+
+
+@pytest.mark.parametrize(
     ("tables_list,expected_result"),
     (
         # Test that lone asterisk is expanded.

--- a/tests/unit/test_find_tables.py
+++ b/tests/unit/test_find_tables.py
@@ -264,3 +264,33 @@ def test__get_table_map_from_obj_list_mixed_case(
     table_configs = module_under_test._get_table_map_from_obj_list(table_list)
 
     assert table_configs == expected_result
+
+
+@mock.patch("data_validation.find_tables.get_mapped_table_configs")
+@mock.patch("data_validation.clients.get_data_client")
+@mock.patch("data_validation.state_manager.StateManager.get_connection_config")
+def test_find_tables_using_string_matching_parsing(
+    mock_get_conn_config, mock_get_client, mock_get_configs, module_under_test
+):
+    """Test parsing logic in find_tables_using_string_matching."""
+    mock_args = mock.MagicMock()
+    mock_args.source_conn = "source"
+    mock_args.target_conn = "target"
+    mock_args.allowed_schemas = "s1,s2=t2"
+    mock_args.include_views = False
+    mock_args.score_cutoff = 0.8
+
+    mock_get_conn_config.return_value = {}
+    mock_get_client.return_value = mock.MagicMock()
+    mock_get_configs.return_value = []
+
+    module_under_test.find_tables_using_string_matching(mock_args)
+
+    mock_get_configs.assert_called_once_with(
+        mock.ANY,
+        mock.ANY,
+        allowed_schemas=["s1", "s2"],
+        include_views=False,
+        score_cutoff=0.8,
+        schema_map={"s2": "t2"},
+    )


### PR DESCRIPTION
## Description of changes
This change enhances the `--allowed-schemas` option to support schema name differences across source and target systems.

From the docs:
```
If your source and target environments have different schema names (e.g., `prod_raw` vs `dwh_raw`), you
can provide a mapping directly in the `--allowed-schemas` flag using the `source_schema=target_schema` syntax.

data-validation find-tables --source-conn source --target-conn target \
    --allowed-schemas prod=dwh \
    --score-cutoff 1
```

This is required due to a customer migration where the target PostgreSQL schema names differ from the source schema names.

I initially added a new `--schema-map` option for the find-tables command to support this but backed that out after deciding that we could instead mimic the `--tables-list` option for standard validation.

## Issues to be closed

Closes #1640

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


