### PR TITLE
fix: Better message when all columns are pks for -comp-fields

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -336,6 +336,12 @@ def build_config_from_args(args: "Namespace", config_manager: ConfigManager):
                 _get_comparison_config(args, config_manager, primary_keys)
             )
 
+        if not config_manager.comparison_fields:
+            raise ValueError(
+                "No comparison fields remaining after excluding primary keys. "
+                "Use --concat or --hash when all columns are also primary key columns."
+            )
+
     return config_manager
 
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -3,6 +3,7 @@
 ## General
 
 - Floating-point data types, e.g. Float and Double, are inexact by nature. Validations that involve conversion of floating-point data to string, e.g. `--hash` and `--concat`, can be problematic.
+- Row validations using `--comparison-fields` require at least one comparison column that is not a primary key. When all table columns are used as primary keys, you must use `--concat` or `--hash` to validate the rows.
 
 ## BigQuery
 

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -499,7 +499,11 @@ def test_column_validation_ss_types_to_bigquery():
     ]
     # TODO Include col_int1 in max_cols when working on issue-1585.
     max_cols = [_ for _ in cols if _ not in ("col_int1",)]
-    avg_cols = [_ for _ in cols if _ in ("id", "col_int1", "col_int2", "col_int4", "col_int8", "col_dec")]
+    avg_cols = [
+        _
+        for _ in cols
+        if _ in ("id", "col_int1", "col_int2", "col_int4", "col_int8", "col_dec")
+    ]
     column_validation_test(
         tc="bq-conn",
         tables="pso_data_validator.dvt_sql_server_types",


### PR DESCRIPTION
## Description of changes
DVT intentionally removes primary key columns from the list of comparison fields when `-comp-fields` is used. For tables where all columns are in the primary key the combiner fails because there are no remaining comparison fields. This change prevent the unhandled exception in the combiner by raising an explicit exception.

It also documents the limitaton.

## Issues to be closed

Closes #1309

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


