### PR TITLE
fix: Type hints compatible with Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ extras_require = {
         "pytest-cov",
         "pytest-rerunfailures",
         "pytest-timeout",
+        "snowflake-connector-python",
+        "snowflake-sqlalchemy",
     ],
 }
 

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timedelta
 import json
 import logging
+import random
+from unittest import mock
+
+from google.cloud import bigquery
+import ibis.expr.datatypes as dt
 import pandas
 import pytest
-import random
-from datetime import datetime, timedelta
-from unittest import mock
-from google.cloud import bigquery
-
-import ibis.expr.datatypes as dt
+# Import tabulate here because it is lazily loaded in pandas which fails when fakefs is in play.
+import tabulate  # noqa: F401
 
 from data_validation import consts
 from data_validation.result_handlers.bigquery import BQRH_NO_WRITE_MESSAGE

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -22,6 +22,7 @@ from google.cloud import bigquery
 import ibis.expr.datatypes as dt
 import pandas
 import pytest
+
 # Import tabulate here because it is lazily loaded in pandas which fails when fakefs is in play.
 import tabulate  # noqa: F401
 

--- a/third_party/ibis/ibis_addon/operations.py
+++ b/third_party/ibis/ibis_addon/operations.py
@@ -25,13 +25,14 @@ non-textual languages.
 
 import datetime
 import dateutil
-import numpy as np
 import string
+from typing import Union
 
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
+import numpy as np
 import pandas as pd
 import sqlalchemy as sa
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
@@ -111,7 +112,7 @@ NAT_INT64_MIN_IN_SECONDS = np.iinfo(np.int64).min // 1_000_000_000
 
 
 class BinaryLength(ops.Value):
-    arg: ops.Value[dt.Binary | dt.String]
+    arg: ops.Value[Union[dt.Binary, dt.String]]
     dtype = dt.int32
     shape = rlz.shape_like("arg")
 
@@ -123,7 +124,7 @@ class PaddedCharLength(ops.Value):
 
 
 class ToChar(ops.Value):
-    arg: ops.Value[dt.Decimal | dt.Float64 | dt.Date | dt.Time | dt.Timestamp]
+    arg: ops.Value[Union[dt.Decimal, dt.Float64, dt.Date, dt.Time, dt.Timestamp]]
     fmt: ops.Value[dt.String]
     dtype = dt.string
     shape = rlz.shape_like("arg")


### PR DESCRIPTION
## Description of changes
Fixes a type hint added recently which was incompatible with Python 3.9.

Also resolves a small issue with a unit test dependency and adds some test dependencies to the develop stanza in `setup.py`.

## Issues to be closed

* Closes #1796
* Closes #1795

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


