### PR TITLE
fix: Remove source/target conn from JSON config file

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import logging
 import os
@@ -489,9 +490,7 @@ def convert_config_to_json(config_managers: list) -> dict:
             "JSON configs can only be created for single table validations."
         )
     config_manager = config_managers[0]
-    json_config = config_manager.config
-    json_config[consts.CONFIG_SOURCE_CONN] = config_manager.get_source_connection()
-    json_config[consts.CONFIG_TARGET_CONN] = config_manager.get_target_connection()
+    json_config = copy.deepcopy(config_manager.config)
     return json_config
 
 

--- a/data_validation/consts.py
+++ b/data_validation/consts.py
@@ -146,9 +146,11 @@ SOURCE_TYPE_TERADATA = "Teradata"
 # BigQuery Result Handler Configs
 RH_TYPE = "type"
 RH_CONN = "connection"
-PROJECT_ID = "project_id"
 TABLE_ID = "table_id"
 GOOGLE_SERVICE_ACCOUNT_KEY_PATH = "google_service_account_key_path"
+
+# BigQuery connection attributes
+PROJECT_ID = "project_id"
 API_ENDPOINT = "api_endpoint"
 STORAGE_API_ENDPOINT = "storage_api_endpoint"
 CLIENT_PROJECT_ID = "client_project_id"

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -1379,7 +1379,7 @@ def test_column_validation_convert_config_to_json(mock_conn):
 
     # Ensure that the final validation executes successfully using the converted JSON config
     data_validator = data_validation.DataValidation(json_config, verbose=False)
-    df = data_validator.execute()
+    _ = data_validator.execute()
     # If we get to here then there was no exception, meaning the JSON was valid.
 
 

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -49,7 +49,7 @@ from tests.system.result_handlers.test_bigquery import create_bigquery_results_t
 PROJECT_ID = os.environ["PROJECT_ID"]
 TEST_BUCKET = os.environ.get("TEST_BUCKET", PROJECT_ID)
 os.environ[consts.ENV_DIRECTORY_VAR] = f"gs://{TEST_BUCKET}/integration_tests/"
-BQ_CONN = {consts.SOURCE_TYPE: consts.SOURCE_TYPE_BIGQUERY, "project_id": PROJECT_ID}
+BQ_CONN = {consts.SOURCE_TYPE: consts.SOURCE_TYPE_BIGQUERY, consts.PROJECT_ID: PROJECT_ID, consts.BILLING_PROJECT_ID: PROJECT_ID}
 CONFIG_COUNT_VALID = {
     # BigQuery Specific Connection Name
     consts.CONFIG_SOURCE_CONN: BQ_CONN,
@@ -411,8 +411,6 @@ TEST_JSON_VALIDATION_CONFIG = {
             consts.CONFIG_TYPE: "count",
         },
     ],
-    consts.CONFIG_SOURCE_CONN: BQ_CONN,
-    consts.CONFIG_TARGET_CONN: BQ_CONN,
     consts.CONFIG_CASE_INSENSITIVE_MATCH: False,
     consts.CONFIG_ROW_CONCAT: None,
     consts.CONFIG_ROW_HASH: None,
@@ -1370,8 +1368,15 @@ def test_column_validation_convert_config_to_json(mock_conn):
     assert len(config_managers) == 1
 
     json_config = main.convert_config_to_json(config_managers)
-    # assert structure
+    # Assert structure
     assert json_config == TEST_JSON_VALIDATION_CONFIG
+    # Ensure that raw connection info is not in the JSON anywhere.
+    assert consts.SOURCE_TYPE not in str(json_config)
+
+    # Ensure that the final validation executes successfully using the converted JSON config
+    data_validator = data_validation.DataValidation(json_config, verbose=False)
+    df = data_validator.execute()
+    # If we get to here then there was no exception, meaning the JSON was valid.
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_bigquery.py
+++ b/tests/system/data_sources/test_bigquery.py
@@ -49,7 +49,11 @@ from tests.system.result_handlers.test_bigquery import create_bigquery_results_t
 PROJECT_ID = os.environ["PROJECT_ID"]
 TEST_BUCKET = os.environ.get("TEST_BUCKET", PROJECT_ID)
 os.environ[consts.ENV_DIRECTORY_VAR] = f"gs://{TEST_BUCKET}/integration_tests/"
-BQ_CONN = {consts.SOURCE_TYPE: consts.SOURCE_TYPE_BIGQUERY, consts.PROJECT_ID: PROJECT_ID, consts.BILLING_PROJECT_ID: PROJECT_ID}
+BQ_CONN = {
+    consts.SOURCE_TYPE: consts.SOURCE_TYPE_BIGQUERY,
+    consts.PROJECT_ID: PROJECT_ID,
+    consts.BILLING_PROJECT_ID: PROJECT_ID,
+}
 CONFIG_COUNT_VALID = {
     # BigQuery Specific Connection Name
     consts.CONFIG_SOURCE_CONN: BQ_CONN,


### PR DESCRIPTION
## Description of changes

In `data_validation/__main__.py` we used to add the raw connection info into the JSON. The PR removes that code and adds a test to ensure that the resulting JSON executes correctly (i.e. the fields were not required).

## Issues to be closed

Closes #1738

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


