### PR TITLE
fix(config): expand YAML row hash wildcards

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -451,6 +451,16 @@ def build_config_managers_from_yaml(args, config_file_path):
             config, source_client, target_client, verbose=args.verbose
         )
         config_manager.config[consts.CONFIG_FILE] = config_file_path
+        if (
+            config_manager.validation_type == consts.ROW_VALIDATION
+            or (
+                config_manager.validation_type == consts.CUSTOM_QUERY
+                and config_manager.custom_query_type == consts.ROW_VALIDATION.lower()
+            )
+        ) and not config_manager.calculated_fields:
+            config_manager.append_calculated_fields(
+                _get_calculated_config(args, config_manager)
+            )
         config_managers.append(config_manager)
 
     return config_managers

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -231,6 +231,127 @@ class MockIbisClient(object):
     name = "bigquery"
 
 
+class MockYamlConfigManager(object):
+    instances = []
+
+    def __init__(self, config, source_client, target_client, verbose=False):
+        self.config = config
+        self.source_client = source_client
+        self.target_client = target_client
+        self.verbose = verbose
+        self.appended_calculated_fields = []
+        MockYamlConfigManager.instances.append(self)
+
+    @property
+    def validation_type(self):
+        return self.config[consts.CONFIG_TYPE]
+
+    @property
+    def custom_query_type(self):
+        return self.config.get(consts.CONFIG_CUSTOM_QUERY_TYPE, "")
+
+    @property
+    def calculated_fields(self):
+        return self.config.get(consts.CONFIG_CALCULATED_FIELDS, [])
+
+    def append_calculated_fields(self, calculated_configs):
+        self.appended_calculated_fields.extend(calculated_configs)
+        self.config[consts.CONFIG_CALCULATED_FIELDS] = (
+            self.calculated_fields + calculated_configs
+        )
+
+
+@mock.patch(
+    "data_validation.__main__._get_calculated_config",
+    return_value=[{"name": "hash__all"}],
+)
+@mock.patch("data_validation.__main__.ConfigManager", MockYamlConfigManager)
+@mock.patch("data_validation.clients.get_data_client", return_value=MockIbisClient())
+@mock.patch(
+    "data_validation.__main__.state_manager.StateManager.get_connection_config",
+    return_value=TEST_CONN,
+)
+@mock.patch(
+    "data_validation.cli_tools.get_validation",
+    return_value={
+        consts.YAML_SOURCE: "my_source",
+        consts.YAML_TARGET: "my_target",
+        consts.YAML_RESULT_HANDLER: {},
+        consts.YAML_VALIDATIONS: [
+            {
+                consts.CONFIG_TYPE: consts.ROW_VALIDATION,
+                consts.CONFIG_SCHEMA_NAME: "mydataset",
+                consts.CONFIG_TABLE_NAME: "mytable",
+                consts.CONFIG_TARGET_SCHEMA_NAME: "mydataset",
+                consts.CONFIG_TARGET_TABLE_NAME: "mytable",
+                consts.CONFIG_PRIMARY_KEYS: [
+                    {
+                        consts.CONFIG_SOURCE_COLUMN: "id",
+                        consts.CONFIG_TARGET_COLUMN: "id",
+                        consts.CONFIG_FIELD_ALIAS: "id",
+                    }
+                ],
+                consts.CONFIG_ROW_HASH: "*",
+            }
+        ],
+    },
+)
+def test_build_config_managers_from_yaml_expands_unmaterialized_row_hash(
+    mock_get_validation,
+    mock_get_connection_config,
+    mock_get_data_client,
+    mock_get_calculated_config,
+):
+    MockYamlConfigManager.instances = []
+    args = argparse.Namespace(verbose=False, config_dir=None)
+
+    config_managers = main.build_config_managers_from_yaml(args, "test.yaml")
+
+    assert len(config_managers) == 1
+    assert mock_get_calculated_config.call_count == 1
+    assert config_managers[0].calculated_fields == [{"name": "hash__all"}]
+
+
+@mock.patch(
+    "data_validation.__main__._get_calculated_config",
+    return_value=[{"name": "hash__all"}],
+)
+@mock.patch("data_validation.__main__.ConfigManager", MockYamlConfigManager)
+@mock.patch("data_validation.clients.get_data_client", return_value=MockIbisClient())
+@mock.patch(
+    "data_validation.__main__.state_manager.StateManager.get_connection_config",
+    return_value=TEST_CONN,
+)
+@mock.patch(
+    "data_validation.cli_tools.get_validation",
+    return_value={
+        consts.YAML_SOURCE: "my_source",
+        consts.YAML_TARGET: "my_target",
+        consts.YAML_RESULT_HANDLER: {},
+        consts.YAML_VALIDATIONS: [
+            {
+                consts.CONFIG_TYPE: consts.ROW_VALIDATION,
+                consts.CONFIG_CALCULATED_FIELDS: [{"name": "existing_hash"}],
+                consts.CONFIG_ROW_HASH: "*",
+            }
+        ],
+    },
+)
+def test_build_config_managers_from_yaml_preserves_materialized_hash_fields(
+    mock_get_validation,
+    mock_get_connection_config,
+    mock_get_data_client,
+    mock_get_calculated_config,
+):
+    MockYamlConfigManager.instances = []
+    args = argparse.Namespace(verbose=False, config_dir=None)
+
+    config_managers = main.build_config_managers_from_yaml(args, "test.yaml")
+
+    assert mock_get_calculated_config.call_count == 0
+    assert config_managers[0].calculated_fields == [{"name": "existing_hash"}]
+
+
 @mock.patch(
     "argparse.ArgumentParser.parse_args",
     return_value=argparse.Namespace(**CLI_ARGS),


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Description of changes
- Expands hand-authored YAML row-validation `hash: '*'` / `concat: '*'` configs through the same calculated-field builder used by the CLI path.
- Keeps regenerated YAML configs that already contain `calculated_fields` unchanged to avoid double-expansion.
- Adds unit coverage for expanding an unmaterialized row hash wildcard and preserving already materialized hash fields.

## Issues to be closed
Closes #1743

## Testing
- RED: `PYTHONPATH=/tmp/dsv_test_stubs:$PYTHONPATH /opt/homebrew/Cellar/pyenv/2.6.7/versions/3.11.7/bin/python -m pytest tests/unit/test__main.py::test_build_config_managers_from_yaml_expands_unmaterialized_row_hash tests/unit/test__main.py::test_build_config_managers_from_yaml_preserves_materialized_hash_fields -q` failed before the source fix with `_get_calculated_config.call_count == 0` for the unmaterialized YAML hash case.
- `PYTHONPATH=/tmp/dsv_test_stubs:$PYTHONPATH /opt/homebrew/Cellar/pyenv/2.6.7/versions/3.11.7/bin/python -m pytest tests/unit/test__main.py -q` (22 passed)
- `/opt/homebrew/Cellar/pyenv/2.6.7/versions/3.11.7/bin/python -m black --check data_validation/__main__.py tests/unit/test__main.py`
- `git diff --check`
- `/opt/homebrew/Cellar/pyenv/2.6.7/versions/3.11.7/bin/python -m py_compile data_validation/__main__.py tests/unit/test__main.py`

Note: the local pyenv Python lacks the `_lzma` stdlib extension, so the pytest command used a minimal `/tmp/dsv_test_stubs/lzma.py` import stub; the exercised tests do not use lzma functionality.

## AI assistance disclosure
This draft PR was prepared by Hermes Agent acting for GitHub user `leno23`.

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [ ] I have manually executed end-to-end testing (E2E) with the affected databases/engines
