### PR TITLE
fix: Ensure padded char PK detection works for upper case columns

### DIFF
--- a/data_validation/validation_builder.py
+++ b/data_validation/validation_builder.py
@@ -105,8 +105,8 @@ class ValidationBuilder(object):
         # Clients only need to implement _is_char_type_padded method if they pad strings
         return (
             (
-                client.is_char_type_padded(raw_column_metadata[column_name])
-                if raw_column_metadata.get(column_name)
+                client.is_char_type_padded(raw_column_metadata[column_name.casefold()])
+                if raw_column_metadata.get(column_name.casefold())
                 else False
             )
             if hasattr(client, "is_char_type_padded") and raw_column_metadata

--- a/tests/resources/sqlserver_test_tables.sql
+++ b/tests/resources/sqlserver_test_tables.sql
@@ -246,7 +246,7 @@ CREATE TABLE pso_data_validator.dvt_fixed_char_id_upper
 ,   [OTHER_DATA]  CHAR(100)
 );
 EXECUTE sp_addextendedproperty 'Comment', 'Integration test table used to test fixed char pk matching on upper case ID column.', 'SCHEMA', 'pso_data_validator', 'table', 'dvt_fixed_char_id_upper';
-INSERT INTO pso_data_validator.dvt_fixed_char_id_upper SELECT * FORM pso_data_validator.dvt_fixed_char_id;
+INSERT INTO pso_data_validator.dvt_fixed_char_id_upper SELECT * FROM pso_data_validator.dvt_fixed_char_id;
 
 DROP TABLE IF EXISTS pso_data_validator.dvt_varchar_id;
 CREATE TABLE pso_data_validator.dvt_varchar_id

--- a/tests/resources/sqlserver_test_tables.sql
+++ b/tests/resources/sqlserver_test_tables.sql
@@ -240,6 +240,14 @@ INSERT INTO pso_data_validator.dvt_fixed_char_id VALUES ('DVT3', 'Row 3  ');
 INSERT INTO pso_data_validator.dvt_fixed_char_id VALUES ('DVT4', 'Row 4  	  ');
 INSERT INTO pso_data_validator.dvt_fixed_char_id VALUES ('DVT5', 'Row 5');
 
+DROP TABLE IF EXISTS pso_data_validator.dvt_fixed_char_id_upper;
+CREATE TABLE pso_data_validator.dvt_fixed_char_id_upper
+(   [ID]          CHAR(6) NOT NULL PRIMARY KEY
+,   [OTHER_DATA]  CHAR(100)
+);
+EXECUTE sp_addextendedproperty 'Comment', 'Integration test table used to test fixed char pk matching on upper case ID column.', 'SCHEMA', 'pso_data_validator', 'table', 'dvt_fixed_char_id_upper';
+INSERT INTO pso_data_validator.dvt_fixed_char_id_upper SELECT * FORM pso_data_validator.dvt_fixed_char_id;
+
 DROP TABLE IF EXISTS pso_data_validator.dvt_varchar_id;
 CREATE TABLE pso_data_validator.dvt_varchar_id
 (   id          VARCHAR(15) NOT NULL PRIMARY KEY

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -838,7 +838,9 @@ def test_fixed_char_pk_row_validation_to_bigquery():
 def test_fixed_char_pk_upper_row_validation_to_bigquery():
     """Test fixed char primary keys"""
     id_column_row_validation_test(
-        "pso_data_validator.dvt_fixed_char_id_upper=pso_data_validator.dvt_fixed_char_id", hash="id", use_random_row=True
+        "pso_data_validator.dvt_fixed_char_id_upper=pso_data_validator.dvt_fixed_char_id",
+        hash="id",
+        use_random_row=True,
     )
 
 

--- a/tests/system/data_sources/test_sql_server.py
+++ b/tests/system/data_sources/test_sql_server.py
@@ -835,6 +835,17 @@ def test_fixed_char_pk_row_validation_to_bigquery():
     "data_validation.state_manager.StateManager.get_connection_config",
     new=mock_get_connection_config,
 )
+def test_fixed_char_pk_upper_row_validation_to_bigquery():
+    """Test fixed char primary keys"""
+    id_column_row_validation_test(
+        "pso_data_validator.dvt_fixed_char_id_upper=pso_data_validator.dvt_fixed_char_id", hash="id", use_random_row=True
+    )
+
+
+@mock.patch(
+    "data_validation.state_manager.StateManager.get_connection_config",
+    new=mock_get_connection_config,
+)
 def test_varchar_pk_row_validation_to_bigquery():
     """Test varchar primary keys"""
     id_column_row_validation_test("pso_data_validator.dvt_varchar_id")


### PR DESCRIPTION
## Description of changes
Ensures padded char PK detection works for upper case columns.

We lower case column names in raw column metadata, but weren't lower casing the names we were checking in the metadata.

## Issues to be closed

Closes #1791

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


