### PR TITLE
fix: expand hash/concat wildcards in YAML validation path

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -451,6 +451,23 @@ def build_config_managers_from_yaml(args, config_file_path):
             config, source_client, target_client, verbose=args.verbose
         )
         config_manager.config[consts.CONFIG_FILE] = config_file_path
+
+        # Expand hash/concat wildcards for hand-authored YAML configs.
+        # The CLI path calls _get_calculated_config() which expands `hash: '*'` into
+        # per-column calculated_fields entries. The YAML path skips that step, leaving
+        # the literal '*' in place and causing a downstream reduce() on an empty list.
+        # Guard on calculated_fields being empty so regenerated YAML (which already
+        # contains materialized fields) is not double-expanded.
+        is_row_validation = config_manager.validation_type == consts.ROW_VALIDATION
+        is_custom_row = (
+            config_manager.validation_type == consts.CUSTOM_QUERY
+            and config_manager.custom_query_type == consts.ROW_VALIDATION.lower()
+        )
+        if (is_row_validation or is_custom_row) and not config_manager.calculated_fields:
+            config_manager.append_calculated_fields(
+                _get_calculated_config(args, config_manager)
+            )
+
         config_managers.append(config_manager)
 
     return config_managers

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -605,3 +605,59 @@ def test_successful_generate_partitions_with_mocked_partition_builder(
 )
 def test_successful_deploy_with_mocked_app_run(mock_args, mock_run):
     main.main()
+
+
+# Regression test for https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1743
+# YAML configs with `hash: '*'` crashed because build_config_managers_from_yaml() never
+# called _get_calculated_config(), leaving the wildcard unexpanded.
+ROW_YAML_HASH_WILDCARD_CONFIG = {
+    consts.CONFIG_TYPE: consts.ROW_VALIDATION,
+    consts.CONFIG_SCHEMA_NAME: "my_schema",
+    consts.CONFIG_TABLE_NAME: "my_table",
+    consts.CONFIG_PRIMARY_KEYS: [],
+    consts.CONFIG_ROW_HASH: "*",
+}
+
+ROW_YAML_VALIDATIONS = {
+    consts.YAML_SOURCE: "my_source",
+    consts.YAML_TARGET: "my_target",
+    consts.YAML_RESULT_HANDLER: None,
+    consts.YAML_VALIDATIONS: [ROW_YAML_HASH_WILDCARD_CONFIG],
+}
+
+
+DUMMY_CALCULATED_FIELD = {"name": "hash__all", "calc_type": "hash"}
+
+
+@mock.patch("data_validation.clients.get_data_client", return_value=MockIbisClient())
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    return_value=TEST_CONN,
+)
+@mock.patch(
+    "data_validation.cli_tools.get_validation",
+    return_value=ROW_YAML_VALIDATIONS,
+)
+@mock.patch(
+    "data_validation.__main__._get_calculated_config",
+    return_value=[DUMMY_CALCULATED_FIELD],
+)
+def test_build_config_managers_from_yaml_expands_hash_wildcard(
+    mock_calc, mock_get_validation, mock_get_conn, mock_get_client
+):
+    """build_config_managers_from_yaml must call _get_calculated_config for hash: '*'.
+
+    Before the fix, the YAML path never called _get_calculated_config(), so the
+    literal '*' was left unexpanded, causing a downstream crash when the validator
+    tried to reduce an empty list of fields.
+    """
+    args = argparse.Namespace(
+        config_dir=None,
+        verbose=False,
+    )
+    managers = main.build_config_managers_from_yaml(args, "dummy.yaml")
+    assert len(managers) == 1
+    mock_calc.assert_called_once()
+    assert managers[0].calculated_fields == [DUMMY_CALCULATED_FIELD], (
+        "calculated_fields must be populated after expanding hash: '*'"
+    )


### PR DESCRIPTION
## Summary

- `build_config_managers_from_yaml()` never called `_get_calculated_config()`, so a hand-authored YAML config with `hash: '*'` (or `concat: '*'`) left the literal `'*'` unexpanded
- Downstream code then tried to `reduce()` over an empty list and crashed
- Fix calls `_get_calculated_config()` for row and custom-query-row validations, gated on `calculated_fields` being empty to avoid double-expanding regenerated YAML that already has materialized fields

Fixes #1743

## Test plan

- [x] New unit test `test_build_config_managers_from_yaml_expands_hash_wildcard` added to `tests/unit/test__main.py`
- [x] Verifies `_get_calculated_config` is called exactly once and its result is appended to `calculated_fields`
- [x] Full `tests/unit/test__main.py` suite: 21/21 passing