### PR TITLE
test: Add Ibis 7 compiler matrix coverage

### DIFF
--- a/tests/unit/ibis_addon/test_compiler_matrix.py
+++ b/tests/unit/ibis_addon/test_compiler_matrix.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.metadata
+
 import ibis
 import pytest
 from ibis.backends.bigquery.compiler import BigQueryCompiler
@@ -22,7 +24,24 @@ from ibis.backends.postgres.compiler import PostgreSQLCompiler
 
 # Import required in order to register DVT operations.
 import third_party.ibis.ibis_addon.operations  # noqa: F401
+from third_party.ibis.ibis_cloud_spanner.compiler import SpannerCompiler
 from third_party.ibis.ibis_redshift.compiler import RedshiftCompiler
+
+try:
+    from ibis.backends.snowflake import SnowflakeCompiler
+except (ImportError, importlib.metadata.PackageNotFoundError) as exc:
+    SnowflakeCompiler = None
+    SNOWFLAKE_SKIP_REASON = f"Snowflake compiler unavailable: {exc}"
+else:
+    SNOWFLAKE_SKIP_REASON = ""
+
+try:
+    from third_party.ibis.ibis_teradata.compiler import TeradataCompiler
+except ImportError as exc:
+    TeradataCompiler = None
+    TERADATA_SKIP_REASON = f"Teradata compiler unavailable: {exc}"
+else:
+    TERADATA_SKIP_REASON = ""
 
 try:
     from third_party.ibis.ibis_oracle.compiler import OracleCompiler
@@ -47,115 +66,157 @@ def _compile(compiler_class, expr):
     return str(compiler_class().to_sql(expr))
 
 
