### PR TITLE
fix: Exclude Oracle system schemas from list_databases

### DIFF
--- a/tests/unit/ibis_oracle/test_init.py
+++ b/tests/unit/ibis_oracle/test_init.py
@@ -113,6 +113,7 @@ def test_raw_column_metadata_qry(mock_begin, module_under_test):
 @pytest.mark.skipif(not get_module_under_test(), reason="No Oracle driver")
 @mock.patch("sqlalchemy.inspect")
 def test_list_databases(mock_inspect, module_under_test):
+    """Test that list_databases excludes Oracle system schemas while preserving user and monitoring schemas."""
     mock_inspect_result = mock.Mock()
     mock_inspect_result.get_schema_names.return_value = [
         "SYS",
@@ -131,5 +132,30 @@ def test_list_databases(mock_inspect, module_under_test):
 
     # SYS and C##DS should be filtered out.
     # SYSTEM, DBSNMP, and DVT_TEST should remain.
-    assert schemas == ["SYSTEM", "DBSNMP", "DVT_TEST"]
+    assert sorted(schemas) == sorted(["SYSTEM", "DBSNMP", "DVT_TEST"])
+    mock_inspect.assert_called_with(backend.con)
+
+
+@pytest.mark.skipif(not get_module_under_test(), reason="No Oracle driver")
+@mock.patch("sqlalchemy.inspect")
+def test_list_databases_with_like(mock_inspect, module_under_test):
+    """Test that list_databases correctly filters schemas when a like pattern is provided."""
+    mock_inspect_result = mock.Mock()
+    mock_inspect_result.get_schema_names.return_value = [
+        "SYS",
+        "SYSTEM",
+        "DBSNMP",
+        "C##DS",
+        "DVT_TEST",
+    ]
+    mock_inspect.return_value = mock_inspect_result
+
+    backend = module_under_test.Backend()
+    # Need to set self.con for sa.inspect to work
+    backend.con = mock.Mock()
+
+    schemas = backend.list_databases(like=".*DVT.*")
+
+    # Only DVT_TEST should match
+    assert schemas == ["DVT_TEST"]
     mock_inspect.assert_called_with(backend.con)

--- a/tests/unit/ibis_oracle/test_init.py
+++ b/tests/unit/ibis_oracle/test_init.py
@@ -108,3 +108,28 @@ def test_raw_column_metadata_qry(mock_begin, module_under_test):
     assert all(_[1] == "MOCKTYPE" for _ in raw_types)
     # Ensure we have 7 attributes.
     assert all(len(_) == 7 for _ in raw_types)
+
+
+@pytest.mark.skipif(not get_module_under_test(), reason="No Oracle driver")
+@mock.patch("sqlalchemy.inspect")
+def test_list_databases(mock_inspect, module_under_test):
+    mock_inspect_result = mock.Mock()
+    mock_inspect_result.get_schema_names.return_value = [
+        "SYS",
+        "SYSTEM",
+        "DBSNMP",
+        "C##DS",
+        "DVT_TEST",
+    ]
+    mock_inspect.return_value = mock_inspect_result
+
+    backend = module_under_test.Backend()
+    # Need to set self.con for sa.inspect to work
+    backend.con = mock.Mock()
+
+    schemas = backend.list_databases()
+
+    # SYS and C##DS should be filtered out.
+    # SYSTEM, DBSNMP, and DVT_TEST should remain.
+    assert schemas == ["SYSTEM", "DBSNMP", "DVT_TEST"]
+    mock_inspect.assert_called_with(backend.con)

--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Iterable, Literal, Optional, Tuple, Dict, Any
 
 import sqlalchemy as sa
@@ -20,7 +21,6 @@ from sqlalchemy.dialects.oracle.base import (
     RESERVED_WORDS as ORACLE_RESERVED_WORDS,
 )
 from sqlalchemy.dialects.oracle.oracledb import OracleDialect_oracledb
-import re
 
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
@@ -44,7 +44,6 @@ ORACLE_SYSTEM_SCHEMAS = {
     "ANONYMOUS",
     "APPQOSSYS",
     "AUDSYS",
-    "C##DS",
     "CTXSYS",
     "DBSFWUSER",
     "DGPDB_INT",
@@ -302,13 +301,25 @@ class Backend(BaseAlchemyBackend):
         padded values, which DVT may want to trim"""
         return char_type[0] in ["CHAR", "NCHAR"]
 
-    def list_databases(self) -> list:
+    def list_databases(self, like: Optional[str] = None) -> list[str]:
+        """Return a list of user schemas in the Oracle database.
+
+        Excludes Oracle-maintained system schemas to avoid performance bottlenecks
+        and permission errors during table discovery.
+
+        Args:
+            like: Optional pattern string to filter returned schema names.
+
+        Returns:
+            list[str]: Filtered list of schema names.
+        """
         all_schemas = sa.inspect(self.con).get_schema_names()
-        return [
+        schemas = [
             schema
             for schema in all_schemas
             if schema.upper() not in ORACLE_SYSTEM_SCHEMAS
         ]
+        return self._filter_with_like(schemas, like)
 
     def dvt_tuple_in_supported(self) -> bool:
         """Return True if backend client supports native SQL tuple/struct IN expressions."""

--- a/third_party/ibis/ibis_oracle/__init__.py
+++ b/third_party/ibis/ibis_oracle/__init__.py
@@ -37,6 +37,56 @@ EXTRA_RESERVED_WORDS = set(
 )
 
 
+# We use a hardcoded list instead of checking the `oracle_maintained` column
+# in `all_users` because we want more granular control over which schemas to ignore.
+# For example, some customers use SYSTEM and DBSNMP for their own monitoring tables.
+ORACLE_SYSTEM_SCHEMAS = {
+    "ANONYMOUS",
+    "APPQOSSYS",
+    "AUDSYS",
+    "C##DS",
+    "CTXSYS",
+    "DBSFWUSER",
+    "DGPDB_INT",
+    "DIP",
+    "DVF",
+    "DVSYS",
+    "EXFSYS",
+    "FLOWS_FILES",
+    "GGSYS",
+    "GSMADMIN_INTERNAL",
+    "GSMCATUSER",
+    "GSMUSER",
+    "LBACSYS",
+    "MDDATA",
+    "MDSYS",
+    "MGMT_VIEW",
+    "OJVMSYS",
+    "OLAPSYS",
+    "ORACLE_OCM",
+    "ORDDATA",
+    "ORDPLUGINS",
+    "ORDSYS",
+    "OUTLN",
+    "PDBADMIN",
+    "REMOTE_SCHEDULER_AGENT",
+    "SI_INFORMTN_SCHEMA",
+    "SPATIAL_CSW_ADMIN_USR",
+    "SPATIAL_WFS_ADMIN_USR",
+    "SYS",
+    "SYS$UMF",
+    "SYSBACKUP",
+    "SYSDG",
+    "SYSKM",
+    "SYSMAN",
+    "SYSRAC",
+    "TSMSYS",
+    "WMSYS",
+    "XDB",
+    "XS$NULL",
+}
+
+
 def _ora_denormalize_name(self, name):
     """Oracle specific version of sqlalchemy/engine/default.py.denormalize_name()
 
@@ -253,7 +303,12 @@ class Backend(BaseAlchemyBackend):
         return char_type[0] in ["CHAR", "NCHAR"]
 
     def list_databases(self) -> list:
-        return sa.inspect(self.con).get_schema_names()
+        all_schemas = sa.inspect(self.con).get_schema_names()
+        return [
+            schema
+            for schema in all_schemas
+            if schema.upper() not in ORACLE_SYSTEM_SCHEMAS
+        ]
 
     def dvt_tuple_in_supported(self) -> bool:
         """Return True if backend client supports native SQL tuple/struct IN expressions."""


### PR DESCRIPTION
## Description of changes
Excludes Oracle system schemas from list_databases results.

## Issues to be closed

Closes #1765

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines


