### PR TITLE
fix: Protect PostgreSQL padded chars length expression from NULLs

### DIFF
--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -414,8 +414,6 @@ def test_column_validation_oracle_to_postgres():
         max_cols=max_cols,
         avg_cols=sum_cols,
         std_cols=sum_cols,
-        # TODO Remove this filters clause when working on issue-1717.
-        filters="id < 4",
     )
 
 
@@ -424,7 +422,6 @@ def test_column_validation_oracle_to_postgres():
     new=mock_get_connection_config,
 )
 def test_column_validation_all_null_oracle_to_postgres():
-    # TODO Change cols below to include col_char_2, col_nchar_2 when issue-1717 is complete.
     cols = ",".join(
         [
             _
@@ -436,8 +433,6 @@ def test_column_validation_all_null_oracle_to_postgres():
                 "col_json",
                 "col_jsonb",
                 "col_uuid",
-                "col_char_2",
-                "col_nchar_2",
             )
         ]
     )

--- a/third_party/ibis/ibis_postgres/registry.py
+++ b/third_party/ibis/ibis_postgres/registry.py
@@ -83,4 +83,9 @@ def sa_format_postgres_padded_char_length(translator, op):
     Without this workaround the bpchar value is implicitly cast to varchar and loses trailing spaces.
     """
     arg = translator.translate(op.arg)
-    return sa.func.char_length(sa.func.concat(arg, sa.text("''")))
+    return sa.func.char_length(
+        sa.case(
+            (arg.is_(None), sa.literal_column("NULL")),
+            else_=sa.func.concat(arg, sa.text("''")),
+        )
+    )


### PR DESCRIPTION
## Description of changes
This PR adds protection for the PostgreSQL padded chars length expression from NULL input values. Also adds tests.

## Issues to be closed

Closes #1717


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


