### PR TITLE
fix: Support Redshift reflection under Ibis 7

### DIFF
--- a/tests/unit/ibis_redshift/test_init.py
+++ b/tests/unit/ibis_redshift/test_init.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import registry
+from sqlalchemy.engine.reflection import ReflectionDefaults
+
+from third_party.ibis import ibis_redshift
+
+
+def test_redshift_dialect_registered_for_psycopg2():
+    assert registry.load("redshift.psycopg2") is ibis_redshift.RedshiftPsycopg2Dialect
+
+
+def test_sqlalchemy_engine_loads_redshift_dialect():
+    engine = sa.create_engine("redshift+psycopg2://user:pass@example.com:5439/dev")
+
+    assert isinstance(engine.dialect, ibis_redshift.RedshiftPsycopg2Dialect)
+
+
+def test_redshift_dialect_skips_unsupported_postgres_reflection():
+    dialect = ibis_redshift.RedshiftPsycopg2Dialect()
+
+    dialect._set_backslash_escapes(None)
+
+    assert dialect._backslash_escapes is False
+    assert dialect.supports_native_enum is False
+    assert dialect._load_domains(None) == []
+    assert dialect.get_multi_pk_constraint(
+        None, "analytics", ["orders"], None, None
+    ) == [(("analytics", "orders"), ReflectionDefaults.pk_constraint())]
+    assert dialect.get_multi_foreign_keys(
+        None, "analytics", ["orders"], None, None
+    ) == [(("analytics", "orders"), ReflectionDefaults.foreign_keys())]
+    assert dialect.get_multi_indexes(None, "analytics", ["orders"], None, None) == [
+        (("analytics", "orders"), ReflectionDefaults.indexes())
+    ]
+    assert dialect.get_multi_unique_constraints(
+        None, "analytics", ["orders"], None, None
+    ) == [(("analytics", "orders"), ReflectionDefaults.unique_constraints())]
+    assert dialect.get_multi_check_constraints(
+        None, "analytics", ["orders"], None, None
+    ) == [(("analytics", "orders"), ReflectionDefaults.check_constraints())]
+
+
+@mock.patch("third_party.ibis.ibis_redshift.BaseAlchemyBackend.do_connect")
+@mock.patch("third_party.ibis.ibis_redshift.sa.event.listens_for")
+@mock.patch("third_party.ibis.ibis_redshift.sa.create_engine")
+def test_do_connect_uses_redshift_sqlalchemy_dialect(
+    mock_create_engine, mock_listens_for, mock_base_do_connect
+):
+    engine = mock.Mock()
+    mock_create_engine.return_value = engine
+    mock_listens_for.side_effect = lambda *args, **kwargs: lambda fn: fn
+
+    backend = ibis_redshift.Backend()
+    backend.do_connect(
+        host="redshift.example.com",
+        port=5439,
+        database="dev",
+        user="admin",
+        password="password",
+        schema="analytics",
+    )
+
+    alchemy_url = mock_create_engine.call_args.args[0]
+    create_engine_kwargs = mock_create_engine.call_args.kwargs
+
+    assert alchemy_url.drivername == "redshift+psycopg2"
+    assert alchemy_url.host == "redshift.example.com"
+    assert alchemy_url.port == 5439
+    assert alchemy_url.database == "dev"
+    assert alchemy_url.username == "admin"
+    assert create_engine_kwargs["connect_args"] == {
+        "options": "-csearch_path=analytics"
+    }
+    assert create_engine_kwargs["execution_options"] == {
+        "isolation_level": "AUTOCOMMIT"
+    }
+    mock_base_do_connect.assert_called_once_with(engine)

--- a/third_party/ibis/ibis_redshift/__init__.py
+++ b/third_party/ibis/ibis_redshift/__init__.py
@@ -16,10 +16,75 @@ import sqlalchemy as sa
 import ibis.expr.datatypes as dt
 from typing import Iterable, Literal, Tuple
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
+from sqlalchemy.dialects import registry
+from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
+from sqlalchemy.engine.reflection import ReflectionDefaults
 from third_party.ibis.ibis_redshift.compiler import RedshiftCompiler
 from ibis.backends.postgres.datatypes import PostgresType
 from third_party.ibis.ibis_addon.api import cache_generator_results
 from ibis import util
