### PR TITLE
fix: custom query row validation on Db2 loses precision and scale

### DIFF
--- a/tests/system/data_sources/test_db2.py
+++ b/tests/system/data_sources/test_db2.py
@@ -564,12 +564,11 @@ def test_custom_query_row_validation_core_types_to_bigquery():
 )
 def test_custom_query_row_concat_validation_core_types_to_bigquery():
     """Db2 to BigQuery dvt_core_types custom-query row concat validation"""
-    # TODO Add col_dec_10_2 when working on issue-1706.
     custom_query_validation_test(
         validation_type="row",
         source_query="select id,col_int64,col_dec_10_2,COL_VARCHAR_30,col_date from pso_data_validator.dvt_core_types",
         target_query="select id,col_int64,col_dec_10_2,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
-        concat="col_int64,col_varchar_30,col_date",
+        concat="col_int64,col_dec_10_2,col_varchar_30,col_date",
     )
 
 

--- a/third_party/ibis/ibis_db2/__init__.py
+++ b/third_party/ibis/ibis_db2/__init__.py
@@ -100,8 +100,7 @@ class Backend(BaseAlchemyBackend):
             result = con.exec_driver_sql(f"SELECT * FROM {query} t0 LIMIT 1")
             cursor = result.cursor
             yield from (
-                (column[0].lower(), _get_type(column[1]))
-                for column in cursor.description
+                (column[0].lower(), _get_type(column)) for column in cursor.description
             )
 
     def list_primary_key_columns(self, database: str, table: str) -> list:

--- a/third_party/ibis/ibis_db2/datatypes.py
+++ b/third_party/ibis/ibis_db2/datatypes.py
@@ -54,8 +54,16 @@ def sa_sf_binary(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
-def _get_type(typename) -> dt.DataType:
+def _get_type(column) -> dt.DataType:
+    typename = column[1]
     typ = _type_mapping.get(typename)
     if typ is None:
-        raise NotImplementedError(f"DB2 type {typename} is not supported")
+        raise NotImplementedError(f"Db2 type {typename} is not supported")
+
+    if typ == dt.Decimal:
+        precision = column[4]
+        scale = column[5]
+        if precision is not None and scale is not None:
+            return dt.Decimal(precision, scale)
+
     return typ


### PR DESCRIPTION
## Description of changes
Fixes an issue where custom query row validation on Db2 loses decimal precision and scale because it was ignoring cursor.description values.

Updated `_get_type()` to receive the entire column tuple, rather than just the type string, and extracted precision and scale. This mimics how PostgreSQL and Oracle backends extract type sizes.

## Issues to be closed

Closes #1706

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


