### PR TITLE
test: Parameterize filesystem GCS fixtures

### DIFF
--- a/tests/system/data_sources/test_filesystem.py
+++ b/tests/system/data_sources/test_filesystem.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest import mock
 
 
@@ -23,6 +24,10 @@ from data_validation import (
 from tests.system.data_sources.common_functions import (
     schema_validation_test,
 )
+
+TEST_BUCKET = os.getenv("TEST_BUCKET") or os.getenv("PROJECT_ID")
+FILE_CONNECTION_BUCKET = TEST_BUCKET or "pso-kokoro-resources"
+FILE_CONNECTION_PREFIX = f"gs://{FILE_CONNECTION_BUCKET}/file_connection"
 
 
 def mock_get_connection_config(*args):
@@ -41,28 +46,28 @@ def mock_get_connection_config(*args):
 CSV_CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_FILESYSTEM,
     "table_name": "entries",
-    "file_path": "gs://pso-kokoro-resources/file_connection/csv/entries.csv",
+    "file_path": f"{FILE_CONNECTION_PREFIX}/csv/entries.csv",
     "file_type": "csv",
 }
 
 JSON_CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_FILESYSTEM,
     "table_name": "entries",
-    "file_path": "gs://pso-kokoro-resources/file_connection/json/entries.json",
+    "file_path": f"{FILE_CONNECTION_PREFIX}/json/entries.json",
     "file_type": "json",
 }
 
 ORC_CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_FILESYSTEM,
     "table_name": "entries",
-    "file_path": "gs://pso-kokoro-resources/file_connection/orc/entries.orc",
+    "file_path": f"{FILE_CONNECTION_PREFIX}/orc/entries.orc",
     "file_type": "orc",
 }
 
 PARQUET_CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_FILESYSTEM,
     "table_name": "entries",
-    "file_path": "gs://pso-kokoro-resources/file_connection/parquet/entries.parquet",
+    "file_path": f"{FILE_CONNECTION_PREFIX}/parquet/entries.parquet",
     "file_type": "parquet",
 }
 


### PR DESCRIPTION
## Description of changes
Parameterize the filesystem system-test GCS fixture paths.

The filesystem data-source tests still default to `gs://pso-kokoro-resources/file_connection`, so Kokoro can keep using the existing fixture bucket. Local and alternate validation environments can now point the same tests at a bucket by setting `TEST_BUCKET`, or fall back to `PROJECT_ID` when the project id matches the test bucket name.

This keeps the test fixture layout unchanged while avoiding hard-coded access to the Kokoro bucket for local Ibis 7.1 validation.

## Issues to be closed
N/A

## Testing
- `venv/bin/python -m black --check tests/system/data_sources/test_filesystem.py`
- `PROJECT_ID=<test-bucket-project> venv/bin/python -m pytest tests/system/data_sources/test_filesystem.py -q`
- `TZ=UTC venv/bin/python -m pytest tests/unit -q`
- `git diff --check upstream/ibis-7.1-modernization...HEAD`

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [ ] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [ ] I have manually executed end-to-end testing (E2E) with the affected databases/engines
