### PR TITLE
fix: Remove invalid SET TIMEZONE command on Db2 LUW

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -315,9 +315,7 @@ def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
-    _setup_session_requirements(
-        session, extra_packages=["ibm-db-sa<0.4.2"]
-    )
+    _setup_session_requirements(session, extra_packages=["ibm-db-sa<0.4.2"])
 
     expected_env_vars = [
         "PROJECT_ID",

--- a/noxfile.py
+++ b/noxfile.py
@@ -315,9 +315,8 @@ def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
-    # TODO Remove dependency "ibm-db<3.2.7" below when working on issue-1591.
     _setup_session_requirements(
-        session, extra_packages=["ibm-db-sa<0.4.2", "ibm-db<3.2.7"]
+        session, extra_packages=["ibm-db-sa<0.4.2"]
     )
 
     expected_env_vars = [

--- a/third_party/ibis/ibis_db2/__init__.py
+++ b/third_party/ibis/ibis_db2/__init__.py
@@ -62,11 +62,6 @@ class Backend(BaseAlchemyBackend):
         self.database_name = database
         self.url = sa_url
 
-        @sa.event.listens_for(engine, "connect")
-        def connect(dbapi_connection, connection_record):
-            with dbapi_connection.cursor() as cur:
-                cur.execute("SET TIMEZONE = UTC")
-
         super().do_connect(engine)
 
     def find_db(self):


### PR DESCRIPTION
## Description of changes
Removes invalid SET TIMEZONE command on Db2 LUW which allows us to remove the limit on Db2 driver version.

Db2 LUW inherits time zone from the OS and there is no way to influence a default at the session level.

## Issues to be closed

Closes #1591

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


