### PR TITLE
fix: Prevent scientific notation in row validation for Db2 REAL/DOUBLE columns

### DIFF
--- a/docs/internal/floats_as_strings.md
+++ b/docs/internal/floats_as_strings.md
@@ -1,0 +1,118 @@
+# Floating-point data types converted to string
+
+This document captures some testing of casts of floating-point values to string. We all know data types such as Float and Double are inexact but I wanted to capture an example for future reference.
+
+When running tests I was careful to cast directly from string to the floating-point type to avoid decimal data types from being used and confusing matters further.
+
+By way of example I picked single float and double values and compared the resulting strings with the original input strings. It is likely there are other input values that will produce a different set of variations.
+
+## Tests
+
+### BigQuery
+
+```sql
+-- no float32
+
+select cast(cast('12345678.2' as float64) as string);
+
+12345678.2
+```
+
+### Db2 LUW
+
+```sql
+| `$ db2 "select to_char(cast('123456.1' as real)) from sysibm.sysdummy1"
+123456.1015625 $ db2 "select to_char(cast('12345678.2' as double)) from sysibm.sysdummy1" 1 ------------------------------------------ 12345678.199999999
+```
+
+### Hive
+
+```sql
+| `select cast(cast('123456.1' as float) as string) 123456.1 select cast(cast('12345678.2' as double) as string) 1.23456782E7
+```
+
+### Impala
+
+```sql
+select cast(cast('123456.1' as float) as string)
+
+123456.102
+
+select cast(cast('12345678.2' as double) as string)
+
+12345678.199999999
+```
+
+### MySQL
+
+```sql
+select cast(cast('123456.1' as real) as char);
+
+123456.1
+
+select cast(cast('12345678.2' as double) as char);
+
+12345678.2
+```
+
+### Oracle
+
+```sql
+select to_char(cast('123456.1' as binary_float),'tm9') from dual;
+
+123456.102
+
+select to_char(cast('12345678.2' as binary_double),'tm9') from dual;
+
+12345678.199999999
+```
+
+### PostgreSQL
+
+```sql
+select cast(cast('123456.1' as real) as text);
+
+123456.1
+
+select cast(cast('12345678.2' as double precision) as text);
+
+12345678.2
+```
+
+### SQL Server
+
+```sql
+select format(cast('123456.1' as real), 'G');
+
+123456.1
+
+select format(cast('12345678.2' as float), 'G');
+
+12345678.2
+```
+
+### Teradata
+
+```sql
+select to_char(cast('123456.1' as float),'tm9');
+
+123456.1
+
+select to_char(cast('12345678.2' as double precision),'tm9');
+
+12345678.2
+```
+
+## Results
+
+| System / Input String | FLOAT32 '123456.1' | FLOAT64 '12345678.2' |
+| :---- | :---- | :---- |
+| BigQuery | N/A | 12345678.2 |
+| Db2 LUW | 123456.1015625 | 12345678.199999999 |
+| Hive | 123456.1 | 1.23456782E7 |
+| Impala | 123456.102 | 12345678.199999999 |
+| MySQL | 123456.1 | 12345678.2 |
+| Oracle | 123456.102 | 12345678.199999999 |
+| PostgreSQL | 123456.1 | 12345678.2 |
+| SQL Server | 123456.1 | 12345678.2 |
+| Teradata | 123456.1 | 12345678.2 |

--- a/docs/internal/floats_as_strings.md
+++ b/docs/internal/floats_as_strings.md
@@ -21,14 +21,25 @@ select cast(cast('12345678.2' as float64) as string);
 ### Db2 LUW
 
 ```sql
-| `$ db2 "select to_char(cast('123456.1' as real)) from sysibm.sysdummy1"
-123456.1015625 $ db2 "select to_char(cast('12345678.2' as double)) from sysibm.sysdummy1" 1 ------------------------------------------ 12345678.199999999
+select to_char(cast('123456.1' as real)) from sysibm.sysdummy1
+
+123456.1015625
+
+select to_char(cast('12345678.2' as double)) from sysibm.sysdummy1"
+
+12345678.199999999
 ```
 
 ### Hive
 
 ```sql
-| `select cast(cast('123456.1' as float) as string) 123456.1 select cast(cast('12345678.2' as double) as string) 1.23456782E7
+select cast(cast('123456.1' as float) as string)
+
+123456.1
+
+select cast(cast('12345678.2' as double) as string)
+
+1.23456782E7
 ```
 
 ### Impala

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,8 +1,12 @@
 # Data Validation Tool Restrictions and Limitations
 
+## General
+
+- Floating-point data types, e.g. Float and Double, are inexact by nature. Validations that involve conversion of floating-point data to string, e.g. `--hash` and `--concat`, can be problematic.
+
 ## BigQuery
 
-- BigQuery does not have a 32 bit float data type. Validations of systems containing 32 bit floats (e.g. Oracle BINARY_FLOAT) will likely be problematic when compared to FLOAT64.
+- BigQuery does not have a 32 bit floating-point data type. Validations of systems containing 32 bit floats (e.g. Oracle BINARY_FLOAT) will likely be problematic when compared to FLOAT64.
 
 ## Db2 LUW
 

--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -32,6 +32,7 @@ from ibis.backends.base.sql.alchemy import (
     get_sqla_table,
 )
 from ibis.backends.base.sql.alchemy.registry import variance_reduction
+from ibm_db_sa import DOUBLE
 
 from third_party.ibis.ibis_addon.api import ibis_integer_string_length
 
@@ -132,6 +133,13 @@ def _cast(t, op):
             if string_length:
                 # Restring target string length to appropriate length for integer size.
                 return sa.cast(sa_arg, sa.String(string_length))
+    elif (
+        arg_dtype.is_floating() or isinstance(getattr(sa_arg, "type", None), DOUBLE)
+    ) and typ.is_string():
+        # Db2 DOUBLE is subclassed from NUMERIC which means it is identified as Ibis Decimal.
+        # Above we check the column data type directly to force DOUBLE into floating point expression code.
+        # To prevent scientific notation when casting to string we use TO_CHAR which appears to avoid the problem.
+        return sa.func.to_char(sa_arg)
     elif arg_dtype.is_decimal() and typ.is_string():
         if arg_dtype.scale is not None and arg_dtype.scale > 0:
             # Db2 always pads fractional part of the number out to length of scale.
@@ -149,9 +157,6 @@ def _cast(t, op):
                     sa.literal_column("''"),
                 )
             )
-        # Max expected precision 38 plus 2 for minus sign and decimal place.
-        return sa.cast(sa_arg, sa.String(40))
-    elif arg_dtype.is_floating() and typ.is_string():
         # Max expected precision 38 plus 2 for minus sign and decimal place.
         return sa.cast(sa_arg, sa.String(40))
 


### PR DESCRIPTION
## Description of changes

This PR prevents scientific notation in row validation for Db2 REAL/DOUBLE columns. To do this I changed `cast(... to varchar)` to `to_char(...)`. In my tests, with this change in place, I did not see scientific notation used.

I cannot add `col_float32/64` to tests though due to general differences in string conversion output. I added an internal doc capturing that for future reference.

## Issues to be closed

Closes #1722

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


