### PR TITLE
fix: mock list_validations in config_runner tests to remove GCS dependency

### DIFF
--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -51,7 +51,7 @@ CONFIG_RUNNER_ARGS_2 = {
     "command": "configs",
     "validation_config_cmd": "run",
     "kube_completions": True,
-    "config_dir": "gs://pso-kokoro-resources/resources/test/unit/test__main/3validations",
+    "config_dir": "/tmp/test/unit/test__main/3validations",
 }
 CONFIG_RUNNER_ARGS_3 = {
     "verbose": False,
@@ -69,7 +69,7 @@ CONFIG_RUNNER_ARGS_4 = {
     "command": "configs",
     "kube_completions": False,
     "validation_config_cmd": "run",
-    "config_dir": "gs://pso-kokoro-resources/resources/test/unit/test__main/4partitions",
+    "config_dir": "/tmp/test/unit/test__main/4partitions",
 }
 
 CONFIG_RUNNER_EXCEPTION_TEXT = (
@@ -280,10 +280,14 @@ def test_config_runner_1(mock_args, mock_build, mock_run, caplog):
     return_value=["config dict from one file"],
 )
 @mock.patch(
+    "data_validation.cli_tools.list_validations",
+    return_value=["first.yaml", "second.yaml", "third.yaml"],
+)
+@mock.patch(
     "argparse.ArgumentParser.parse_args",
     return_value=argparse.Namespace(**CONFIG_RUNNER_ARGS_2),
 )
-def test_config_runner_2(mock_args, mock_build, mock_run, caplog):
+def test_config_runner_2(mock_args, mock_list, mock_build, mock_run, caplog):
     """Second test - run validation on a directory - and provide the -kc argument,
     but not running in a Kubernetes Completion Configuration. Expected result
     1. Multiple (3) config manager created for validation
@@ -336,10 +340,14 @@ def test_config_runner_3(mock_args, mock_build, mock_run, caplog):
     return_value=["config dict from one file"],
 )
 @mock.patch(
+    "data_validation.cli_tools.list_validations",
+    return_value=["0000.yaml", "0001.yaml", "0002.yaml", "0003.yaml"],
+)
+@mock.patch(
     "argparse.ArgumentParser.parse_args",
     return_value=argparse.Namespace(**CONFIG_RUNNER_ARGS_4),
 )
-def test_config_runner_4(mock_args, mock_build, mock_run, caplog):
+def test_config_runner_4(mock_args, mock_list, mock_build, mock_run, caplog):
     """Third test - run validation on a directory with failures in one validation,
         Running in a non Kube completions environment. Expected Result:
     1. All 4 files are validated, even though one of them raises an exception.


### PR DESCRIPTION
## Summary
- Mock `cli_tools.list_validations` in `test_config_runner_2` and `test_config_runner_4` to remove dependency on real GCS buckets (`gs://pso-kokoro-resources`)
- Replace GCS paths in test config dicts with local paths

## Issue
Fixes #1482

## Root Cause
`config_runner()` calls `cli_tools.list_validations(config_dir=args.config_dir)` which reaches `gcs_helper.list_gcs_directory()` when the path starts with `gs://`. External contributors without GCS credentials get `DefaultCredentialsError`.

## Changes
- `test_config_runner_2`: Added `@mock.patch("data_validation.cli_tools.list_validations")` returning 3 YAML filenames
- `test_config_runner_4`: Added `@mock.patch("data_validation.cli_tools.list_validations")` returning 4 YAML filenames
- `CONFIG_RUNNER_ARGS_2` / `CONFIG_RUNNER_ARGS_4`: Changed `config_dir` from `gs://pso-kokoro-resources/...` to `/tmp/test/...`

## Testing
```
$ python -m pytest tests/unit/test__main.py -v
============================= 20 passed in 10.96s ==============================
```

```
$ python -m black --check tests/unit/test__main.py
All done! 1 file would be left unchanged.

$ python -m flake8 tests/unit/test__main.py
(no output)
```

Full unit test suite: 375 passed, 2 failed (pre-existing GCP auth failures unrelated to this change), 10 skipped.