-COMPILER_CASES = [
+def _assert_fragments(sql, expected_fragments, unexpected_fragments):
+    for fragment in expected_fragments:
+        assert fragment in sql
+    for fragment in unexpected_fragments:
+        assert fragment not in sql
+
+
+HASHBYTES_COMPILER_CASES = [
     pytest.param(
         BigQueryCompiler,
-        lambda: TABLE.s.hashbytes().name("h"),
         ["TO_HEX(SHA256(t0.`s`))"],
         [],
-        id="bigquery-hashbytes",
-    ),
-    pytest.param(
-        BigQueryCompiler,
-        lambda: TABLE.b.byte_length().name("len"),
-        ["LENGTH(t0.`b`)"],
-        [],
-        id="bigquery-binary-length",
-    ),
-    pytest.param(
-        BigQueryCompiler,
-        lambda: TABLE.ts.epoch_seconds().name("epoch"),
-        ["UNIX_SECONDS(CAST(t0.`ts` AS TIMESTAMP))"],
-        [],
-        id="bigquery-epoch",
+        id="bigquery",
     ),
     pytest.param(
         PostgreSQLCompiler,
-        lambda: TABLE.s.hashbytes().name("h"),
         ["encode(sha256(convert_to(t0.s, 'UTF8')), 'hex')"],
         [],
-        id="postgres-hashbytes",
-    ),
-    pytest.param(
-        PostgreSQLCompiler,
-        lambda: TABLE.d.cast("string").name("dstr"),
-        ["rtrim(to_char(t0.d"],
-        [],
-        id="postgres-decimal-string",
+        id="postgres",
     ),
     pytest.param(
         MySQLCompiler,
-        lambda: TABLE.s.hashbytes().name("h"),
         ["sha2(t0.s, '256')"],
         [],
-        id="mysql-hashbytes",
-    ),
-    pytest.param(
-        MySQLCompiler,
-        lambda: TABLE.b.byte_length().name("len"),
-        ["length(t0.b)"],
-        [],
-        id="mysql-binary-length",
+        id="mysql",
     ),
     pytest.param(
         MsSqlCompiler,
-        lambda: TABLE.s.hashbytes().name("h"),
         ["hashbytes('SHA2_256'", "convert(VARCHAR(MAX), t0.s)"],
         [],
-        id="mssql-hashbytes",
-    ),
-    pytest.param(
-        MsSqlCompiler,
-        lambda: TABLE.b.byte_length().name("len"),
-        ["datalength(t0.b)"],
-        [],
-        id="mssql-binary-length",
+        id="mssql",
     ),
     pytest.param(
         ImpalaCompiler,
-        lambda: TABLE.s.hashbytes().name("h"),
         ["sha2(t0.`s`, 256)"],
         [],
-        id="impala-hashbytes",
-    ),
-    pytest.param(
-        ImpalaCompiler,
-        lambda: TABLE.b.byte_length().name("len"),
-        ["length(t0.`b`)"],
-        [":length"],
-        id="impala-binary-length",
+        id="impala",
     ),
     pytest.param(
         RedshiftCompiler,
-        lambda: TABLE.s.hashbytes().name("h"),
         ["sha2(t0.s, 256)"],
         [],
-        id="redshift-hashbytes",
+        id="redshift",
     ),
     pytest.param(
-        RedshiftCompiler,
-        lambda: TABLE.b.byte_length().name("len"),
-        ["length(t0.b)"],
+        SpannerCompiler,
+        ["TO_HEX(SHA256(t0.`s`))"],
         [],
-        id="redshift-binary-length",
+        id="spanner",
+    ),
+    pytest.param(
+        SnowflakeCompiler,
+        ['sha2(t0."s")'],
+        [],
+        id="snowflake",
+        marks=pytest.mark.skipif(
+            SnowflakeCompiler is None,
+            reason=SNOWFLAKE_SKIP_REASON,
+        ),
+    ),
+    pytest.param(
+        TeradataCompiler,
+        ['rtrim(hash_sha256(TransUnicodeToUTF8(t0."s")))'],
+        [],
+        id="teradata",
+        marks=pytest.mark.skipif(
+            TeradataCompiler is None,
+            reason=TERADATA_SKIP_REASON,
+        ),
     ),
     pytest.param(
         OracleCompiler,
-        lambda: TABLE.s.hashbytes().name("h"),
         ["standard_hash(convert(t0.s, 'UTF8'), 'SHA256')"],
         [],
-        id="oracle-hashbytes",
+        id="oracle",
         marks=pytest.mark.skipif(
             OracleCompiler is None,
             reason=ORACLE_SKIP_REASON,
         ),
     ),
+]
+
+
+BINARY_LENGTH_COMPILER_CASES = [
+    pytest.param(
+        BigQueryCompiler,
+        ["LENGTH(t0.`b`)"],
+        [],
+        id="bigquery",
+    ),
+    pytest.param(
+        PostgreSQLCompiler,
+        ["length(t0.b)"],
+        [],
+        id="postgres",
+    ),
+    pytest.param(
+        MySQLCompiler,
+        ["length(t0.b)"],
+        [],
+        id="mysql",
+    ),
+    pytest.param(
+        MsSqlCompiler,
+        ["datalength(t0.b)"],
+        [],
+        id="mssql",
+    ),
+    pytest.param(
+        ImpalaCompiler,
+        ["length(t0.`b`)"],
+        [":length"],
+        id="impala",
+    ),
+    pytest.param(
+        RedshiftCompiler,
+        ["length(t0.b)"],
+        [],
+        id="redshift",
+    ),
+    pytest.param(
+        SpannerCompiler,
+        ["length(t0.`b`)"],
+        [":length"],
+        id="spanner",
+    ),
+    pytest.param(
+        SnowflakeCompiler,
+        ['length(t0."b")'],
+        [],
+        id="snowflake",
+        marks=pytest.mark.skipif(
+            SnowflakeCompiler is None,
+            reason=SNOWFLAKE_SKIP_REASON,
+        ),
+    ),
+    pytest.param(
+        TeradataCompiler,
+        ['length(t0."b")'],
+        [":length"],
+        id="teradata",
+        marks=pytest.mark.skipif(
+            TeradataCompiler is None,
+            reason=TERADATA_SKIP_REASON,
+        ),
+    ),
     pytest.param(
         OracleCompiler,
-        lambda: TABLE.b.byte_length().name("len"),
         ["dbms_lob.getlength(t0.b)"],
         [],
-        id="oracle-binary-length",
+        id="oracle",
         marks=pytest.mark.skipif(
             OracleCompiler is None,
             reason=ORACLE_SKIP_REASON,
@@ -165,15 +226,36 @@ COMPILER_CASES = [
 
 
 @pytest.mark.parametrize(
-    "compiler_class,expr_factory,expected_fragments,unexpected_fragments",
-    COMPILER_CASES,
+    "compiler_class,expected_fragments,unexpected_fragments",
+    HASHBYTES_COMPILER_CASES,
 )
-def test_backend_compiler_matrix(
-    compiler_class, expr_factory, expected_fragments, unexpected_fragments
+def test_hashbytes_compiler_matrix(
+    compiler_class, expected_fragments, unexpected_fragments
 ):
-    sql = _compile(compiler_class, expr_factory())
+    sql = _compile(compiler_class, TABLE.s.hashbytes().name("h"))
 
-    for fragment in expected_fragments:
-        assert fragment in sql
-    for fragment in unexpected_fragments:
-        assert fragment not in sql
+    _assert_fragments(sql, expected_fragments, unexpected_fragments)
+
+
+@pytest.mark.parametrize(
+    "compiler_class,expected_fragments,unexpected_fragments",
+    BINARY_LENGTH_COMPILER_CASES,
+)
+def test_binary_length_compiler_matrix(
+    compiler_class, expected_fragments, unexpected_fragments
+):
+    sql = _compile(compiler_class, TABLE.b.byte_length().name("len"))
+
+    _assert_fragments(sql, expected_fragments, unexpected_fragments)
+
+
+def test_bigquery_epoch_seconds_compiles_timestamp_cast():
+    sql = _compile(BigQueryCompiler, TABLE.ts.epoch_seconds().name("epoch"))
+
+    assert "UNIX_SECONDS(CAST(t0.`ts` AS TIMESTAMP))" in sql
+
+
+def test_postgres_decimal_string_cast_compiles_to_char():
+    sql = _compile(PostgreSQLCompiler, TABLE.d.cast("string").name("dstr"))
+
+    assert "rtrim(to_char(t0.d, :to_char_1), :rtrim_1)" in sql

--- a/tests/unit/ibis_addon/test_compiler_matrix.py
+++ b/tests/unit/ibis_addon/test_compiler_matrix.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ibis
+import pytest
+from ibis.backends.bigquery.compiler import BigQueryCompiler
+from ibis.backends.impala.compiler import ImpalaCompiler
+from ibis.backends.mssql.compiler import MsSqlCompiler
+from ibis.backends.mysql.compiler import MySQLCompiler
+from ibis.backends.postgres.compiler import PostgreSQLCompiler
+
+# Import required in order to register DVT operations.
+import third_party.ibis.ibis_addon.operations  # noqa: F401
+from third_party.ibis.ibis_redshift.compiler import RedshiftCompiler
+
+try:
+    from third_party.ibis.ibis_oracle.compiler import OracleCompiler
+except ModuleNotFoundError as exc:
+    OracleCompiler = None
+    ORACLE_SKIP_REASON = f"Oracle compiler unavailable: missing {exc.name}"
+else:
+    ORACLE_SKIP_REASON = ""
+
+TABLE = ibis.table(
+    {
+        "s": "string",
+        "b": "binary",
+        "d": "decimal(10, 2)",
+        "ts": "timestamp",
+    },
+    name="t",
+)
+
+
+def _compile(compiler_class, expr):
+    return str(compiler_class().to_sql(expr))
+
+
+COMPILER_CASES = [
+    pytest.param(
+        BigQueryCompiler,
+        lambda: TABLE.s.hashbytes().name("h"),
+        ["TO_HEX(SHA256(t0.`s`))"],
+        [],
+        id="bigquery-hashbytes",
+    ),
+    pytest.param(
+        BigQueryCompiler,
+        lambda: TABLE.b.byte_length().name("len"),
+        ["LENGTH(t0.`b`)"],
+        [],
+        id="bigquery-binary-length",
+    ),
+    pytest.param(
+        BigQueryCompiler,
+        lambda: TABLE.ts.epoch_seconds().name("epoch"),
+        ["UNIX_SECONDS(CAST(t0.`ts` AS TIMESTAMP))"],
+        [],
+        id="bigquery-epoch",
+    ),
+    pytest.param(
+        PostgreSQLCompiler,
+        lambda: TABLE.s.hashbytes().name("h"),
+        ["encode(sha256(convert_to(t0.s, 'UTF8')), 'hex')"],
+        [],
+        id="postgres-hashbytes",
+    ),
+    pytest.param(
+        PostgreSQLCompiler,
+        lambda: TABLE.d.cast("string").name("dstr"),
+        ["rtrim(to_char(t0.d"],
+        [],
+        id="postgres-decimal-string",
+    ),
+    pytest.param(
+        MySQLCompiler,
+        lambda: TABLE.s.hashbytes().name("h"),
+        ["sha2(t0.s, '256')"],
+        [],
+        id="mysql-hashbytes",
+    ),
+    pytest.param(
+        MySQLCompiler,
+        lambda: TABLE.b.byte_length().name("len"),
+        ["length(t0.b)"],
+        [],
+        id="mysql-binary-length",
+    ),
+    pytest.param(
+        MsSqlCompiler,
+        lambda: TABLE.s.hashbytes().name("h"),
+        ["hashbytes('SHA2_256'", "convert(VARCHAR(MAX), t0.s)"],
+        [],
+        id="mssql-hashbytes",
+    ),
+    pytest.param(
+        MsSqlCompiler,
+        lambda: TABLE.b.byte_length().name("len"),
+        ["datalength(t0.b)"],
+        [],
+        id="mssql-binary-length",
+    ),
+    pytest.param(
+        ImpalaCompiler,
+        lambda: TABLE.s.hashbytes().name("h"),
+        ["sha2(t0.`s`, 256)"],
+        [],
+        id="impala-hashbytes",
+    ),
+    pytest.param(
+        ImpalaCompiler,
+        lambda: TABLE.b.byte_length().name("len"),
+        ["length(t0.`b`)"],
+        [":length"],
+        id="impala-binary-length",
+    ),
+    pytest.param(
+        RedshiftCompiler,
+        lambda: TABLE.s.hashbytes().name("h"),
+        ["sha2(t0.s, 256)"],
+        [],
+        id="redshift-hashbytes",
+    ),
+    pytest.param(
+        RedshiftCompiler,
+        lambda: TABLE.b.byte_length().name("len"),
+        ["length(t0.b)"],
+        [],
+        id="redshift-binary-length",
+    ),
+    pytest.param(
+        OracleCompiler,
+        lambda: TABLE.s.hashbytes().name("h"),
+        ["standard_hash(convert(t0.s, 'UTF8'), 'SHA256')"],
+        [],
+        id="oracle-hashbytes",
+        marks=pytest.mark.skipif(
+            OracleCompiler is None,
+            reason=ORACLE_SKIP_REASON,
+        ),
+    ),
+    pytest.param(
+        OracleCompiler,
+        lambda: TABLE.b.byte_length().name("len"),
+        ["dbms_lob.getlength(t0.b)"],
+        [],
+        id="oracle-binary-length",
+        marks=pytest.mark.skipif(
+            OracleCompiler is None,
+            reason=ORACLE_SKIP_REASON,
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "compiler_class,expr_factory,expected_fragments,unexpected_fragments",
+    COMPILER_CASES,
+)
+def test_backend_compiler_matrix(
+    compiler_class, expr_factory, expected_fragments, unexpected_fragments
+):
+    sql = _compile(compiler_class, expr_factory())
+
+    for fragment in expected_fragments:
+        assert fragment in sql
+    for fragment in unexpected_fragments:
+        assert fragment not in sql

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -716,7 +716,7 @@ ImpalaExprTranslator._registry[RawSQL] = format_raw_sql
 ImpalaExprTranslator._registry[ops.HashBytes] = impala_sa_format_hashbytes
 ImpalaExprTranslator._registry[ops.RandomScalar] = fixed_arity("RAND", 0)
 ImpalaExprTranslator._registry[ops.Strftime] = impala_sa_strftime
-ImpalaExprTranslator._registry[BinaryLength] = sa_format_binary_length
+ImpalaExprTranslator._registry[BinaryLength] = fixed_arity("length", 1)
 
 if OracleExprTranslator:
     OracleExprTranslator._registry[RawSQL] = sa_format_raw_sql

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -784,12 +784,12 @@ if Db2zOSExprTranslator:
 
 SpannerExprTranslator._registry[RawSQL] = format_raw_sql
 SpannerExprTranslator._registry[ops.HashBytes] = bigquery_format_hashbytes
-SpannerExprTranslator._registry[BinaryLength] = sa_format_binary_length
+SpannerExprTranslator._registry[BinaryLength] = fixed_arity("length", 1)
 
 if TeradataExprTranslator:
     TeradataExprTranslator._registry[RawSQL] = format_raw_sql
     TeradataExprTranslator._registry[ops.HashBytes] = format_hashbytes_teradata
-    TeradataExprTranslator._registry[BinaryLength] = sa_format_binary_length
+    TeradataExprTranslator._registry[BinaryLength] = fixed_arity("length", 1)
     TeradataExprTranslator._registry[PaddedCharLength] = (
         TeradataExprTranslator._registry[ops.StringLength]
     )


### PR DESCRIPTION
## Description of changes
Add regression coverage for DVT's local Ibis addon layer under Ibis 7.1.

DVT uses custom Ibis operations for validation-specific expressions such as row hashing, binary length, decimal-to-string formatting, and timestamp epoch conversion. These operations are registered with backend-specific SQL compilers, so the same DVT expression compiles differently for BigQuery, PostgreSQL, MySQL, SQL Server, Impala, Redshift, and Oracle.

The new compiler matrix verifies those custom operations still compile to the expected backend SQL fragments after the Ibis 7.1 migration. Oracle cases run when the Oracle compiler dependency is available.

This also fixes the Impala `BinaryLength` registration to compile as `length(<expr>)` instead of using the SQLAlchemy generic function path that produced a bound function name.

## Issues to be closed
N/A

## Testing
- `venv/bin/python -m pytest tests/unit/ibis_addon/test_compiler_matrix.py -q`
- `TZ=UTC venv/bin/python -m pytest tests/unit/ibis_addon -q`
- `TZ=UTC venv/bin/python -m pytest tests/unit -q`
- `venv/bin/python -m black --check tests/unit/ibis_addon/test_compiler_matrix.py third_party/ibis/ibis_addon/operations.py`
- `git diff --check upstream/ibis-7.1-modernization...HEAD`

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [ ] I have manually executed end-to-end testing (E2E) with the affected databases/engines
