### PR TITLE
fix: Replace typehints that are incompatible with Python 3.9

### DIFF
--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -41,15 +41,18 @@ pytestmark = pytest.mark.flaky(
 )
 
 DB2_HOST = os.getenv("DB2_HOST", "localhost")
+DB2_USER = os.getenv("DB2_USER", "db2inst1")
 DB2_PASSWORD = os.getenv("DB2_PASSWORD")
+DB2_DATABASE = os.getenv("DB2_DATABASE", "testdb")
+DB2_PORT = os.getenv("DB2_PORT", 50000)
 
 CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_DB2,
     "host": DB2_HOST,
-    "user": "db2inst1",
+    "user": DB2_USER,
     "password": DB2_PASSWORD,
-    "port": 50000,
-    "database": "testdb",
+    "port": DB2_PORT,
+    "database": DB2_DATABASE,
 }
 
 

--- a/third_party/ibis/ibis_db2/__init__.py
+++ b/third_party/ibis/ibis_db2/__init__.py
@@ -73,11 +73,6 @@ class Backend(BaseAlchemyBackend):
         self.database_name = database
         self.url = sa_url
 
-        @sa.event.listens_for(engine, "connect")
-        def connect(dbapi_connection, connection_record):
-            with dbapi_connection.cursor() as cur:
-                cur.execute("SET TIMEZONE = UTC")
-
         super().do_connect(engine)
 
     def find_db(self):
@@ -188,8 +183,8 @@ class Backend(BaseAlchemyBackend):
     def table(
         self,
         name: str,
-        database: str | None = None,
-        schema: str | None = None,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
     ) -> "ir.Table":
         """Intercept Ibis table() call and inject Db2 customizations before returning the table object."""
         return_table = super().table(name, database, schema)


### PR DESCRIPTION
## Description of changes
This PR:
- Replaces a type hints that is incompatible with Python 3.9
- Removes an invalid SET TIMEZONE command, this silently fails but begins to throw an exception on newer versions of the IBM driver.
- Adds env vars for some test settings, such as the user to connect as when running tests

## Issues to be closed

Closes #1703

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


