### PR TITLE
fix: Cap Db2 precision at 31 when casting decimals to string

### DIFF
--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -138,6 +138,9 @@ def _cast(t, op):
             # Db2 always pads fractional part of the number out to length of scale.
             # We need to remove those insignificant digits.
             precision = arg_dtype.precision or 31
+            # 31 is the max decimal precision on Db2.
+            if precision > 31:
+                precision = 31
             fmt = (
                 ("9" * (precision - arg_dtype.scale - 1))
                 + "0."
@@ -150,11 +153,11 @@ def _cast(t, op):
                     sa.literal_column("''"),
                 )
             )
-        # Max expected precision 38 plus 2 for minus sign and decimal place.
-        return sa.cast(sa_arg, sa.String(40))
+        # Max expected precision 31 plus 2 for minus sign and decimal place.
+        return sa.cast(sa_arg, sa.String(33))
     elif arg_dtype.is_floating() and typ.is_string():
-        # Max expected precision 38 plus 2 for minus sign and decimal place.
-        return sa.cast(sa_arg, sa.String(40))
+        # Max expected precision 31 plus 2 for minus sign and decimal place.
+        return sa.cast(sa_arg, sa.String(33))
 
     if arg_dtype.is_time() and typ.is_string():
         # Force colons as time separator with CHAR(column,JIS) expression.


### PR DESCRIPTION
## Description of changes
Cap Db2 precision at 31 when casting decimals to string

## Issues to be closed

Closes #1685

## Checklist

- [ ] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated any relevant documentation to reflect my changes, if applicable
- [ ] I have added unit and/or integration tests relevant to my change as needed
- [ ] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [ ] I have manually executed end-to-end testing (E2E) with the affected databases/engines


