### PR TITLE
fix: custom query row validation on Db2 loses precision and scale

### DIFF
--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -561,6 +561,20 @@ def test_custom_query_row_validation_core_types_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_custom_query_row_concat_validation_core_types_to_bigquery():
+    """Db2 to BigQuery dvt_core_types custom-query row concat validation"""
+    custom_query_validation_test(
+        validation_type="row",
+        source_query="select id,col_int64,col_dec_10_2,COL_VARCHAR_30,col_date from pso_data_validator.dvt_core_types",
+        target_query="select id,col_int64,col_dec_10_2,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
+        concat="col_int64,col_dec_10_2,col_varchar_30,col_date",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_varchar_pk_query_row_validation_to_bigquery():
     """Test varchar primary keys on custom query"""
     id_column_query_row_validation_test("pso_data_validator.dvt_varchar_id")

--- a/third_party/ibis/ibis_db2/__init__.py
+++ b/third_party/ibis/ibis_db2/__init__.py
@@ -89,7 +89,7 @@ class Backend(BaseAlchemyBackend):
             result = con.exec_driver_sql(f"SELECT * FROM {query} t0 LIMIT 1")
             cursor = result.cursor
             yield from (
-                (column[0].lower(), _get_type(column[1]))
+                (column[0].lower(), _get_type(column))
                 for column in cursor.description
             )
 

--- a/third_party/ibis/ibis_db2/__init__.py
+++ b/third_party/ibis/ibis_db2/__init__.py
@@ -89,8 +89,7 @@ class Backend(BaseAlchemyBackend):
             result = con.exec_driver_sql(f"SELECT * FROM {query} t0 LIMIT 1")
             cursor = result.cursor
             yield from (
-                (column[0].lower(), _get_type(column))
-                for column in cursor.description
+                (column[0].lower(), _get_type(column)) for column in cursor.description
             )
 
     def list_primary_key_columns(self, database: str, table: str) -> list:

--- a/third_party/ibis/ibis_db2/datatypes.py
+++ b/third_party/ibis/ibis_db2/datatypes.py
@@ -65,5 +65,5 @@ def _get_type(col) -> dt.DataType:
         scale = col[5]
         if precision is not None and scale is not None:
             return dt.Decimal(precision, scale)
-    
+
     return typ

--- a/third_party/ibis/ibis_db2/datatypes.py
+++ b/third_party/ibis/ibis_db2/datatypes.py
@@ -59,11 +59,11 @@ def _get_type(col) -> dt.DataType:
     typ = _type_mapping.get(typename)
     if typ is None:
         raise NotImplementedError(f"DB2 type {typename} is not supported")
-    
+
     if typ == dt.Decimal:
         precision = col[4]
         scale = col[5]
         if precision is not None and scale is not None:
             return dt.Decimal(precision, scale)
-            
+    
     return typ

--- a/third_party/ibis/ibis_db2/datatypes.py
+++ b/third_party/ibis/ibis_db2/datatypes.py
@@ -54,8 +54,16 @@ def sa_sf_binary(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
-def _get_type(typename) -> dt.DataType:
+def _get_type(col) -> dt.DataType:
+    typename = col[1]
     typ = _type_mapping.get(typename)
     if typ is None:
         raise NotImplementedError(f"DB2 type {typename} is not supported")
+    
+    if typ == dt.Decimal:
+        precision = col[4]
+        scale = col[5]
+        if precision is not None and scale is not None:
+            return dt.Decimal(precision, scale)
+            
     return typ


### PR DESCRIPTION
## Summary
Fixes an issue where custom query row validation on Db2 loses decimal precision and scale because it was ignoring `cursor.description` values.

## Problem
Closes #1706

## Solution
Updated `_get_type()` to receive the entire `column` tuple from `cursor.description` rather than just the type string, and extracted `precision` and `scale` (at indexes 4 and 5 respectively) when returning an Ibis Decimal data type. This mimics how PostgreSQL and Oracle extract type sizes.

## Testing
- Code updated
- Lint passed

---
*This PR was created with AI assistance.*