### PR TITLE
test: Remove LONG RAW Oracle test column

### DIFF
--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -1382,6 +1382,12 @@ class ConfigManager(object):
                 )
                 result_source_columns.pop(source_column)
                 result_target_columns.pop(target_column)
+            if self._is_oracle_lob(source_column, target_column):
+                logging.info(
+                    f"Skipping column {source_column} due to Oracle LOB data type"
+                )
+                result_source_columns.pop(source_column)
+                result_target_columns.pop(target_column)
             if self._is_db2_blob(source_column, target_column):
                 # Db2 BLOB is incompatible with Db2s own HEX function.
                 # Users would need to use a custom query to a custom UDF to row validate these.

--- a/data_validation/config_manager.py
+++ b/data_validation/config_manager.py
@@ -699,8 +699,8 @@ class ConfigManager(object):
         """Returns True when either source or target column is Oracle LOB data type.
 
         Unexpectedly the raw types for for LOB types are:
-            BLOB: LONG_RAW
-            CLOB: LONG
+            BLOB: LONG_RAW (this covers Oracle LONG_RAW too)
+            CLOB: LONG (this covers Oracle LONG too)
             NCLOB: LONG_NVARCHAR
         """
         return self._is_raw_data_type(

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -27,6 +27,8 @@
 ## Oracle
 
 - Requires the `oracledb` package to be installed as an extra dependency.
+- Oracle LONG and LONG RAW data types are not supported.
+- Oracle BLOB, CLOB, and NCLOB data types are not supported for row validation (except when used as part of a custom query).
 
 ## Snowflake
 

--- a/tests/resources/oracle_test_tables.sql
+++ b/tests/resources/oracle_test_tables.sql
@@ -152,7 +152,6 @@ CREATE TABLE pso_data_validator.dvt_ora2pg_types
 ,   col_tsltz       TIMESTAMP(6) WITH LOCAL TIME ZONE
 ,   col_interval_ds INTERVAL DAY(2) TO SECOND (3)
 ,   col_raw         RAW(16)
-,   col_long_raw    LONG RAW
 ,   col_blob        BLOB
 ,   col_clob        CLOB
 ,   col_nclob       NCLOB
@@ -177,8 +176,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,to_timestamp_tz('1970-01-01 00:00:01.123456 00:00','YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')
 ,to_timestamp_tz('1970-01-01 00:00:01.123456 00:00','YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')
 ,INTERVAL '1 2:03:44.0' DAY TO SECOND(3)
-,UTL_RAW.CAST_TO_RAW('DVT'),UTL_RAW.CAST_TO_RAW('DVT')
-,UTL_RAW.CAST_TO_RAW('DVT'),'DVT A','DVT A'
+,UTL_RAW.CAST_TO_RAW('DVT'),UTL_RAW.CAST_TO_RAW('DVT'),'DVT A','DVT A'
 ,HEXTORAW('187BDC3B218443B28EC23AC791C5B0F1')
 ,'{"dvt": 123, "status": "abc"}','{"dvt": 123, "status": "abc"}'
 );
@@ -192,8 +190,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,to_timestamp_tz('1970-01-02 00:00:02.123456 -02:00','YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')
 ,to_timestamp_tz('1970-01-02 00:00:02.123456 -02:00','YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')
 ,INTERVAL '2 3:04:55.666' DAY TO SECOND(3)
-,UTL_RAW.CAST_TO_RAW('DVT'),UTL_RAW.CAST_TO_RAW('DVT DVT')
-,UTL_RAW.CAST_TO_RAW('DVT DVT'),'DVT B','DVT B'
+,UTL_RAW.CAST_TO_RAW('DVT'),UTL_RAW.CAST_TO_RAW('DVT DVT'),'DVT B','DVT B'
 ,HEXTORAW('287BDC3B218443B28EC23AC791C5B0F1')
 ,'{"dvt": 234, "status": "def"}','{"dvt": 234, "status": "def"}'
 );
@@ -207,8 +204,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,to_timestamp_tz('1970-01-03 00:00:03.654321 -03:00','YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')
 ,to_timestamp_tz('1970-01-03 00:00:03.654321 -03:00','YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')
 ,INTERVAL '3 4:05:06.7' DAY TO SECOND(3)
