### PR TITLE
chore: Table name indicator in DataValidation exceptions

### DIFF
--- a/data_validation/__main__.py
+++ b/data_validation/__main__.py
@@ -529,33 +529,40 @@ def run_validation(config_manager: ConfigManager, dry_run=False, verbose=False):
         logging.warning(
             "Trim String Primary Keys has been deprecated, validation results may vary"
         )
-    with DataValidation(
-        config_manager.config,
-        validation_builder=None,
-        result_handler=None,
-        verbose=verbose,
-        cached_source_client=source_client,
-        cached_target_client=target_client,
-    ) as validator:
+    try:
+        with DataValidation(
+            config_manager.config,
+            validation_builder=None,
+            result_handler=None,
+            verbose=verbose,
+            cached_source_client=source_client,
+            cached_target_client=target_client,
+        ) as validator:
 
-        if dry_run:
-            print(
-                json.dumps(
-                    {
-                        "source_query": util.ibis_table_to_sql(
-                            validator.validation_builder.get_source_query(),
-                            source_client,
-                        ),
-                        "target_query": util.ibis_table_to_sql(
-                            validator.validation_builder.get_target_query(),
-                            target_client,
-                        ),
-                    },
-                    indent=4,
+            if dry_run:
+                print(
+                    json.dumps(
+                        {
+                            "source_query": util.ibis_table_to_sql(
+                                validator.validation_builder.get_source_query(),
+                                source_client,
+                            ),
+                            "target_query": util.ibis_table_to_sql(
+                                validator.validation_builder.get_target_query(),
+                                target_client,
+                            ),
+                        },
+                        indent=4,
+                    )
                 )
-            )
-        else:
-            validator.execute()
+            else:
+                validator.execute()
+    except Exception as e:
+        if config_manager.full_source_table:
+            raise exceptions.ValidationException(
+                f"Validation failed for table '{config_manager.full_source_table}': {e}"
+            ) from e
+        raise
 
 
 def run_validations(args, config_managers):

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -694,5 +694,8 @@ def test_run_validation_exception_handling(mock_data_validation):
     with pytest.raises(exceptions.ValidationException) as exc_info:
         main.run_validation(mock_config_manager)
 
-    assert "Validation failed for table 'test_schema.test_table': Some execution error" in str(exc_info.value)
+    assert (
+        "Validation failed for table 'test_schema.test_table': Some execution error"
+        in str(exc_info.value)
+    )
     assert isinstance(exc_info.value.__cause__, ValueError)

--- a/tests/unit/test__main.py
+++ b/tests/unit/test__main.py
@@ -678,3 +678,21 @@ def test_store_config_dir_custom_query_raises():
         main.store_config_dir(args, [config_mgr], is_json=False)
 
     assert main.CUSTOM_QUERY_DIR_SUPPORT_ERROR in str(exc_info.value)
+
+
+@mock.patch("data_validation.__main__.DataValidation")
+def test_run_validation_exception_handling(mock_data_validation):
+    """Test that exceptions in run_validation are wrapped with table names."""
+    mock_validator = mock.Mock()
+    mock_validator.execute.side_effect = ValueError("Some execution error")
+    mock_data_validation.return_value.__enter__.return_value = mock_validator
+
+    mock_config_manager = mock.Mock()
+    mock_config_manager.full_source_table = "test_schema.test_table"
+    mock_config_manager.config = {}
+
+    with pytest.raises(exceptions.ValidationException) as exc_info:
+        main.run_validation(mock_config_manager)
+
+    assert "Validation failed for table 'test_schema.test_table': Some execution error" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, ValueError)


### PR DESCRIPTION
## Description of changes
Adds a small usability change to include the source table name (where possible) in `DataValidation()` exceptions.

## Issues to be closed

Closes #1776

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


