### PR TITLE
fix: Cast binary values to hex in combiner before reporting them to screen

### DIFF
--- a/tests/unit/test_combiner.py
+++ b/tests/unit/test_combiner.py
@@ -1264,3 +1264,51 @@ def test_convert_large_ints_to_decimals(module_under_test):
 
     assert isinstance(res["normal_int"][0], (int, numpy.integer))
     assert isinstance(res["string_col"][0], str)
+
+
+def test_generate_report_with_binary_data(module_under_test):
+    """Test report generation with binary data containing non-UTF-8 characters.
+
+    This ensures that DVT does not crash with a UnicodeDecodeError when
+    casting binary columns to string in the Pandas combiner phase. Instead,
+    the binary data should be formatted as a hex string in the report.
+    """
+    # Binary data with non-UTF-8 bytes (e.g. 0xac)
+    binary_data = b"\xac\xed\x00\x05"
+    source_df = pandas.DataFrame({"id": [1], "bin_col": [binary_data]})
+    target_df = pandas.DataFrame({"id": [1], "bin_col": [binary_data]})
+
+    run_metadata = metadata.RunMetadata(
+        validations={
+            "bin_col": metadata.ValidationMetadata(
+                source_table_name="test_source",
+                source_table_schema="bq-public.source_dataset",
+                source_column_name="bin_col",
+                target_table_name="test_target",
+                target_table_schema="bq-public.target_dataset",
+                target_column_name="bin_col",
+                validation_type="Row",
+                aggregation_type="hash",
+                primary_keys=["id"],
+                num_random_rows=None,
+                threshold=0.0,
+            ),
+        },
+        start_time=datetime.datetime(1998, 9, 4, 7, 30, 1),
+        end_time=datetime.datetime(1998, 9, 4, 7, 31, 42),
+        labels=[],
+        run_id="test-run",
+    )
+
+    report = module_under_test.generate_report(
+        run_metadata,
+        source_df,
+        target_df,
+        join_on_fields=("id",),
+        is_value_comparison=True,
+    )
+
+    assert consts.SOURCE_AGG_VALUE in report.columns
+    assert consts.TARGET_AGG_VALUE in report.columns
+    assert report[consts.SOURCE_AGG_VALUE].iloc[0] == "aced0005"
+    assert report[consts.TARGET_AGG_VALUE].iloc[0] == "aced0005"

--- a/third_party/ibis/ibis_pandas/execution.py
+++ b/third_party/ibis/ibis_pandas/execution.py
@@ -15,7 +15,6 @@
 from collections.abc import Sized
 from datetime import date
 import dateutil.parser
-import numpy as np
 import pandas as pd
 
 from ibis.backends.pandas.dispatch import execute_node
@@ -122,5 +121,5 @@ def execute_cast_series_string(op, data, type, **kwargs):
     that are not valid UTF-8.
     """
     if op.arg.dtype.is_binary():
-        return data.map(lambda x: x.hex() if isinstance(x, bytes) else x)
+        return data.map(lambda x: x.hex() if isinstance(x, (bytes, bytearray)) else x)
     return data.astype(pandas_constants.IBIS_TYPE_TO_PANDAS_TYPE[type])

--- a/third_party/ibis/ibis_pandas/execution.py
+++ b/third_party/ibis/ibis_pandas/execution.py
@@ -18,9 +18,11 @@ import dateutil.parser
 import numpy as np
 import pandas as pd
 
+from ibis.backends.pandas.dispatch import execute_node
 import ibis.backends.pandas.execution.constants as pandas_constants
 import ibis.backends.pandas.execution.generic as gp
 import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
 import ibis.formats.pandas as fp
 
 
@@ -109,3 +111,16 @@ def dvt_convert_Date(s, dtype, pandas_type):
 
 
 fp.PandasData.convert_Date = dvt_convert_Date
+
+
+@execute_node.register(ops.Cast, pd.Series, dt.String)
+def execute_cast_series_string(op, data, type, **kwargs):
+    """Cast a Pandas Series to string, representing binary data as hex.
+
+    This specializes the cast operation from dt.Binary to dt.String to prevent
+    UnicodeDecodeError crashes in Pandas when the binary data contains bytes
+    that are not valid UTF-8.
+    """
+    if op.arg.dtype.is_binary():
+        return data.map(lambda x: x.hex() if isinstance(x, bytes) else x)
+    return data.astype(pandas_constants.IBIS_TYPE_TO_PANDAS_TYPE[type])


### PR DESCRIPTION
## Description of changes
This PR changes the DVT combiner to convert binary columns to hex before reporting them.

This is because and binary column containing non-UTF8 characters will trigger an exception:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xac in position 0: invalid start byte
```

This only applies to comparison fields validations, concat/hash already cast to hex in the source/target SQL statements.

The down side to this is that any binary columns containing all UTF8 tokens will be output as hex, even though they "could" be output as a pure binary-to-string cast. But it brings comparison fields into line with other validations and prevent exceptions. I think the pros outweigh the cons.

## Issues to be closed

Closes #1810

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