-,UTL_RAW.CAST_TO_RAW('DVT'),UTL_RAW.CAST_TO_RAW('DVT DVT DVT')
-,UTL_RAW.CAST_TO_RAW('DVT DVT DVT'),'DVT C','DVT C'
+,UTL_RAW.CAST_TO_RAW('DVT'),UTL_RAW.CAST_TO_RAW('DVT DVT DVT'),'DVT C','DVT C'
 ,HEXTORAW('387BDC3B218443B28EC23AC791C5B0F1')
 ,'{"dvt": 345, "status": "ghi"}','{"dvt": 345, "status": "ghi"}'
 );
@@ -217,7 +213,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 --,NULL,NULL
 ,NULL,NULL,NULL
 ,NULL,NULL,NULL,NULL
-,NULL,NULL,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL
 ,NULL,NULL,NULL,NULL,NULL,NULL
 ,NULL,NULL
 );

--- a/tests/resources/postgresql_test_tables.sql
+++ b/tests/resources/postgresql_test_tables.sql
@@ -120,7 +120,6 @@ CREATE TABLE pso_data_validator.dvt_ora2pg_types
 ,   col_tsltz       timestamp(6) with time zone
 ,   col_interval_ds interval day to second (3)
 ,   col_raw         bytea
-,   col_long_raw    bytea
 ,   col_blob        bytea
 ,   col_clob        text
 ,   col_nclob       text
@@ -141,8 +140,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,TIMESTAMP WITH TIME ZONE'1970-01-01 00:00:01.123456 +00:00'
 ,TIMESTAMP WITH TIME ZONE'1970-01-01 00:00:01.123456 +00:00'
 ,INTERVAL '1 2:03:44.0' DAY TO SECOND(3)
-,CAST('DVT' AS BYTEA),CAST('DVT' AS BYTEA)
-,CAST('DVT' AS BYTEA),'DVT A','DVT A'
+,CAST('DVT' AS BYTEA),CAST('DVT' AS BYTEA),'DVT A','DVT A'
 ,uuid('187bdc3b218443b28ec23ac791c5b0f1')
 ,'{"dvt": 123, "status": "abc"}','{"dvt": 123, "status": "abc"}')
 ,(2,2222,123456789,123456789012345678,1234567890123456789012345
@@ -154,8 +152,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,TIMESTAMP WITH TIME ZONE'1970-01-02 00:00:02.123456 -02:00'
 ,TIMESTAMP WITH TIME ZONE'1970-01-02 00:00:02.123456 -02:00'
 ,INTERVAL '2 3:04:55.666' DAY TO SECOND(3)
-,CAST('DVT' AS BYTEA),CAST('DVT DVT' AS BYTEA)
-,CAST('DVT DVT' AS BYTEA),'DVT B','DVT B'
+,CAST('DVT' AS BYTEA),CAST('DVT DVT' AS BYTEA),'DVT B','DVT B'
 ,uuid('287bdc3b218443b28ec23ac791c5b0f1')
 ,'{"dvt": 234, "status": "def"}','{"dvt": 234, "status": "def"}')
 ,(3,3333,123456789,123456789012345678,1234567890123456789012345
@@ -167,8 +164,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,TIMESTAMP WITH TIME ZONE'1970-01-03 00:00:03.654321 -03:00'
 ,TIMESTAMP WITH TIME ZONE'1970-01-03 00:00:03.654321 -03:00'
 ,INTERVAL '3 4:05:06.7' DAY TO SECOND(3)
-,CAST('DVT' AS BYTEA),CAST('DVT DVT DVT' AS BYTEA)
-,CAST('DVT DVT DVT' AS BYTEA),'DVT C','DVT C'
+,CAST('DVT' AS BYTEA),CAST('DVT DVT DVT' AS BYTEA),'DVT C','DVT C'
 ,uuid('387bdc3b218443b28ec23ac791c5b0f1')
 ,'{"dvt": 345, "status": "ghi"}','{"dvt": 345, "status": "ghi"}')
 ,(4,NULL,NULL,NULL,NULL,NULL,NULL
@@ -176,7 +172,7 @@ INSERT INTO pso_data_validator.dvt_ora2pg_types VALUES
 ,NULL,NULL,NULL
 ,NULL,NULL,NULL,NULL
 ,NULL,NULL,NULL,NULL,NULL
-,NULL,NULL,NULL,NULL,NULL,NULL
+,NULL,NULL,NULL,NULL,NULL
 ,NULL,NULL);
 
  /* Following table used for validating generating table partitions */

