### PR TITLE
test: Add 'connections add' tests

### DIFF
--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -826,8 +826,13 @@ def connections_add_test(
     caplog: pytest.LogCaptureFixture,
     conn_type: str,
     conn_args: list,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Generic 'connections add' test."""
+    # Set PSO_DV_CONN_HOME to tmp_path to bypass GCS and use a local temp directory.
+    # This avoids pyfakefs module loading issues while keeping file creation isolated.
+    monkeypatch.setenv(consts.ENV_DIRECTORY_VAR, str(tmp_path))
     with caplog.at_level(logging.INFO):
         parser = cli_tools.configure_arg_parser()
         cli_arg_list = [

--- a/tests/system/data_sources/common_functions.py
+++ b/tests/system/data_sources/common_functions.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import json
+import logging
 import os
 import random
 import string
 from typing import TYPE_CHECKING, Optional, Tuple
 import pathlib
+
+import pytest
 
 from data_validation import __main__ as main
 from data_validation import (
@@ -25,9 +28,10 @@ from data_validation import (
     consts,
     data_validation,
     find_tables,
+    gcs_helper,
     raw_query,
+    state_manager,
 )
-
 from data_validation.partition_builder import PartitionBuilder
 
 if TYPE_CHECKING:
@@ -816,3 +820,33 @@ def raw_query_test(
     raw_query.print_raw_query_output(rows)
     captured = capsys.readouterr()
     assert "characters truncated" not in captured.out
+
+
+def connections_add_test(
+    caplog: pytest.LogCaptureFixture,
+    conn_type: str,
+    conn_args: list,
+):
+    """Generic 'connections add' test."""
+    with caplog.at_level(logging.INFO):
+        parser = cli_tools.configure_arg_parser()
+        cli_arg_list = [
+            "connections",
+            "add",
+            "-c=new-conn",
+            conn_type,
+        ] + conn_args
+        cli_arg_list = [_ for _ in cli_arg_list if _]
+        args = parser.parse_args(cli_arg_list)
+
+        main.run_connections(args)
+
+        # Check success message in logging
+        assert any(
+            gcs_helper.WRITE_SUCCESS_STRING in record.msg for record in caplog.records
+        )
+
+        # Check if file exists in the mocked filesystem
+        mgr = state_manager.StateManager()
+        connection_path = mgr._get_connection_path("new-conn")
+        assert os.path.exists(connection_path)

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -589,3 +589,24 @@ def test_find_tables():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys, table="pso_data_validator.dvt_core_types")
+
+
+####################
+# CONNECTIONS TESTS
+####################
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--host",
+        DB2_HOST,
+        "--user",
+        DB2_USER,
+        "--password",
+        DB2_PASSWORD,
+        "--port",
+        str(DB2_PORT),
+        "--database",
+        DB2_DATABASE,
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_DB2, conn_args)

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -24,6 +24,7 @@ from tests.system.data_sources.common_functions import (
     binary_key_assertions,
     column_validation_test,
     column_validation_test_args,
+    connections_add_test,
     custom_query_validation_test,
     find_tables_test,
     id_column_row_validation_test,
@@ -47,14 +48,14 @@ DB2_HOST = os.getenv("DB2_HOST", "localhost")
 DB2_USER = os.getenv("DB2_USER", "db2inst1")
 DB2_PASSWORD = os.getenv("DB2_PASSWORD")
 DB2_DATABASE = os.getenv("DB2_DATABASE", "testdb")
-DB2_PORT = os.getenv("DB2_PORT", 50000)
+DB2_PORT = os.getenv("DB2_PORT", "50000")
 
 CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_DB2,
     "host": DB2_HOST,
     "user": DB2_USER,
     "password": DB2_PASSWORD,
-    "port": DB2_PORT,
+    "port": int(DB2_PORT),
     "database": DB2_DATABASE,
 }
 
@@ -588,3 +589,24 @@ def test_find_tables():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys, table="pso_data_validator.dvt_core_types")
+
+
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--host",
+        DB2_HOST,
+        "--user",
+        DB2_USER,
+        "--password",
+        DB2_PASSWORD,
+        "--port",
+        DB2_PORT,
+        "--database",
+        DB2_DATABASE,
+        "--driver",
+        "ibm_db_sa",
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_DB2, conn_args)

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -594,9 +594,11 @@ def test_raw_query_dvt_row_types(capsys):
 ####################
 # CONNECTIONS TESTS
 ####################
-def test_connections_add(caplog, fs, monkeypatch):
+def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    # Set PSO_DV_CONN_HOME to tmp_path to bypass GCS and use a local temp directory.
+    # This avoids pyfakefs module loading issues while keeping file creation isolated.
+    monkeypatch.setenv(consts.ENV_DIRECTORY_VAR, str(tmp_path))
     conn_args = [
         "--host",
         DB2_HOST,

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -589,24 +589,3 @@ def test_find_tables():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys, table="pso_data_validator.dvt_core_types")
-
-
-def test_connections_add(caplog, fs, monkeypatch):
-    """Test data-validation connections add command."""
-    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
-    conn_args = [
-        "--host",
-        DB2_HOST,
-        "--user",
-        DB2_USER,
-        "--password",
-        DB2_PASSWORD,
-        "--port",
-        DB2_PORT,
-        "--database",
-        DB2_DATABASE,
-        "--driver",
-        "ibm_db_sa",
-    ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_DB2, conn_args)

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -608,4 +608,6 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--database",
         DB2_DATABASE,
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_DB2, conn_args, tmp_path, monkeypatch)
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_DB2, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -596,9 +596,6 @@ def test_raw_query_dvt_row_types(capsys):
 ####################
 def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    # Set PSO_DV_CONN_HOME to tmp_path to bypass GCS and use a local temp directory.
-    # This avoids pyfakefs module loading issues while keeping file creation isolated.
-    monkeypatch.setenv(consts.ENV_DIRECTORY_VAR, str(tmp_path))
     conn_args = [
         "--host",
         DB2_HOST,
@@ -611,4 +608,4 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--database",
         DB2_DATABASE,
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_DB2, conn_args)
+    connections_add_test(caplog, consts.SOURCE_TYPE_DB2, conn_args, tmp_path, monkeypatch)

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -22,6 +22,7 @@ from data_validation import cli_tools, consts
 from tests.system.data_sources.common_functions import (
     DVT_TRICKY_DATES_COLUMNS,
     column_validation_test,
+    connections_add_test,
     find_tables_test,
     id_type_test_assertions,
     raw_query_test,
@@ -391,3 +392,25 @@ def test_find_tables():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys)
+
+
+####################
+# CONNECTIONS TESTS
+####################
+def test_connections_add(caplog, tmp_path, monkeypatch):
+    """Test data-validation connections add command."""
+    conn_args = [
+        "--host",
+        IMPALA_HOST,
+        "--port",
+        IMPALA_PORT,
+        "--database",
+        IMPALA_DATABASE,
+        "--auth-mechanism",
+        IMPALA_AUTH_MECH,
+        "--timeout",
+        "1000",
+    ]
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_IMPALA, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_impala.py
+++ b/tests/system/data_sources/test_impala.py
@@ -408,8 +408,9 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         IMPALA_DATABASE,
         "--auth-mechanism",
         IMPALA_AUTH_MECH,
-        "--timeout",
-        "1000",
+        # TODO Add options below back in once issue-1720 is complete.
+        # "--timeout",
+        # "1000",
     ]
     connections_add_test(
         caplog, consts.SOURCE_TYPE_IMPALA, conn_args, tmp_path, monkeypatch

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -1443,4 +1443,6 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--connect-args",
         '{ "disable_oob": "true" }',
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_ORACLE, conn_args, tmp_path, monkeypatch)
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_ORACLE, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -1427,10 +1427,8 @@ def test_raw_column_metadata():
 ####################
 # CONNECTIONS TESTS
 ####################
-def test_connections_add(caplog, fs, monkeypatch):
+def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
     conn_args = [
         "--host",
         ORACLE_HOST,
@@ -1445,4 +1443,4 @@ def test_connections_add(caplog, fs, monkeypatch):
         "--connect-args",
         '{ "disable_oob": "true" }',
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_ORACLE, conn_args)
+    connections_add_test(caplog, consts.SOURCE_TYPE_ORACLE, conn_args, tmp_path, monkeypatch)

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -1424,6 +1424,9 @@ def test_raw_column_metadata():
     assert raw_types == DVT_CORE_TYPES_RAW_DATA_TYPES
 
 
+####################
+# CONNECTIONS TESTS
+####################
 def test_connections_add(caplog, fs, monkeypatch):
     """Test data-validation connections add command."""
     # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -1440,6 +1440,7 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         ORACLE_PORT,
         "--database",
         ORACLE_DATABASE,
+        # disable_oob is a harmless setting we can use to exercise --connect-args.
         "--connect-args",
         '{ "disable_oob": "true" }',
     ]

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -25,6 +25,7 @@ from tests.system.data_sources.common_functions import (
     column_validation_test,
     column_validation_test_args,
     column_validation_test_config_managers,
+    connections_add_test,
     find_tables_test,
     generate_and_run_table_partitions_test,
     id_column_row_validation_test,
@@ -1421,3 +1422,24 @@ def test_raw_column_metadata():
         )
     )
     assert raw_types == DVT_CORE_TYPES_RAW_DATA_TYPES
+
+
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--host",
+        ORACLE_HOST,
+        "--user",
+        ORACLE_USER,
+        "--password",
+        ORACLE_PASSWORD,
+        "--port",
+        ORACLE_PORT,
+        "--database",
+        ORACLE_DATABASE,
+        "--connect-args",
+        '{ "disable_oob": "true" }',
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_ORACLE, conn_args)

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -1455,4 +1455,6 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--database",
         POSTGRES_DATABASE,
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_POSTGRES, conn_args, tmp_path, monkeypatch)
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_POSTGRES, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -35,6 +35,7 @@ from tests.system.data_sources.common_functions import (
     binary_key_assertions,
     column_validation_test,
     column_validation_test_args,
+    connections_add_test,
     custom_query_validation_test,
     find_tables_test,
     generate_and_run_table_partitions_test,
@@ -1435,3 +1436,25 @@ def test_raw_column_metadata():
         )
     )
     assert raw_types == DVT_CORE_TYPES_RAW_DATA_TYPES
+
+
+####################
+# CONNECTIONS TESTS
+####################
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--host",
+        POSTGRES_HOST,
+        "--user",
+        "postgres",
+        "--password",
+        POSTGRES_PASSWORD,
+        "--port",
+        str(POSTGRES_PORT),
+        "--database",
+        POSTGRES_DATABASE,
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_POSTGRES, conn_args)

--- a/tests/system/data_sources/test_postgres.py
+++ b/tests/system/data_sources/test_postgres.py
@@ -1441,10 +1441,8 @@ def test_raw_column_metadata():
 ####################
 # CONNECTIONS TESTS
 ####################
-def test_connections_add(caplog, fs, monkeypatch):
+def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
     conn_args = [
         "--host",
         POSTGRES_HOST,
@@ -1457,4 +1455,4 @@ def test_connections_add(caplog, fs, monkeypatch):
         "--database",
         POSTGRES_DATABASE,
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_POSTGRES, conn_args)
+    connections_add_test(caplog, consts.SOURCE_TYPE_POSTGRES, conn_args, tmp_path, monkeypatch)

--- a/tests/system/data_sources/test_snowflake.py
+++ b/tests/system/data_sources/test_snowflake.py
@@ -23,6 +23,7 @@ from tests.system.data_sources.common_functions import (
     DVT_CORE_TYPES_COLUMNS,
     DVT_TRICKY_DATES_COLUMNS,
     binary_key_assertions,
+    connections_add_test,
     find_tables_test,
     id_column_row_validation_test,
     id_type_test_assertions,
@@ -667,3 +668,23 @@ def test_row_validation_comp_fields_reserved_words():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys, table="PSO_DATA_VALIDATOR.PUBLIC.DVT_CORE_TYPES")
+
+
+####################
+# CONNECTIONS TESTS
+####################
+def test_connections_add(caplog, tmp_path, monkeypatch):
+    """Test data-validation connections add command."""
+    conn_args = [
+        "--account",
+        SNOWFLAKE_ACCOUNT,
+        "--user",
+        SNOWFLAKE_USER,
+        "--password",
+        SNOWFLAKE_PASSWORD,
+        "--database",
+        SNOWFLAKE_DATABASE,
+    ]
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_SNOWFLAKE, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -421,4 +421,6 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--database-id",
         SPANNER_DATABASE,
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_SPANNER, conn_args, tmp_path, monkeypatch)
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_SPANNER, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -22,13 +22,14 @@ import pytest
 from data_validation import cli_tools, consts, data_validation, find_tables
 from tests.system.data_sources.common_functions import (
     binary_key_assertions,
+    column_validation_test,
+    connections_add_test,
+    custom_query_validation_test,
     raw_query_test,
     row_validation_many_columns_test,
+    row_validation_test,
     run_test_from_cli_args,
     schema_validation_test,
-    column_validation_test,
-    row_validation_test,
-    custom_query_validation_test,
 )
 from tests.system.data_sources.test_bigquery import BQ_CONN
 
@@ -405,3 +406,18 @@ def test_custom_query_row_validation_many_columns():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys, table="dvt_core_types")
+
+
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--project-id",
+        PROJECT_ID,
+        "--instance-id",
+        SPANNER_INSTANCE,
+        "--database-id",
+        SPANNER_DATABASE,
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_SPANNER, conn_args)

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -411,10 +411,8 @@ def test_raw_query_dvt_row_types(capsys):
 ####################
 # CONNECTIONS TESTS
 ####################
-def test_connections_add(caplog, fs, monkeypatch):
+def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
     conn_args = [
         "--project-id",
         PROJECT_ID,
@@ -423,4 +421,4 @@ def test_connections_add(caplog, fs, monkeypatch):
         "--database-id",
         SPANNER_DATABASE,
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_SPANNER, conn_args)
+    connections_add_test(caplog, consts.SOURCE_TYPE_SPANNER, conn_args, tmp_path, monkeypatch)

--- a/tests/system/data_sources/test_spanner.py
+++ b/tests/system/data_sources/test_spanner.py
@@ -408,6 +408,9 @@ def test_raw_query_dvt_row_types(capsys):
     raw_query_test(capsys, table="dvt_core_types")
 
 
+####################
+# CONNECTIONS TESTS
+####################
 def test_connections_add(caplog, fs, monkeypatch):
     """Test data-validation connections add command."""
     # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -1080,10 +1080,8 @@ def test_raw_query_dvt_row_types(capsys):
 ####################
 # CONNECTIONS TESTS
 ####################
-def test_connections_add(caplog, fs, monkeypatch):
+def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
     conn_args = [
         "--host",
         SQL_SERVER_HOST,
@@ -1098,4 +1096,4 @@ def test_connections_add(caplog, fs, monkeypatch):
         "--query",
         '{"TrustServerCertificate": "yes"}',
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_MSSQL, conn_args)
+    connections_add_test(caplog, consts.SOURCE_TYPE_MSSQL, conn_args, tmp_path, monkeypatch)

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -1096,4 +1096,6 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--query",
         '{"TrustServerCertificate": "yes"}',
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_MSSQL, conn_args, tmp_path, monkeypatch)
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_MSSQL, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -26,6 +26,7 @@ from tests.system.data_sources.common_functions import (
     DVT_CORE_TYPES_COLUMNS,
     DVT_TRICKY_DATES_COLUMNS,
     binary_key_assertions,
+    connections_add_test,
     find_tables_test,
     id_column_row_validation_test,
     id_type_test_assertions,
@@ -47,16 +48,18 @@ from tests.system.data_sources.test_bigquery import BQ_CONN
 
 # Cloud SQL Proxy listens on localhost
 SQL_SERVER_HOST = os.getenv("SQL_SERVER_HOST", "127.0.0.1")
+SQL_SERVER_PORT = os.getenv("SQL_SERVER_PORT", "1433")
 SQL_SERVER_USER = os.getenv("SQL_SERVER_USER", "sqlserver")
 SQL_SERVER_PASSWORD = os.getenv("SQL_SERVER_PASSWORD")
+SQL_SERVER_DATABASE = os.getenv("SQL_SERVER_DATABASE", "guestbook")
 PROJECT_ID = os.getenv("PROJECT_ID")
 CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_MSSQL,
     "host": SQL_SERVER_HOST,
     "user": SQL_SERVER_USER,
     "password": SQL_SERVER_PASSWORD,
-    "port": 1433,
-    "database": "guestbook",
+    "port": int(SQL_SERVER_PORT),
+    "database": SQL_SERVER_DATABASE,
 }
 
 EXPECTED_DATETIME_ID_PARTITION_FILTER = [
@@ -1072,3 +1075,24 @@ def test_find_tables():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys)
+
+
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--host",
+        SQL_SERVER_HOST,
+        "--user",
+        SQL_SERVER_USER,
+        "--password",
+        SQL_SERVER_PASSWORD,
+        "--port",
+        SQL_SERVER_PORT,
+        "--database",
+        SQL_SERVER_DATABASE,
+        "--query",
+        '{"TrustServerCertificate": "yes"}',
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_MSSQL, conn_args)

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -1077,6 +1077,9 @@ def test_raw_query_dvt_row_types(capsys):
     raw_query_test(capsys)
 
 
+####################
+# CONNECTIONS TESTS
+####################
 def test_connections_add(caplog, fs, monkeypatch):
     """Test data-validation connections add command."""
     # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.

--- a/tests/system/data_sources/test_sybase.py
+++ b/tests/system/data_sources/test_sybase.py
@@ -781,4 +781,6 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--query",
         '{"autocommit": "True"}',
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_SYBASE, conn_args, tmp_path, monkeypatch)
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_SYBASE, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_sybase.py
+++ b/tests/system/data_sources/test_sybase.py
@@ -23,6 +23,7 @@ from tests.system.data_sources.common_functions import (
     DVT_TRICKY_DATES_COLUMNS,
     binary_key_assertions,
     column_validation_test,
+    connections_add_test,
     find_tables_test,
     generate_and_run_table_partitions_test,
     id_column_row_validation_test,
@@ -759,3 +760,27 @@ def test_find_tables():
 def test_raw_query_dvt_row_types(capsys):
     """Test data-validation query command."""
     raw_query_test(capsys)
+
+
+####################
+# CONNECTIONS TESTS
+####################
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--host",
+        SYBASE_HOST,
+        "--user",
+        SYBASE_USER,
+        "--password",
+        SYBASE_PASSWORD,
+        "--database",
+        SYBASE_DATABASE,
+        "--odbc-driver",
+        SYBASE_ODBC_DRIVER,
+        "--query",
+        '{"autocommit": "True"}',
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_SYBASE, conn_args)

--- a/tests/system/data_sources/test_sybase.py
+++ b/tests/system/data_sources/test_sybase.py
@@ -765,10 +765,8 @@ def test_raw_query_dvt_row_types(capsys):
 ####################
 # CONNECTIONS TESTS
 ####################
-def test_connections_add(caplog, fs, monkeypatch):
+def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
     conn_args = [
         "--host",
         SYBASE_HOST,
@@ -783,4 +781,4 @@ def test_connections_add(caplog, fs, monkeypatch):
         "--query",
         '{"autocommit": "True"}',
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_SYBASE, conn_args)
+    connections_add_test(caplog, consts.SOURCE_TYPE_SYBASE, conn_args, tmp_path, monkeypatch)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -1083,4 +1083,6 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         "--port",
         "1025",
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_TERADATA, conn_args, tmp_path, monkeypatch)
+    connections_add_test(
+        caplog, consts.SOURCE_TYPE_TERADATA, conn_args, tmp_path, monkeypatch
+    )

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -24,6 +24,7 @@ from tests.system.data_sources.common_functions import (
     DVT_TRICKY_DATES_COLUMNS,
     binary_key_assertions,
     column_validation_test,
+    connections_add_test,
     custom_query_validation_test,
     find_tables_test,
     id_column_row_validation_test,
@@ -1065,3 +1066,20 @@ def test_raw_column_metadata():
     client = clients.get_data_client(CONN)
     raw_types = list(client.raw_column_metadata(database="udf", table="dvt_core_types"))
     assert raw_types == DVT_CORE_TYPES_RAW_DATA_TYPES
+
+
+def test_connections_add(caplog, fs, monkeypatch):
+    """Test data-validation connections add command."""
+    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
+    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
+    conn_args = [
+        "--host",
+        TERADATA_HOST,
+        "--user-name",
+        TERADATA_USER,
+        "--password",
+        TERADATA_PASSWORD,
+        "--port",
+        "1025",
+    ]
+    connections_add_test(caplog, consts.SOURCE_TYPE_TERADATA, conn_args)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -1071,10 +1071,8 @@ def test_raw_column_metadata():
 ####################
 # CONNECTIONS TESTS
 ####################
-def test_connections_add(caplog, fs, monkeypatch):
+def test_connections_add(caplog, tmp_path, monkeypatch):
     """Test data-validation connections add command."""
-    # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.
-    monkeypatch.delenv(consts.ENV_DIRECTORY_VAR, raising=False)
     conn_args = [
         "--host",
         TERADATA_HOST,
@@ -1085,4 +1083,4 @@ def test_connections_add(caplog, fs, monkeypatch):
         "--port",
         "1025",
     ]
-    connections_add_test(caplog, consts.SOURCE_TYPE_TERADATA, conn_args)
+    connections_add_test(caplog, consts.SOURCE_TYPE_TERADATA, conn_args, tmp_path, monkeypatch)

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -1082,6 +1082,9 @@ def test_connections_add(caplog, tmp_path, monkeypatch):
         TERADATA_PASSWORD,
         "--port",
         "1025",
+        # connect_timeout is a harmless setting we can use to exercise --json-params.
+        "--json-params",
+        '{ "connect_timeout": "1000" }',
     ]
     connections_add_test(
         caplog, consts.SOURCE_TYPE_TERADATA, conn_args, tmp_path, monkeypatch

--- a/tests/system/data_sources/test_teradata.py
+++ b/tests/system/data_sources/test_teradata.py
@@ -1068,6 +1068,9 @@ def test_raw_column_metadata():
     assert raw_types == DVT_CORE_TYPES_RAW_DATA_TYPES
 
 
+####################
+# CONNECTIONS TESTS
+####################
 def test_connections_add(caplog, fs, monkeypatch):
     """Test data-validation connections add command."""
     # TODO Line below prevents PSO_DV_CONN_HOME from leaking into this test. See issue-1712.


### PR DESCRIPTION
## Description of changes
We don't have integration tests for most connection types for adding new connections. This PR adds some more.

## Issues to be closed

Closes #1713

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


