### PR TITLE
fix: Fix extract epoch expression for Db2

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -309,9 +309,8 @@ def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
-    _setup_session_requirements(
-        session, extra_packages=["ibm-db-sa", "ibm-db<3.2.7"]
-    )
+    # TODO Remove dependency "ibm-db<3.2.7" below when working on issue-1591.
+    _setup_session_requirements(session, extra_packages=["ibm-db-sa", "ibm-db<3.2.7"])
 
     expected_env_vars = [
         "PROJECT_ID",

--- a/noxfile.py
+++ b/noxfile.py
@@ -309,9 +309,8 @@ def integration_db2(session):
     """Run DB2 integration tests.
     Ensure DB2 validation is running as expected.
     """
-    # TODO Remove dependency "ibm-db<3.2.7" below when working on issue-1591.
     _setup_session_requirements(
-        session, extra_packages=["ibm-db-sa<0.4.2", "ibm-db<3.2.7"]
+        session, extra_packages=["ibm-db-sa", "ibm-db<3.2.7"]
     )
 
     expected_env_vars = [

--- a/third_party/ibis/ibis_db2/registry.py
+++ b/third_party/ibis/ibis_db2/registry.py
@@ -69,6 +69,10 @@ def _extract(fmt: str):
     return translator
 
 
+def _extract_epoch(t, op):
+    return sa.cast(sa.extract("epoch", t.translate(op.arg)), sa.BIGINT)
+
+
 def _second(t, op):
     # extracting the second gives us the fractional part as well, so smash that
     # with a cast to SMALLINT
@@ -550,7 +554,7 @@ operation_registry.update(
         ops.ExtractDay: _extract("day"),
         ops.ExtractDayOfYear: _extract("doy"),
         ops.ExtractQuarter: _extract("quarter"),
-        ops.ExtractEpochSeconds: _extract("epoch"),
+        ops.ExtractEpochSeconds: _extract_epoch,
         ops.ExtractHour: _extract("hour"),
         ops.ExtractMinute: _extract("minute"),
         ops.ExtractSecond: _second,


### PR DESCRIPTION
## Description of changes
Fix numeric overflow in with `ibm-db-sa` >= 0.4.2. This allows us to remove the restriction from `noxfile.py`.

## Issues to be closed

Closes #1541

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