+
+
+class RedshiftPsycopg2Dialect(PGDialect_psycopg2):
+    name = "redshift"
+    supports_native_enum = False
+    supports_statement_cache = True
+
+    def _set_backslash_escapes(self, connection):
+        self._backslash_escapes = False
+
+    def _load_domains(self, connection, schema=None, **kw):
+        return []
+
+    def _empty_reflection(self, schema, filter_names, default):
+        if filter_names is None:
+            return []
+        return [((schema, table_name), default()) for table_name in filter_names]
+
+    def get_multi_pk_constraint(
+        self, connection, schema, filter_names, scope, kind, **kw
+    ):
+        return self._empty_reflection(
+            schema, filter_names, ReflectionDefaults.pk_constraint
+        )
+
+    def get_multi_foreign_keys(
+        self,
+        connection,
+        schema,
+        filter_names,
+        scope,
+        kind,
+        postgresql_ignore_search_path=False,
+        **kw,
+    ):
+        return self._empty_reflection(
+            schema, filter_names, ReflectionDefaults.foreign_keys
+        )
+
+    def get_multi_indexes(self, connection, schema, filter_names, scope, kind, **kw):
+        return self._empty_reflection(schema, filter_names, ReflectionDefaults.indexes)
+
+    def get_multi_unique_constraints(
+        self, connection, schema, filter_names, scope, kind, **kw
+    ):
+        return self._empty_reflection(
+            schema, filter_names, ReflectionDefaults.unique_constraints
+        )
+
+    def get_multi_check_constraints(
+        self, connection, schema, filter_names, scope, kind, **kw
+    ):
+        return self._empty_reflection(
+            schema, filter_names, ReflectionDefaults.check_constraints
+        )
+
+
+registry.register(
+    "redshift.psycopg2",
+    "third_party.ibis.ibis_redshift",
+    "RedshiftPsycopg2Dialect",
+)
 
 
 class Backend(BaseAlchemyBackend):
@@ -48,7 +113,7 @@ class Backend(BaseAlchemyBackend):
             user=user,
             password=password,
             database=database,
-            driver=f"postgresql+{driver}",
+            driver=f"redshift+{driver}",
         )
         self.database_name = alchemy_url.database
 
@@ -88,8 +153,8 @@ class Backend(BaseAlchemyBackend):
         raw_name = util.guid().lower()
         name = self._quote(raw_name)
         type_info_sql = """
-        SELECT 
-            "column_name", 
+        SELECT
+            "column_name",
             "data_type"
         FROM SVV_ALL_COLUMNS
         WHERE table_name = :raw_name


### PR DESCRIPTION
## Description of changes
Support Redshift table reflection on the Ibis 7.1 modernization branch.

Ibis 7.1 table loading uses SQLAlchemy reflection paths that now reach PostgreSQL catalog queries when the Redshift backend is connected through the generic `postgresql+psycopg2` dialect. Redshift does not support all of those PostgreSQL catalog APIs, so DVT can fail while loading a Redshift table before validation begins.

This change registers a small `redshift+psycopg2` SQLAlchemy dialect for DVT's Redshift backend. The dialect keeps the existing psycopg2 connection path, skips unsupported PostgreSQL domain/reflection queries, and returns empty defaults for constraint/index reflection that DVT does not use for Redshift validation. Column metadata reflection remains handled by the existing Redshift backend path.

The Redshift backend now builds `redshift+psycopg2` URLs so SQLAlchemy resolves to this dialect instead of the generic PostgreSQL dialect.

## Issues to be closed
N/A

## Testing
- `venv/bin/python -m pytest tests/unit/ibis_redshift/test_init.py -q`
- `venv/bin/python -m flake8 third_party/ibis/ibis_redshift tests/unit/ibis_redshift`
- `venv/bin/python -m black --check third_party/ibis/ibis_redshift tests/unit/ibis_redshift`
- `TZ=UTC venv/bin/python -m pytest tests/unit -q`
- `git diff --check upstream/ibis-7.1-modernization...HEAD`
- Manual live Redshift validation with a temporary Redshift Serverless workgroup: table schema reflection, row count/read execution, schema validation, column validation, row validation, and hash-based row validation all passed; temporary resources were removed after validation.

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines