### PR TITLE
fix: Use UTC for naive timestamp epoch conversion

### DIFF
--- a/tests/unit/ibis_addon/test_operations.py
+++ b/tests/unit/ibis_addon/test_operations.py
@@ -79,6 +79,18 @@ def test_format_raw_sql_expr(module_under_test):
             "1969-12-31 23:59:00",
             -60,
         ),
+        (
+            "1970-01-01T00:00:00Z",
+            0,
+        ),
+        (
+            "1970-01-01T01:00:00+01:00",
+            0,
+        ),
+        (
+            "1969-12-31T23:00:00-01:00",
+            0,
+        ),
     ],
 )
 def test_string_to_epoch(module_under_test, test_input: str, expected: int):

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -644,7 +644,10 @@ def string_to_epoch(ts: str) -> int:
             # Casting datetime64 to int64 uses the minimum possible int64 when it
             # encounters NaT. Simulating the same here for when auto cast fails.
             return NAT_INT64_MIN_IN_SECONDS
-        parsed_ts = dateutil.parser.isoparse(ts).astimezone(dateutil.tz.UTC)
+        parsed_ts = dateutil.parser.isoparse(ts)
+        if parsed_ts.tzinfo is None:
+            parsed_ts = parsed_ts.replace(tzinfo=datetime.timezone.utc)
+        parsed_ts = parsed_ts.astimezone(datetime.timezone.utc)
         return (
             parsed_ts - datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
         ).total_seconds()


### PR DESCRIPTION
## Description of changes
Fix epoch conversion for timezone-naive timestamp strings on the Ibis 7.1 modernization branch.

`string_to_epoch` previously parsed naive timestamp values and immediately called `astimezone`, which interpreted the timestamp in the local timezone before converting to UTC. This caused unit tests to return timezone-shifted epoch values. This change treats naive parsed timestamps as UTC before computing epoch seconds.

## Issues to be closed
N/A

## Testing
- `venv/bin/python -m pytest tests/unit/ibis_addon/test_operations.py -q`
- `venv/bin/python -m pytest tests/unit -q`
- `git diff --check origin/ibis-7.1-modernization..HEAD`

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [ ] I have manually executed end-to-end testing (E2E) with the affected databases/engines