--- a/tests/system/data_sources/test_oracle.py
+++ b/tests/system/data_sources/test_oracle.py
@@ -111,7 +111,6 @@ ORA2PG_COLUMNS = [
     "col_tstz",
     "col_interval_ds",
     "col_raw",
-    "col_long_raw",
     "col_blob",
     "col_clob",
     "col_nclob",
@@ -374,17 +373,14 @@ def test_column_validation_oracle_to_postgres():
     # TODO Change min/max_cols below to include col_interval_ds when issue-1214 is complete.
     # TODO Change min/max_cols below to include col_json/col_jsonb when issue-1338 is complete.
     # TODO Change min_cols below to include col_uuid when issue-1716 is complete.
-    count_cols = ",".join(
-        [_ for _ in ORA2PG_COLUMNS if _ not in ("col_long_raw", "col_uuid")]
-    )
-    sum_cols = ",".join([_ for _ in ORA2PG_COLUMNS if _ not in ("col_long_raw",)])
+    count_cols = ",".join([_ for _ in ORA2PG_COLUMNS if _ not in ("col_uuid",)])
+    sum_cols = ",".join(ORA2PG_COLUMNS)
     min_cols = ",".join(
         [
             _
             for _ in ORA2PG_COLUMNS
             if _
             not in (
-                "col_long_raw",
                 "col_interval_ds",
                 "col_json",
                 "col_jsonb",
@@ -398,7 +394,6 @@ def test_column_validation_oracle_to_postgres():
             for _ in ORA2PG_COLUMNS
             if _
             not in (
-                "col_long_raw",
                 "col_interval_ds",
                 "col_json",
                 "col_jsonb",
@@ -428,7 +423,6 @@ def test_column_validation_all_null_oracle_to_postgres():
             for _ in ORA2PG_COLUMNS
             if _
             not in (
-                "col_long_raw",
                 "col_interval_ds",
                 "col_json",
                 "col_jsonb",
@@ -624,7 +618,6 @@ def test_row_validation_oracle_to_postgres():
     # TODO Change hash_cols below to include col_json/col_jsonb when issue-1338 is complete.
     # TODO Change hash_cols below to include col_uuid when issue-1716 is complete.
     # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
-    # Excluded col_long_raw because LONG types are not supported.
     hash_cols = ",".join(
         [
             _
@@ -634,7 +627,6 @@ def test_row_validation_oracle_to_postgres():
                 "col_blob",
                 "col_clob",
                 "col_nclob",
-                "col_long_raw",
                 "col_float32",
                 "col_float64",
                 "col_nvarchar_30",
@@ -662,14 +654,12 @@ def test_row_validation_comp_fields_oracle_to_postgres():
     # TODO Change cols below to include col_json/col_jsonb when issue-1338 is complete.
     # TODO Change cols below to include col_uuid when issue-1716 is complete.
     # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
-    # Excluded col_long_raw because LONG types are not supported.
     cols = ",".join(
         [
             _
             for _ in ORA2PG_COLUMNS
             if _
             not in (
-                "col_long_raw",
                 "col_float32",
                 "col_float64",
                 "col_num_38",
@@ -942,7 +932,6 @@ def test_custom_query_row_validation_oracle_to_postgres():
     # TODO Change hash_cols below to include col_json/col_jsonb when issue-1338 is complete.
     # TODO Change hash_cols below to include col_uuid when issue-1716 is complete.
     # Excluded col_float32,col_float64 due to the lossy nature of BINARY_FLOAT/DOUBLE.
-    # Excluded col_long_raw because LONG types are not supported.
     hash_cols = ",".join(
         [
             _
@@ -952,7 +941,6 @@ def test_custom_query_row_validation_oracle_to_postgres():
                 "col_blob",
                 "col_clob",
                 "col_nclob",
-                "col_long_raw",
                 "col_float32",
                 "col_float64",
                 "col_nvarchar_30",


### PR DESCRIPTION
## Description of changes
Remove LONG RAW Oracle test column and document an Oracle limitation that LONG columns are not supported.

## Issues to be closed

Closes #1736

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


