### PR TITLE
fix: SQL Server padded char columns are detected correctly

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -283,6 +283,7 @@ def integration_snowflake(session):
     """Run Snowflake integration tests.
     Ensure Snowflake validation is running as expected.
     """
+    session.skip("Snowflake testing disabled due to account suspension.")
     # TODO Remove pinned version below when working on issue-1592.
     _setup_session_requirements(
         session,

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -820,7 +820,7 @@ def test_row_validation_datetime_pk_to_bigquery():
 )
 def test_fixed_char_pk_row_validation_to_bigquery():
     """Test fixed char primary keys"""
-    id_column_row_validation_test("pso_data_validator.dvt_fixed_char_id")
+    id_column_row_validation_test("pso_data_validator.dvt_fixed_char_id", hash="id")
 
 
 @mock.patch(
@@ -1049,7 +1049,9 @@ def test_custom_query_row_hash_validation_core_types_to_bigquery():
 )
 def test_fixed_char_pk_query_row_validation_to_bigquery():
     """Test fixed char primary keys on custom query"""
-    id_column_query_row_validation_test("pso_data_validator.dvt_fixed_char_id")
+    id_column_query_row_validation_test(
+        "pso_data_validator.dvt_fixed_char_id", hash="id"
+    )
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -820,7 +820,9 @@ def test_row_validation_datetime_pk_to_bigquery():
 )
 def test_fixed_char_pk_row_validation_to_bigquery():
     """Test fixed char primary keys"""
-    id_column_row_validation_test("pso_data_validator.dvt_fixed_char_id", hash="id")
+    id_column_row_validation_test(
+        "pso_data_validator.dvt_fixed_char_id", hash="id", use_random_row=True
+    )
 
 
 @mock.patch(

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -28,6 +28,7 @@ from tests.system.data_sources.common_functions import (
     binary_key_assertions,
     connections_add_test,
     find_tables_test,
+    id_column_query_row_validation_test,
     id_column_row_validation_test,
     id_type_test_assertions,
     null_not_null_assertions,
@@ -52,6 +53,7 @@ SQL_SERVER_PORT = os.getenv("SQL_SERVER_PORT", "1433")
 SQL_SERVER_USER = os.getenv("SQL_SERVER_USER", "sqlserver")
 SQL_SERVER_PASSWORD = os.getenv("SQL_SERVER_PASSWORD")
 SQL_SERVER_DATABASE = os.getenv("SQL_SERVER_DATABASE", "guestbook")
+SQL_SERVER_CONFIG_JSON = os.getenv("SQL_SERVER_CONFIG_JSON")
 PROJECT_ID = os.getenv("PROJECT_ID")
 CONN = {
     consts.SOURCE_TYPE: consts.SOURCE_TYPE_MSSQL,
@@ -61,6 +63,8 @@ CONN = {
     "port": int(SQL_SERVER_PORT),
     "database": SQL_SERVER_DATABASE,
 }
+if SQL_SERVER_CONFIG_JSON:
+    CONN["query"] = SQL_SERVER_CONFIG_JSON
 
 EXPECTED_DATETIME_ID_PARTITION_FILTER = [
     [
@@ -814,6 +818,24 @@ def test_row_validation_datetime_pk_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_fixed_char_pk_row_validation_to_bigquery():
+    """Test fixed char primary keys"""
+    id_column_row_validation_test("pso_data_validator.dvt_fixed_char_id")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_varchar_pk_row_validation_to_bigquery():
+    """Test varchar primary keys"""
+    id_column_row_validation_test("pso_data_validator.dvt_varchar_id")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_row_validation_pangrams_to_bigquery():
     """SQL Server to BigQuery dvt_pangrams row validation.
     This is testing comparisons across a wider set of characters than standard test data.
@@ -1019,6 +1041,24 @@ def test_custom_query_row_hash_validation_core_types_to_bigquery():
         target_query="select id,col_int64,col_varchar_30,COL_DATE from pso_data_validator.dvt_core_types",
         hash="col_int64,col_varchar_30,col_date",
     )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_fixed_char_pk_query_row_validation_to_bigquery():
+    """Test fixed char primary keys on custom query"""
+    id_column_query_row_validation_test("pso_data_validator.dvt_fixed_char_id")
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_varchar_pk_query_row_validation_to_bigquery():
+    """Test varchar primary keys on custom query"""
+    id_column_query_row_validation_test("pso_data_validator.dvt_varchar_id")
 
 
 @mock.patch(

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -151,11 +151,17 @@ class Backend(BaseAlchemyBackend):
             for column in result.mappings():
                 # Extract relevant metadata from the result set and construct the metadata tuple (DB API format)
                 # Note: Metadata may vary based on the SQL Server version and the specific query used.
+                system_type = column["system_type_name"]
+                base_type = (
+                    system_type.split("(")[0].strip().lower() if system_type else None
+                )
+                max_length = column.get("max_length")
+
                 yield (
                     column["name"],
-                    column["system_type_name"],  # type_code
-                    None,  # display_size
-                    None,  # internal_size
+                    base_type,  # type_code
+                    max_length,  # display_size
+                    max_length,  # internal_size
                     column["precision"],
                     column["scale"],
                     column["is_nullable"],


### PR DESCRIPTION
## Description of changes
This PR fixed fixed padded char detection for SQL Server and adds missing tests.

Also temporarily disables Snowflake testing due to account issues.

## Issues to be closed

Closes #1778

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


