### PR TITLE
fix: Fix SQL Server avg for integer columns

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -42,6 +42,7 @@
 - SQL Server does not have a function to "right trim" all whitespace, only spaces, therefore any validations relying on removal of trailing white space may encounter issues.
 - The `text` and `ntext` data types are incompatible with the `len()` therefore the `datalength()` function ius used in it's place which will give different results for multibyte characters.
 - The `image` data type is not currently supported, these columns are skipped when validated. See (issue-1578)[https://github.com/GoogleCloudPlatform/professional-services-data-validator/issues/1578] for details.
+- SQL Server's `AVG()` function can overflow and return an arithmetic overflow error when calculating the average of a max-precision decimal column (e.g. `decimal(38)`). If you encounter this, exclude the column(s) from the list of columns passed to the `--avg` option.
 
 ## Sybase ASE
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -283,6 +283,7 @@ def integration_snowflake(session):
     """Run Snowflake integration tests.
     Ensure Snowflake validation is running as expected.
     """
+    session.skip("Snowflake testing disabled due to account suspension.")
     # TODO Remove pinned version below when working on issue-1592.
     _setup_session_requirements(
         session,

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -499,6 +499,7 @@ def test_column_validation_ss_types_to_bigquery():
     ]
     # TODO Include col_int1 in max_cols when working on issue-1585.
     max_cols = [_ for _ in cols if _ not in ("col_int1",)]
+    avg_cols = [_ for _ in cols if _ in ("id", "col_int1", "col_int2", "col_int4", "col_int8", "col_dec")]
     column_validation_test(
         tc="bq-conn",
         tables="pso_data_validator.dvt_sql_server_types",
@@ -506,6 +507,7 @@ def test_column_validation_ss_types_to_bigquery():
         sum_cols=",".join(cols),
         min_cols=",".join(cols),
         max_cols=",".join(max_cols),
+        avg_cols=",".join(avg_cols),
         # SQL Server requires cast_to_bigint for summing tinyint/smallint/int.
         cast_to_bigint=True,
     )

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -494,6 +494,7 @@ MsSqlExprTranslator._registry[BinaryLength] = mssql_registry.sa_format_binary_le
 MsSqlExprTranslator._registry[ops.TableColumn] = mssql_registry.sa_table_column
 MsSqlExprTranslator._registry[ops.ExtractEpochSeconds] = mssql_registry.sa_epoch_seconds
 MsSqlExprTranslator._registry[ops.RStrip] = mssql_registry.sa_whitespace_rstrip
+MsSqlExprTranslator._registry[ops.Mean] = mssql_registry.sa_format_mean
 MsSqlExprTranslator._registry[PaddedCharLength] = MsSqlExprTranslator._registry[
     ops.StringLength
 ]

--- a/third_party/ibis/ibis_mssql/registry.py
+++ b/third_party/ibis/ibis_mssql/registry.py
@@ -176,3 +176,16 @@ def sa_string_join(t, op):
 def sa_whitespace_rstrip(t, op):
     sa_arg = t.translate(op.arg)
     return sa.func.rtrim(sa.cast(sa_arg, sa.VARCHAR(length=None)))
+
+
+def sa_format_mean(translator, op):
+    """Calculate the average aggregation.
+
+    Casts integer inputs to FLOAT to prevent integer truncation. Leaves other
+    types unchanged to preserve precision (e.g., Decimals).
+    """
+    arg = translator.translate(op.arg)
+
+    if op.arg.output_dtype.is_integer():
+        return sa.func.avg(sa.cast(arg, sa.FLOAT))
+    return sa.func.avg(arg)


### PR DESCRIPTION
## Description of changes
SQL Server's AVG() function preserves the data type of the column. If you give it an integer, it truncates the result to an integer. This PR first casts integer columns to a float64.

Also documents a SQL Server AVG limitation.

Unfortunately this changes Ibis addon code. It is only small so shouldn't be a problem to deal with the fallout on the Ibis 7.1 upgrade branch.

## Issues to be closed

Closes #1781


## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


