### PR TITLE
fix: Modify BQ connection to use the correct project id for billing.

### DIFF
--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -75,7 +75,11 @@ CONNECTION_SOURCE_FIELDS = {
         ["project_id", "GCP Project to use for BigQuery"],
         [
             "client_project_id",
-            "(Optional) BigQuery job/billing project (can differ from data project)",
+            "(Deprecated) BigQuery job/billing project (can differ from data project)",
+        ],
+        [
+            "billing_project_id",
+            "(Optional) BigQuery billing project to override default billing project",
         ],
         ["google_service_account_key_path", "(Optional) GCP SA Key Path"],
         [

--- a/data_validation/cli_tools.py
+++ b/data_validation/cli_tools.py
@@ -81,7 +81,7 @@ CONNECTION_SOURCE_FIELDS = {
             "billing_project_id",
             "(Optional) BigQuery billing project to override default billing project",
         ],
-        ["google_service_account_key_path", "(Optional) GCP SA Key Path"],
+        ["google_service_account_key_path", "(Deprecated) GCP SA Key Path"],
         [
             "api_endpoint",
             '(Optional) GCP BigQuery API endpoint (e.g. "https://bigquery-mypsc.p.googleapis.com")',
@@ -153,7 +153,7 @@ CONNECTION_SOURCE_FIELDS = {
         ["project_id", "GCP Project to use for Spanner"],
         ["instance_id", "ID of Spanner instance to connect to"],
         ["database_id", "ID of Spanner database (schema) to connect to"],
-        ["google_service_account_key_path", "(Optional) GCP SA Key Path"],
+        ["google_service_account_key_path", "(Deprecated) GCP SA Key Path"],
         [
             "api_endpoint",
             '(Optional) GCP Spanner API endpoint (e.g. "https://spanner-mypsc.p.googleapis.com")',

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -111,15 +111,13 @@ def get_google_bigquery_client(
     job_config = bigquery.QueryJobConfig(
         connection_properties=[bigquery.ConnectionProperty("time_zone", "UTC")]
     )
-    effective_project = quota_project_id or project_id
     options = None
     if api_endpoint or quota_project_id:
         options = client_options.ClientOptions(
             api_endpoint=api_endpoint,
-            quota_project_id=quota_project_id if quota_project_id else None,
         )
     return bigquery.Client(
-        project=effective_project,
+        project=quota_project_id,
         client_info=info,
         credentials=credentials,
         default_query_job_config=job_config,
@@ -152,20 +150,24 @@ def get_bigquery_client(
     credentials=None,
     api_endpoint: Optional[str] = None,
     storage_api_endpoint: Optional[str] = None,
-    client_project_id: Optional[str] = None,
+    client_project_id: Optional[str] = None, # to be deprecated in the future
+    billing_project_id: Optional[str] = None,
 ):
+    if client_project_id:
+        logging.warning("client_project_id is deprecated and will be removed in the future, use --billing-project-id instead")
+        billing_project_id = client_project_id
     google_client = get_google_bigquery_client(
         project_id,
         credentials=credentials,
         api_endpoint=api_endpoint,
-        quota_project_id=client_project_id,
+        quota_project_id=billing_project_id,
     )
     bqstorage_client = None
     if storage_api_endpoint:
         bqstorage_client = _get_google_bqstorage_client(
             credentials=credentials,
             api_endpoint=storage_api_endpoint,
-            quota_project_id=client_project_id,
+            quota_project_id=billing_project_id,
         )
 
     return bigquery_connect(
@@ -342,6 +344,10 @@ def get_data_client(connection_config):
             consts.GOOGLE_SERVICE_ACCOUNT_KEY_PATH
         )
         if key_path:
+            logging.warning(
+                """"Use of Service Account Keys is strongly discouraged. This option is deprecated and may be removed.
+                Run DVT with the service account identity by using application-default-credentials with --impersonate-service-account"""
+            )
             decrypted_connection_config["credentials"] = (
                 google.oauth2.service_account.Credentials.from_service_account_file(
                     key_path

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -134,7 +134,6 @@ def _get_google_bqstorage_client(
     if api_endpoint or quota_project_id:
         options = client_options.ClientOptions(
             api_endpoint=api_endpoint,
-            quota_project_id=quota_project_id if quota_project_id else None,
         )
     from google.cloud import bigquery_storage_v1 as bigquery_storage
 

--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -150,11 +150,13 @@ def get_bigquery_client(
     credentials=None,
     api_endpoint: Optional[str] = None,
     storage_api_endpoint: Optional[str] = None,
-    client_project_id: Optional[str] = None, # to be deprecated in the future
+    client_project_id: Optional[str] = None,  # to be deprecated in the future
     billing_project_id: Optional[str] = None,
 ):
     if client_project_id:
-        logging.warning("client_project_id is deprecated and will be removed in the future, use --billing-project-id instead")
+        logging.warning(
+            "client_project_id is deprecated and will be removed in the future, use --billing-project-id instead"
+        )
         billing_project_id = client_project_id
     google_client = get_google_bigquery_client(
         project_id,

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -151,6 +151,7 @@ GOOGLE_SERVICE_ACCOUNT_KEY_PATH = "google_service_account_key_path"
 API_ENDPOINT = "api_endpoint"
 STORAGE_API_ENDPOINT = "storage_api_endpoint"
 CLIENT_PROJECT_ID = "client_project_id"
+BILLING_PROJECT_ID = "billing_project_id"
 
 # Result Handler Output Table Fields
 VALIDATION_TYPE = "validation_type"

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -123,7 +123,9 @@ data-validation connections add
     [--secret-manager-project-id SECRET_PROJECT_ID]     Secret Manager project ID
     --connection-name CONN_NAME BigQuery                Connection name
     --project-id MY_PROJECT                             Project ID where BQ data resides
-    [--google-service-account-key-path PATH_TO_SA_KEY]  (Deprecated) Path to SA key, use `gcloud auth application-default --impersonate-service-account` instead.
+    [--google-service-account-key-path PATH_TO_SA_KEY]  (Deprecated) Path to SA key, use
+                                                         gcloud auth application-default --impersonate-service-account <service-account> login
+                                                         instead.
     [--billing-project-id BILLING_PROJECT_ID]           (Optional) BigQuery billing project to override default billing project
     [--api-endpoint API_ENDPOINT]                       BigQuery API endpoint (e.g.
                                                         "https://bigquery-mypsc.p.googleapis.com)
@@ -155,7 +157,9 @@ data-validation connections add
     --project-id MY_PROJECT                             Project ID where BQ data resides
     --instance-id MY_INSTANCE                           Spanner instance to connect to
     --database-id MY-DB                                 Spanner database (schema) to connect to
-    [--google-service-account-key-path PATH_TO_SA_KEY]  Path to SA key
+    [--google-service-account-key-path PATH_TO_SA_KEY]  (Deprecated) Path to SA key, use
+                                                         gcloud auth application-default --impersonate-service-account <service-account> login
+                                                         instead.
     [--api-endpoint API_ENDPOINT]                       Spanner API endpoint (e.g.
                                                         "https://spanner-mypsc.p.googleapis.com")
 ```

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -123,21 +123,22 @@ data-validation connections add
     [--secret-manager-project-id SECRET_PROJECT_ID]     Secret Manager project ID
     --connection-name CONN_NAME BigQuery                Connection name
     --project-id MY_PROJECT                             Project ID where BQ data resides
-    [--google-service-account-key-path PATH_TO_SA_KEY]  Path to SA key
+    [--google-service-account-key-path PATH_TO_SA_KEY]  (Deprecated) Path to SA key, use `gcloud auth application-default --impersonate-service-account` instead.
+    [--billing-project-id BILLING_PROJECT_ID]           (Optional) BigQuery billing project to override default billing project
     [--api-endpoint API_ENDPOINT]                       BigQuery API endpoint (e.g.
                                                         "https://bigquery-mypsc.p.googleapis.com)
     [--storage-api-endpoint STORAGE_API_ENDPOINT]       BigQuery Storage API endpoint (e.g.
                                                         "bigquerystorage-mypsc.p.googleapis.com)
                                                         Note this is a GRPC endpoint and does not
-                                                        include a URI scheme.
+                                                        includ  e a URI scheme.
 ```
-
+BigQuery is a [Client based API](https://docs.cloud.google.com/docs/quotas/quota-project#project-client-based). If the connection is being made by the user who has authenticated using gcloud CLI, the billing project is set by the user's gcloud configuration. Users can change the billing project by using `gcloud config set project <billing-project-id>`. If the connection is being made by a Service Account, the default billing project is the project where the Service Account resides. The option `--billing-project-id` can be used to override the default billing project.
 ### User/Service account needs following BigQuery permissions to run DVT
 
-* bigquery.jobs.create (BigQuery JobUser role)
-* bigquery.readsessions.create (BigQuery Read Session User)
-* bigquery.tables.get (BigQuery Data Viewer)
-* bigquery.tables.getData (BigQuery Data Viewer)
+* bigquery.jobs.create (BigQuery JobUser role) in the billing project.
+* bigquery.readsessions.create (BigQuery Read Session User) in the billing project.
+* bigquery.tables.get (BigQuery Data Viewer) on the table.
+* bigquery.tables.getData (BigQuery Data Viewer) on the table.
 
 ### If you plan to store validation results in BigQuery
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -132,7 +132,7 @@ data-validation connections add
     [--storage-api-endpoint STORAGE_API_ENDPOINT]       BigQuery Storage API endpoint (e.g.
                                                         "bigquerystorage-mypsc.p.googleapis.com)
                                                         Note this is a GRPC endpoint and does not
-                                                        includ  e a URI scheme.
+                                                        include a URI scheme.
 ```
 BigQuery is a [Client based API](https://docs.cloud.google.com/docs/quotas/quota-project#project-client-based). If the connection is being made by the user who has authenticated using gcloud CLI, the billing project is set by the user's gcloud configuration. Users can change the billing project by using `gcloud config set project <billing-project-id>`. If the connection is being made by a Service Account, the default billing project is the project where the Service Account resides. The option `--billing-project-id` can be used to override the default billing project.
 ### User/Service account needs following BigQuery permissions to run DVT

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -166,6 +166,7 @@ CONNECTION_ADD_ARGS = {
     consts.API_ENDPOINT: None,
     consts.STORAGE_API_ENDPOINT: None,
     consts.CLIENT_PROJECT_ID: None,
+    consts.BILLING_PROJECT_ID: None,
 }
 CONNECTION_DESCRIBE_ARGS = {
     "verbose": False,


### PR DESCRIPTION

## Description of changes
As outlined in issue 1710, DVT forces the billing project resulting in incorrect (or non standard) behavior. This fix modifies the way DVT creates the BQ client, so that it behaves like other client libraries/programs. Additionally
* Change the name of the parameter being used to `--billing-project-id` for clarity
* Deprecated `--client-project-id` - users who use it will receive a warning and it will be accepted.
* Updated docs to clarify how to specify the billing project for user and service account calls.
* Deprecated the use of Service Account Key - users will receive a warning and it will be accepted.

## Issues to be closed
_Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google._

Closes #1710

## Checklist

- [X ] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated any relevant documentation to reflect my changes, if applicable
- [X] I have added unit and/or integration tests relevant to my change as needed
- [X] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [X] I have manually executed end-to-end testing (E2E) with the affected databases/engines


