### PR TITLE
fix: SQL Server tinyint type detection

### DIFF
--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -335,9 +335,7 @@ def test_schema_validation_core_types_to_bigquery():
             # All SQL Server integers go to BigQuery INT64.
             "int8:int64,int16:int64,int32:int64,!int32:!int64,"
             # BigQuery does not have a float32 type.
-            "float32:float64,"
-            # SQL Server TIMESTAMP type has scale=7 on Ibis which does not happen in BigQuery.
-            "timestamp(7):timestamp,!timestamp(7):!timestamp,timestamp(7, 'UTC'):timestamp('UTC'),"
+            "float32:float64"
         ),
     )
 
@@ -355,9 +353,7 @@ def test_schema_validation_ss_types_to_bigquery():
             # All SQL Server integers go to BigQuery INT64.
             "int8:int64,int16:int64,int32:int64,!int32:!int64,"
             # BigQuery does not have a float32 type.
-            "float32:float64,"
-            # SQL Server datetime scales are picked up.
-            "timestamp(7):timestamp,timestamp(7, 'UTC'):timestamp('UTC')"
+            "float32:float64"
         ),
         # TODO money types are being identified as integers - issue-1582
         exclusion_columns="col_money,col_smallmoney",
@@ -378,8 +374,6 @@ def test_schema_validation_not_null_vs_nullable():
             "-sc=sql-conn",
             "-tc=bq-conn",
             "-tbls=pso_data_validator.dvt_null_not_null=pso_data_validator.dvt_null_not_null",
-            # SQL Server TIMESTAMP type has scale=7 on Ibis which does not happen in BigQuery.
-            "--allow-list=timestamp(7):timestamp,!timestamp(7):!timestamp,timestamp(7, 'UTC'):timestamp('UTC'),",
         ]
     )
     df = run_test_from_cli_args(args)

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -497,16 +497,18 @@ def test_column_validation_ss_types_to_bigquery():
             "col_ntext",
         )
     ]
-    # TODO Include col_int1 in max_cols when working on issue-1585.
-    max_cols = [_ for _ in cols if _ not in ("col_int1",)]
-    avg_cols = [_ for _ in cols if _ in ("id", "col_int1", "col_int2", "col_int4", "col_int8", "col_dec")]
+    avg_cols = [
+        _
+        for _ in cols
+        if _ in ("id", "col_int1", "col_int2", "col_int4", "col_int8", "col_dec")
+    ]
     column_validation_test(
         tc="bq-conn",
         tables="pso_data_validator.dvt_sql_server_types",
         count_cols=",".join(cols),
         sum_cols=",".join(cols),
         min_cols=",".join(cols),
-        max_cols=",".join(max_cols),
+        max_cols=",".join(cols),
         avg_cols=",".join(avg_cols),
         # SQL Server requires cast_to_bigint for summing tinyint/smallint/int.
         cast_to_bigint=True,
@@ -699,8 +701,6 @@ def test_row_validation_comp_fields_ss_types_to_bigquery():
                 "id",
                 # Excluded col_float32 because BigQuery does not have a float32 type.
                 "col_float32",
-                # TODO Include col_int1 in max_cols when working on issue-1585.
-                "col_int1",
                 # TODO Remove money types from exclude list when working on - issue-1582
                 "col_money",
                 "col_smallmoney",

--- a/third_party/ibis/ibis_mssql/__init__.py
+++ b/third_party/ibis/ibis_mssql/__init__.py
@@ -20,6 +20,9 @@ from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.mssql.compiler import MsSqlCompiler
 from ibis.backends.mssql.datatypes import _type_from_result_set_info
 
+# Import datatypes to patch Ibis MSSQL support.
+import third_party.ibis.ibis_mssql.datatypes
+
 import json
 
 DEFAULT_DRIVER_NAME = "ODBC Driver 17 for SQL Server"

--- a/third_party/ibis/ibis_mssql/datatypes.py
+++ b/third_party/ibis/ibis_mssql/datatypes.py
@@ -33,3 +33,7 @@ def sa_mssql_datetime2(_, sa_type, nullable=True):
 # Needs to be VARCHAR instead of NVARCHAR for Hash function
 _MSSQL_TYPE_MAP[dt.String] = mssql.VARCHAR
 _MSSQL_TYPE_MAP[dt.Float64] = mssql.FLOAT
+
+@dt.dtype.register(MSDialect, mssql.TINYINT)
+def sa_mssql_tinyint(_, sa_type, nullable=True):
+    return dt.Int16(nullable=nullable)

--- a/third_party/ibis/ibis_mssql/datatypes.py
+++ b/third_party/ibis/ibis_mssql/datatypes.py
@@ -34,6 +34,7 @@ def sa_mssql_datetime2(_, sa_type, nullable=True):
 _MSSQL_TYPE_MAP[dt.String] = mssql.VARCHAR
 _MSSQL_TYPE_MAP[dt.Float64] = mssql.FLOAT
 
+
 @dt.dtype.register(MSDialect, mssql.TINYINT)
 def sa_mssql_tinyint(_, sa_type, nullable=True):
     return dt.Int16(nullable=nullable)


### PR DESCRIPTION
## Description of changes
SQL Server's tinyint is an unsigned 8-bit integer, meaning it stores values from 0 to 255. Ibis 8-bit integer is signed, meaning it stores range -128 to 127.

Change in this PR detects SQL Server tinyint as 16-bit int.

## Issues to be closed

Closes #1585

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


