### PR TITLE
fix: Handle BigQuery table locations for Ibis 7

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -233,6 +233,14 @@ def is_oracle_client(client):
         return False
 
 
+def _split_bigquery_table_location(schema_name, database_name=None):
+    if database_name:
+        return database_name, schema_name
+    if schema_name and "." in schema_name:
+        return schema_name.split(".", 1)
+    return None, schema_name
+
+
 def get_ibis_table(client, schema_name, table_name, database_name=None):
     """Return Ibis Table for Supplied Client.
 
@@ -242,8 +250,9 @@ def get_ibis_table(client, schema_name, table_name, database_name=None):
     database_name (str): Database name (generally default is used)
     """
     if client.name == "bigquery":
-        if schema_name and "." in schema_name:
-            database_name, schema_name = schema_name.split(".", 1)
+        database_name, schema_name = _split_bigquery_table_location(
+            schema_name, database_name
+        )
         return client.table(table_name, database=database_name, schema=schema_name)
     elif client.name in [
         "oracle",
@@ -268,7 +277,9 @@ def get_ibis_query(client, query) -> "ir.Table":
     return iq
 
 
-def get_ibis_table_schema(client, schema_name: str, table_name: str) -> "sch.Schema":
+def get_ibis_table_schema(
+    client, schema_name: str, table_name: str, database_name=None
+) -> "sch.Schema":
     """Return Ibis Table Schema for Supplied Client.
 
     client (IbisClient): Client to use for table
@@ -279,9 +290,9 @@ def get_ibis_table_schema(client, schema_name: str, table_name: str) -> "sch.Sch
     if is_sqlalchemy_backend(client):
         return client.table(table_name, schema=schema_name).schema()
     elif client.name == "bigquery":
-        database_name = None
-        if schema_name and "." in schema_name:
-            database_name, schema_name = schema_name.split(".", 1)
+        database_name, schema_name = _split_bigquery_table_location(
+            schema_name, database_name
+        )
         return client.get_schema(table_name, schema=schema_name, database=database_name)
     else:
         return client.get_schema(table_name, schema_name)

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -62,6 +62,16 @@ ORACLE_CONN_CONFIG = {
 }
 
 
+class RecordingBigQueryClient:
+    name = "bigquery"
+
+    def table(self, table_name, database=None, schema=None):
+        return table_name, database, schema
+
+    def get_schema(self, table_name, database=None, schema=None):
+        return table_name, database, schema
+
+
 def _create_table_file(table_path, data):
     """Write JSON data to given file."""
     with open(table_path, "w") as f:
@@ -90,6 +100,44 @@ def test_get_bigquery_client_sets_user_agent():
     )
     user_agent = ibis_client.client._connection._client_info.to_user_agent()
     assert "google-pso-tool/data-validator" in user_agent
+
+
+def test_get_ibis_table_splits_bigquery_project_and_dataset():
+    client = RecordingBigQueryClient()
+
+    table = clients.get_ibis_table(client, "source-project.source_dataset", TABLE_NAME)
+
+    assert table == (TABLE_NAME, "source-project", "source_dataset")
+
+
+def test_get_ibis_table_uses_explicit_bigquery_database():
+    client = RecordingBigQueryClient()
+
+    table = clients.get_ibis_table(
+        client, "source_dataset", TABLE_NAME, database_name="source-project"
+    )
+
+    assert table == (TABLE_NAME, "source-project", "source_dataset")
+
+
+def test_get_ibis_table_schema_splits_bigquery_project_and_dataset():
+    client = RecordingBigQueryClient()
+
+    schema = clients.get_ibis_table_schema(
+        client, "source-project.source_dataset", TABLE_NAME
+    )
+
+    assert schema == (TABLE_NAME, "source-project", "source_dataset")
+
+
+def test_get_ibis_table_schema_uses_explicit_bigquery_database():
+    client = RecordingBigQueryClient()
+
+    schema = clients.get_ibis_table_schema(
+        client, "source_dataset", TABLE_NAME, database_name="source-project"
+    )
+
+    assert schema == (TABLE_NAME, "source-project", "source_dataset")
 
 
 def test_import_oracle_client():


### PR DESCRIPTION
## Description of changes
Handle BigQuery project and dataset locations consistently when building Ibis table and schema expressions.

Ibis 7.1 still accepts `database="project.dataset"` for BigQuery table lookup, but emits a deprecation warning when only `database` is supplied and asks callers to include `schema`. This keeps DVT's existing `project.dataset` schema-name form working while normalizing it to `database="project", schema="dataset"` before calling Ibis.

The helper is shared by table lookup and schema lookup. It also lets schema lookup accept an explicit `database_name`, matching the table lookup path.

## Issues to be closed
N/A

## Testing
- `venv/bin/python -m pytest tests/unit/test_clients.py -q`
- `venv/bin/python -m black --check data_validation/clients.py tests/unit/test_clients.py`
- `TZ=UTC venv/bin/python -m pytest tests/unit -q`
- `git diff --check upstream/ibis-7.1-modernization...HEAD`

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines