### PR TITLE
fix: Handle Snowflake table locations for Ibis 7

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -241,6 +241,14 @@ def _split_bigquery_table_location(schema_name, database_name=None):
     return None, schema_name
 
 
+def _split_snowflake_table_location(schema_name, database_name=None):
+    if database_name:
+        return database_name, schema_name
+    if schema_name and "." in schema_name:
+        return schema_name.split(".", 1)
+    return None, schema_name
+
+
 def get_ibis_table(client, schema_name, table_name, database_name=None):
     """Return Ibis Table for Supplied Client.
 
@@ -251,6 +259,11 @@ def get_ibis_table(client, schema_name, table_name, database_name=None):
     """
     if client.name == "bigquery":
         database_name, schema_name = _split_bigquery_table_location(
+            schema_name, database_name
+        )
+        return client.table(table_name, database=database_name, schema=schema_name)
+    elif client.name == "snowflake":
+        database_name, schema_name = _split_snowflake_table_location(
             schema_name, database_name
         )
         return client.table(table_name, database=database_name, schema=schema_name)
@@ -287,13 +300,20 @@ def get_ibis_table_schema(
     table_name (str): Table name of table object
     database_name (str): Database name (generally default is used)
     """
-    if is_sqlalchemy_backend(client):
-        return client.table(table_name, schema=schema_name).schema()
-    elif client.name == "bigquery":
+    if client.name == "bigquery":
         database_name, schema_name = _split_bigquery_table_location(
             schema_name, database_name
         )
         return client.get_schema(table_name, schema=schema_name, database=database_name)
+    elif client.name == "snowflake":
+        database_name, schema_name = _split_snowflake_table_location(
+            schema_name, database_name
+        )
+        return client.table(
+            table_name, database=database_name, schema=schema_name
+        ).schema()
+    elif is_sqlalchemy_backend(client):
+        return client.table(table_name, schema=schema_name).schema()
     else:
         return client.get_schema(table_name, schema_name)
 

--- a/tests/unit/ibis_snowflake/test_datatypes.py
+++ b/tests/unit/ibis_snowflake/test_datatypes.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ibis.expr.datatypes as dt
+from ibis.backends.snowflake.datatypes import SnowflakeType
+from snowflake.sqlalchemy import BINARY, NUMBER
+
+import third_party.ibis.ibis_snowflake.datatypes  # noqa: F401
+
+
+def test_snowflake_number_maps_to_decimal():
+    dtype = SnowflakeType.to_ibis(NUMBER(10, 0), nullable=False)
+
+    assert isinstance(dtype, dt.Decimal)
+    assert dtype.precision == 10
+    assert dtype.scale == 0
+    assert not dtype.nullable
+
+
+def test_snowflake_binary_maps_to_binary():
+    dtype = SnowflakeType.to_ibis(BINARY(), nullable=False)
+
+    assert isinstance(dtype, dt.Binary)
+    assert not dtype.nullable

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -72,6 +72,23 @@ class RecordingBigQueryClient:
         return table_name, database, schema
 
 
+class RecordingSnowflakeTable:
+    def __init__(self, table_name, database=None, schema=None):
+        self.table_name = table_name
+        self.database = database
+        self.schema_name = schema
+
+    def schema(self):
+        return self.table_name, self.database, self.schema_name
+
+
+class RecordingSnowflakeClient:
+    name = "snowflake"
+
+    def table(self, table_name, database=None, schema=None):
+        return RecordingSnowflakeTable(table_name, database=database, schema=schema)
+
+
 def _create_table_file(table_path, data):
     """Write JSON data to given file."""
     with open(table_path, "w") as f:
@@ -138,6 +155,42 @@ def test_get_ibis_table_schema_uses_explicit_bigquery_database():
     )
 
     assert schema == (TABLE_NAME, "source-project", "source_dataset")
+
+
+def test_get_ibis_table_splits_snowflake_database_and_schema():
+    client = RecordingSnowflakeClient()
+
+    table = clients.get_ibis_table(client, "SOURCE_DATABASE.PUBLIC", TABLE_NAME)
+
+    assert table.schema() == (TABLE_NAME, "SOURCE_DATABASE", "PUBLIC")
+
+
+def test_get_ibis_table_uses_explicit_snowflake_database():
+    client = RecordingSnowflakeClient()
+
+    table = clients.get_ibis_table(
+        client, "PUBLIC", TABLE_NAME, database_name="SOURCE_DATABASE"
+    )
+
+    assert table.schema() == (TABLE_NAME, "SOURCE_DATABASE", "PUBLIC")
+
+
+def test_get_ibis_table_schema_splits_snowflake_database_and_schema():
+    client = RecordingSnowflakeClient()
+
+    schema = clients.get_ibis_table_schema(client, "SOURCE_DATABASE.PUBLIC", TABLE_NAME)
+
+    assert schema == (TABLE_NAME, "SOURCE_DATABASE", "PUBLIC")
+
+
+def test_get_ibis_table_schema_uses_explicit_snowflake_database():
+    client = RecordingSnowflakeClient()
+
+    schema = clients.get_ibis_table_schema(
+        client, "PUBLIC", TABLE_NAME, database_name="SOURCE_DATABASE"
+    )
+
+    assert schema == (TABLE_NAME, "SOURCE_DATABASE", "PUBLIC")
 
 
 def test_import_oracle_client():

--- a/third_party/ibis/ibis_snowflake/datatypes.py
+++ b/third_party/ibis/ibis_snowflake/datatypes.py
@@ -14,26 +14,31 @@
 from typing import Iterable, Tuple
 
 import ibis.expr.datatypes as dt
-import sqlalchemy as sa
 from ibis.backends.snowflake import Backend as SnowflakeBackend
-from ibis.backends.snowflake.datatypes import parse
+from ibis.backends.snowflake.datatypes import SnowflakeType
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.sqlalchemy import NUMBER, BINARY
-from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+orig_snowflake_to_ibis = SnowflakeType.to_ibis
 
 
-@dt.dtype.register(SnowflakeDialect, NUMBER)
-def sa_sf_numeric(_, satype, nullable=True):
-    return dt.Decimal(
-        precision=satype.precision or 38,
-        scale=satype.scale or 0,
+@classmethod
+def dvt_snowflake_to_ibis(cls, typ, nullable=True):
+    if isinstance(typ, NUMBER):
+        return dt.Decimal(
+            precision=typ.precision or 38,
+            scale=typ.scale or 0,
+            nullable=nullable,
+        )
+    elif isinstance(typ, BINARY):
+        return dt.Binary(nullable=nullable)
+    return orig_snowflake_to_ibis(
+        typ,
         nullable=nullable,
     )
 
 
-@dt.dtype.register(SnowflakeDialect, BINARY)
-def sa_sf_binary(_, satype, nullable=True):
-    return dt.Binary(nullable=nullable)
+SnowflakeType.to_ibis = dvt_snowflake_to_ibis
 
 
 def _metadata(self, query: str) -> Iterable[Tuple[str, dt.DataType]]:
@@ -46,7 +51,9 @@ def _metadata(self, query: str) -> Iterable[Tuple[str, dt.DataType]]:
         if type_code < 3 and precision is not None and scale is not None:
             typ = dt.Decimal(precision=precision, scale=scale, nullable=is_nullable)
         else:
-            typ = parse(FIELD_ID_TO_NAME[type_code]).copy(nullable=is_nullable)
+            typ = SnowflakeType.from_string(
+                FIELD_ID_TO_NAME[type_code], nullable=is_nullable
+            )
         yield name, typ
 
 


### PR DESCRIPTION
## Description of changes
Fix Snowflake table and schema lookup on the Ibis 7.1 modernization branch.

This change splits Snowflake `DATABASE.SCHEMA` table locations before calling Ibis so that the database and schema are passed as separate arguments. It also updates the Snowflake datatype patch for Ibis 7.1 by patching `SnowflakeType.to_ibis` directly instead of using the removed `dt.dtype.register` API.

The Snowflake metadata path now uses `SnowflakeType.from_string(..., nullable=...)`, and unit coverage was added for Snowflake table location handling and NUMBER/BINARY datatype conversion.

## Issues to be closed
N/A

## Testing
- `venv/bin/python -m pytest tests/unit/test_clients.py tests/unit/ibis_snowflake/test_datatypes.py -q`
- `venv/bin/python -m black --check data_validation/clients.py tests/unit/test_clients.py third_party/ibis/ibis_snowflake/datatypes.py tests/unit/ibis_snowflake/test_datatypes.py`
- `git diff --check origin/ibis-7.1-modernization..HEAD`
- `PROJECT_ID=tpu-research-cloud-490704 venv/bin/python -m pytest --collect-only tests/system/data_sources/test_snowflake.py -q`
- `venv/bin/python -m pytest tests/unit -q -k 'not string_to_epoch and not execute_epoch_seconds_new'`

Full `venv/bin/python -m pytest tests/unit -q` still has the existing epoch conversion failures that reproduce on `origin/ibis-7.1-modernization`; those failures are unrelated to this Snowflake change.

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [ ] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [ ] I have manually executed end-to-end testing (E2E) with the affected databases/engines
