### PR TITLE
fix: Handle Spanner schema lookup for Ibis 7

### DIFF
--- a/data_validation/clients.py
+++ b/data_validation/clients.py
@@ -254,6 +254,8 @@ def get_ibis_table(client, schema_name, table_name, database_name=None):
             schema_name, database_name
         )
         return client.table(table_name, database=database_name, schema=schema_name)
+    elif client.name == "spanner":
+        return client.table(table_name)
     elif client.name in [
         "oracle",
         "postgres",
@@ -294,6 +296,8 @@ def get_ibis_table_schema(
             schema_name, database_name
         )
         return client.get_schema(table_name, schema=schema_name, database=database_name)
+    elif client.name == "spanner":
+        return client.get_schema(table_name)
     else:
         return client.get_schema(table_name, schema_name)
 

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -72,6 +72,16 @@ class RecordingBigQueryClient:
         return table_name, database, schema
 
 
+class RecordingSpannerClient:
+    name = "spanner"
+
+    def table(self, table_name):
+        return table_name
+
+    def get_schema(self, table_name):
+        return table_name
+
+
 def _create_table_file(table_path, data):
     """Write JSON data to given file."""
     with open(table_path, "w") as f:
@@ -138,6 +148,22 @@ def test_get_ibis_table_schema_uses_explicit_bigquery_database():
     )
 
     assert schema == (TABLE_NAME, "source-project", "source_dataset")
+
+
+def test_get_ibis_table_ignores_spanner_schema():
+    client = RecordingSpannerClient()
+
+    table = clients.get_ibis_table(client, "ignored_schema", TABLE_NAME)
+
+    assert table == TABLE_NAME
+
+
+def test_get_ibis_table_schema_ignores_spanner_schema():
+    client = RecordingSpannerClient()
+
+    schema = clients.get_ibis_table_schema(client, "ignored_schema", TABLE_NAME)
+
+    assert schema == TABLE_NAME
 
 
 def test_import_oracle_client():

--- a/tests/unit/test_schema_validation.py
+++ b/tests/unit/test_schema_validation.py
@@ -232,6 +232,10 @@ def test_expand_precision_or_scale_range(test_input: str, expected: list):
             "date:timestamp('UTC'),timestamp('UTC'):timestamp",
             {"date": ["timestamp('UTC')"], "timestamp('UTC')": ["timestamp"]},
         ),
+        (
+            "timestamp('UTC', 7):timestamp('UTC')",
+            {"timestamp('UTC',7)": ["timestamp('UTC')"]},
+        ),
         ("decimal(38 , 0):decimal ( 38 , 0)", {"decimal(38,0)": ["decimal(38,0)"]}),
         (
             "decimal(38,0):!int32",

--- a/third_party/ibis/ibis_cloud_spanner/__init__.py
+++ b/third_party/ibis/ibis_cloud_spanner/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Any, Mapping, Optional, Tuple
 
 from google.api_core import client_options
@@ -161,8 +162,6 @@ class Backend(BaseSQLBackend):
         query_ast = self.compiler.to_ast_ensure_limit(expr, limit, params=params)
         sql = query_ast.compile()
         self._log(sql)
-
-        schema = expr.as_table().schema()
 
         self._register_in_memory_tables(expr)
         db = self.instance.database(self.dataset_id)


### PR DESCRIPTION
## Summary

- route Cloud Spanner table and schema lookup through Spanner backend methods without passing DVT `schema_name`
- avoid treating DVT schema values as Spanner database names; Spanner should use the database configured on the connection
- restore the Spanner backend `re` import and remove an unused schema extraction in the execute path
- add unit coverage for Spanner schema handling and timestamp precision equivalence parsing

## Tests

- `venv/bin/python -m pytest tests/unit/test_clients.py tests/unit/test_schema_validation.py -q`
- `TZ=UTC venv/bin/python -m pytest tests/unit -q`
