### PR TITLE
fix: Fix SQL Server overflow on SUM(INT)

### DIFF
--- a/tests/resources/sqlserver_test_tables.sql
+++ b/tests/resources/sqlserver_test_tables.sql
@@ -758,7 +758,6 @@ CREATE TABLE pso_data_validator.dvt_reserved_word_columns (
 EXECUTE sp_addextendedproperty 'Comment', 'Integration test table used to test potentially difficult column names', 'SCHEMA', 'pso_data_validator', 'table', 'dvt_reserved_word_columns';
 INSERT INTO pso_data_validator.dvt_reserved_word_columns (id) VALUES (1);
 
-
 -- CamelCase test table.
 DROP TABLE IF EXISTS pso_data_validator.[DvtCamelCase];
 CREATE TABLE pso_data_validator.[DvtCamelCase]
@@ -787,3 +786,13 @@ CREATE TABLE pso_data_validator.dvt_camel_case_lower
 EXECUTE sp_addextendedproperty 'Comment', 'SQL Server table to compare with DvtCamelCase.', 'SCHEMA', 'pso_data_validator', 'table', 'dvt_camel_case_lower';
 INSERT INTO pso_data_validator.dvt_camel_case_lower
 SELECT * FROM pso_data_validator.[DvtCamelCase];
+
+DROP TABLE IF EXISTS pso_data_validator.dvt_int_overflow;
+CREATE TABLE pso_data_validator.dvt_int_overflow
+(   id          INT NOT NULL PRIMARY KEY
+,   col_int32   INT NOT NULL
+,   col_val     DECIMAL(10,2)
+);
+EXECUTE sp_addextendedproperty 'Comment', 'Integration test table used to test INT column SUM overflow in SQL Server', 'SCHEMA', 'pso_data_validator', 'table', 'dvt_int_overflow';
+INSERT INTO pso_data_validator.dvt_int_overflow VALUES (1, 1500000000, 100.50);
+INSERT INTO pso_data_validator.dvt_int_overflow VALUES (2, 1500000000, 200.75);

--- a/tests/resources/sybase_test_tables.sql
+++ b/tests/resources/sybase_test_tables.sql
@@ -672,3 +672,19 @@ INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Paul''s'
 GO
 INSERT INTO pso_data_validator.test_generate_partitions_v2 VALUES ('St. Paul''s', 5678, '2023-08-27 15:00:00', '2023-08-23', 0, 3.5)
 GO
+
+--Integration test table used to test INT column SUM overflow in Sybase
+DROP TABLE pso_data_validator.dvt_int_overflow
+GO
+
+CREATE TABLE pso_data_validator.dvt_int_overflow
+(   id          INT NOT NULL PRIMARY KEY
+,   col_int32   INT NOT NULL
+,   col_val     DECIMAL(10,2)
+)
+GO
+
+INSERT INTO pso_data_validator.dvt_int_overflow VALUES (1, 1500000000, 100.50)
+GO
+INSERT INTO pso_data_validator.dvt_int_overflow VALUES (2, 1500000000, 200.75)
+GO

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -649,6 +649,21 @@ def test_column_validation_uuid_to_bigquery():
     )
 
 
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_int_overflow():
+    """SQL Server dvt_int_overflow column validation.
+
+    SUM(int_column) results in an INT which can cause an overflow error."""
+    column_validation_test(
+        tables="pso_data_validator.dvt_int_overflow",
+        tc="bq-conn",
+        sum_cols="*",
+    )
+
+
 ###############################
 # Row validation
 ###############################

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -659,7 +659,7 @@ def test_column_validation_int_overflow():
     SUM(int_column) results in an INT which can cause an overflow error."""
     column_validation_test(
         tables="pso_data_validator.dvt_int_overflow",
-        tc="bq-conn",
+        tc="mock-conn",
         sum_cols="*",
     )
 

--- a/tests/system/data_sources/test_sybase.py
+++ b/tests/system/data_sources/test_sybase.py
@@ -363,6 +363,21 @@ def test_column_validation_reserved_words():
     )
 
 
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
+def test_column_validation_int_overflow():
+    """Sybase dvt_int_overflow column validation.
+
+    SUM(int_column) results in an INT which can cause an overflow error."""
+    column_validation_test(
+        tables="pso_data_validator.dvt_int_overflow",
+        tc="mock-conn",
+        sum_cols="*",
+    )
+
+
 ###########################
 # ROW VALIDATION TESTS
 ###########################

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -495,6 +495,7 @@ MsSqlExprTranslator._registry[ops.TableColumn] = mssql_registry.sa_table_column
 MsSqlExprTranslator._registry[ops.ExtractEpochSeconds] = mssql_registry.sa_epoch_seconds
 MsSqlExprTranslator._registry[ops.RStrip] = mssql_registry.sa_whitespace_rstrip
 MsSqlExprTranslator._registry[ops.Mean] = mssql_registry.sa_format_mean
+MsSqlExprTranslator._registry[ops.Sum] = mssql_registry.sa_format_sum
 MsSqlExprTranslator._registry[PaddedCharLength] = MsSqlExprTranslator._registry[
     ops.StringLength
 ]

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -558,3 +558,5 @@ if SybaseExprTranslator:
     SybaseExprTranslator._registry[PaddedCharLength] = (
         mssql_registry.sa_format_string_length
     )
+    SybaseExprTranslator._registry[ops.Mean] = mssql_registry.sa_format_mean
+    SybaseExprTranslator._registry[ops.Sum] = mssql_registry.sa_format_sum

--- a/third_party/ibis/ibis_mssql/registry.py
+++ b/third_party/ibis/ibis_mssql/registry.py
@@ -189,3 +189,16 @@ def sa_format_mean(translator, op):
     if op.arg.output_dtype.is_integer():
         return sa.func.avg(sa.cast(arg, sa.FLOAT))
     return sa.func.avg(arg)
+
+
+def sa_format_sum(translator, op):
+    """Calculate the sum aggregation for SQL Server.
+
+    Casts integer inputs to BIGINT to prevent 32-bit integer arithmetic overflow (Error 8115).
+    Leaves non-integer types (e.g., Decimals, Floats) unchanged to preserve precision.
+    """
+    arg = translator.translate(op.arg)
+
+    if op.arg.output_dtype.is_integer():
+        return sa.func.sum(sa.cast(arg, sa.BIGINT))
+    return sa.func.sum(arg)


### PR DESCRIPTION
## Description of changes
This PR fixed a SQL Server overflow issue on SUM(INT) by casting INTs to BIGINT before summing.

The same fix is required on Sybase and is included here.

Also adds tests for both.

## Issues to be closed

Closes #1789

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


