### PR TITLE
test: Add tests for Oracle to PostgreSQL null values

### DIFF
--- a/tests/resources/oracle_test_tables.sql
+++ b/tests/resources/oracle_test_tables.sql
@@ -212,6 +212,15 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,HEXTORAW('387BDC3B218443B28EC23AC791C5B0F1')
 ,'{"dvt": 345, "status": "ghi"}','{"dvt": 345, "status": "ghi"}'
 );
+INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
+(4,NULL,NULL,NULL,NULL,NULL,NULL
+--,NULL,NULL
+,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL,NULL,NULL
+,NULL,NULL
+);
 COMMIT;
 
 DROP TABLE pso_data_validator.dvt_large_decimals;

--- a/tests/resources/postgresql_test_tables.sql
+++ b/tests/resources/postgresql_test_tables.sql
@@ -170,8 +170,14 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,CAST('DVT' AS BYTEA),CAST('DVT DVT DVT' AS BYTEA)
 ,CAST('DVT DVT DVT' AS BYTEA),'DVT C','DVT C'
 ,uuid('387bdc3b218443b28ec23ac791c5b0f1')
-,'{"dvt": 345, "status": "ghi"}','{"dvt": 345, "status": "ghi"}'
-);
+,'{"dvt": 345, "status": "ghi"}','{"dvt": 345, "status": "ghi"}')
+,(4,NULL,NULL,NULL,NULL,NULL,NULL
+--,NULL,NULL
+,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL,NULL,NULL
+,NULL,NULL);
 
  /* Following table used for validating generating table partitions */
 DROP TABLE IF EXISTS public.test_generate_partitions ;

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -369,11 +369,29 @@ def test_column_validation_core_types_to_bigquery():
     new=mock_get_connection_config,
 )
 def test_column_validation_oracle_to_postgres():
-    count_cols = ",".join([_ for _ in ORA2PG_COLUMNS if _ not in ("col_long_raw")])
-    # TODO Change min_cols below to include col_interval_ds when issue-1214 is complete.
-    # TODO Change min_cols below to include col_json/col_jsonb when issue-1338 is complete.
+    # TODO Change count_cols below to include col_uuid when issue-1716 is complete.
+    # TODO Change min/max_cols below to include col_interval_ds when issue-1214 is complete.
+    # TODO Change min/max_cols below to include col_json/col_jsonb when issue-1338 is complete.
+    # TODO Change min_cols below to include col_uuid when issue-1716 is complete.
+    count_cols = ",".join(
+        [_ for _ in ORA2PG_COLUMNS if _ not in ("col_long_raw", "col_uuid")]
+    )
     sum_cols = ",".join([_ for _ in ORA2PG_COLUMNS if _ not in ("col_long_raw",)])
     min_cols = ",".join(
+        [
+            _
+            for _ in ORA2PG_COLUMNS
+            if _
+            not in (
+                "col_long_raw",
+                "col_interval_ds",
+                "col_json",
+                "col_jsonb",
+                "col_uuid",
+            )
+        ]
+    )
+    max_cols = ",".join(
         [
             _
             for _ in ORA2PG_COLUMNS
@@ -392,9 +410,46 @@ def test_column_validation_oracle_to_postgres():
         count_cols=count_cols,
         sum_cols=sum_cols,
         min_cols=min_cols,
-        max_cols=min_cols,
+        max_cols=max_cols,
         avg_cols=sum_cols,
         std_cols=sum_cols,
+        # TODO Remove this filters clause when working on issue-1717.
+        filters="id < 4",
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_all_null_oracle_to_postgres():
+    # TODO Change cols below to include col_char_2, col_nchar_2 when issue-1717 is complete.
+    cols = ",".join(
+        [
+            _
+            for _ in ORA2PG_COLUMNS
+            if _
+            not in (
+                "col_long_raw",
+                "col_interval_ds",
+                "col_json",
+                "col_jsonb",
+                "col_uuid",
+                "col_char_2",
+                "col_nchar_2",
+            )
+        ]
+    )
+    column_validation_test(
+        tc="pg-conn",
+        tables="pso_data_validator.dvt_ora2pg_types",
+        count_cols=cols,
+        sum_cols=cols,
+        min_cols=cols,
+        max_cols=cols,
+        avg_cols=cols,
+        std_cols=cols,
+        filters="id = 4",
     )
 
 
@@ -571,6 +626,7 @@ def test_row_validation_oracle_to_postgres():
     # TODO Change hash_cols below to include col_interval_ds when issue-1214 is complete.
     # TODO Change hash_cols below to include col_clob/col_nclob/col_blob when issue-1364 is complete.
     # TODO Change hash_cols below to include col_json/col_jsonb when issue-1338 is complete.
+    # TODO Change hash_cols below to include col_uuid when issue-1716 is complete.
     # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
     # Excluded col_long_raw because LONG types are not supported.
     hash_cols = ",".join(
@@ -590,6 +646,7 @@ def test_row_validation_oracle_to_postgres():
                 "col_interval_ds",
                 "col_json",
                 "col_jsonb",
+                "col_uuid",
             )
         ]
     )
@@ -607,6 +664,7 @@ def test_row_validation_oracle_to_postgres():
 def test_row_validation_comp_fields_oracle_to_postgres():
     # TODO Change cols below to include col_num_38 when issue-1454 is complete.
     # TODO Change cols below to include col_json/col_jsonb when issue-1338 is complete.
+    # TODO Change cols below to include col_uuid when issue-1716 is complete.
     # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
     # Excluded col_long_raw because LONG types are not supported.
     cols = ",".join(
@@ -621,6 +679,7 @@ def test_row_validation_comp_fields_oracle_to_postgres():
                 "col_num_38",
                 "col_json",
                 "col_jsonb",
+                "col_uuid",
             )
         ]
     )
@@ -885,6 +944,7 @@ def test_custom_query_row_validation_oracle_to_postgres():
     # TODO Change hash_cols below to include col_interval_ds when issue-1214 is complete.
     # TODO Change hash_cols below to include col_clob/col_nclob/col_blob when issue-1364 is complete.
     # TODO Change hash_cols below to include col_json/col_jsonb when issue-1338 is complete.
+    # TODO Change hash_cols below to include col_uuid when issue-1716 is complete.
     # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
     # Excluded col_long_raw because LONG types are not supported.
     hash_cols = ",".join(
@@ -904,6 +964,7 @@ def test_custom_query_row_validation_oracle_to_postgres():
                 "col_interval_ds",
                 "col_json",
                 "col_jsonb",
+                "col_uuid",
             )
         ]
     )


### PR DESCRIPTION
## Description of changes

Adds tests validating NULLs for Oracle to PostgreSQL. This is to reproduce an issue discussed with a customer and highlighted two bugs, both of which have had dedicated issues raised:

- https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1717
- https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1716

This PR is for adding tests only, no fixes are included.

## Issues to be closed

Closes #1718


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


