### PR TITLE
fix: Use UTC for naive timestamp epoch conversion

### DIFF
--- a/data_validation/util.py
+++ b/data_validation/util.py
@@ -18,7 +18,7 @@ import re
 import time
 import uuid
 
-from data_validation import clients, exceptions
+from data_validation import exceptions
 
 from typing import TYPE_CHECKING
 
@@ -76,6 +76,10 @@ def ibis_table_to_sql(ibis_table: "IbisTable", alchemy_client: "BaseBackend") ->
 
     We need the client in order to find the dialect, otherwise we end up with generic literals.
     """
+    # Import clients here because it is a heavy weight import for a utility module
+    # and we want to avoid circular imports since clients also (eventually) imports utils.
+    from data_validation import clients
+
     # If the backend uses sqlalchemy, we will need to request sqla to bind variables
     # for a non sqlalchemy backend, the parameters are already bound
     if alchemy_client and clients.is_sqlalchemy_backend(alchemy_client):

--- a/tests/unit/ibis_addon/test_operations.py
+++ b/tests/unit/ibis_addon/test_operations.py
@@ -80,6 +80,10 @@ def test_format_raw_sql_expr(module_under_test):
             -60,
         ),
         (
+            "1969-12-31 23:59:00Z",
+            -60,
+        ),
+        (
             "1970-01-01T00:00:00Z",
             0,
         ),

--- a/tests/unit/ibis_addon/test_operations.py
+++ b/tests/unit/ibis_addon/test_operations.py
@@ -79,6 +79,18 @@ def test_format_raw_sql_expr(module_under_test):
             "1969-12-31 23:59:00",
             -60,
         ),
+        (
+            "1970-01-01T00:00:00Z",
+            0,
+        ),
+        (
+            "1970-01-01T01:00:00+01:00",
+            0,
+        ),
+        (
+            "1969-12-31T23:00:00-01:00",
+            0,
+        ),
     ],
 )
 def test_string_to_epoch(module_under_test, test_input: str, expected: int):

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -381,7 +381,10 @@ def string_to_epoch(ts: str) -> int:
             # Casting datetime64 to int64 uses the minimum possible int64 when it
             # encounters NaT. Simulating the same here for when auto cast fails.
             return NAT_INT64_MIN_IN_SECONDS
-        parsed_ts = dateutil.parser.isoparse(ts).astimezone(dateutil.tz.UTC)
+        parsed_ts = dateutil.parser.isoparse(ts)
+        if parsed_ts.tzinfo is None:
+            parsed_ts = parsed_ts.replace(tzinfo=datetime.timezone.utc)
+        parsed_ts = parsed_ts.astimezone(datetime.timezone.utc)
         return (
             parsed_ts - datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
         ).total_seconds()


### PR DESCRIPTION
## Summary
- Treat timezone-naive parsed timestamp strings as UTC before epoch conversion.
- Add explicit timezone-aware string cases, including a pre-1970 UTC timestamp.
- Move the `data_validation.clients` import inside `ibis_table_to_sql()` to avoid import-cycle failures.

## Rationale
`datetime.astimezone()` interprets naive datetimes as local machine time, which makes epoch conversion depend on the host timezone. Existing tests already expect naive timestamp strings to use UTC epoch semantics.

The utility import change keeps `data_validation.util` lightweight at import time and avoids recursively importing `data_validation.clients` through backend modules before initialization is complete.

## Tests
- `venv-develop/bin/python -m pytest tests/unit/ibis_addon/test_operations.py -q`
- `venv-develop/bin/python -m pytest tests/unit -q`
- `venv-develop/bin/python -m black --check tests/unit/ibis_addon/test_operations.py`
- `git diff --check`