### PR TITLE
feat: add GitHub Copilot app config

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,22 @@
+instructions: |
+  This repository contains the Google Cloud Data Validation Tool (DVT), a Python CLI for comparing source and target data across heterogeneous databases and warehouses.
+
+  Key repo guidance:
+  - Prefer small, targeted changes that preserve the existing CLI conventions and validation abstractions.
+  - Use pytest and nox for validation; the canonical unit test entry point is `python -m pytest tests/unit --quiet` and the project also defines `nox -s unit_default_python` and `nox -s lint`.
+  - Keep changes compatible with the existing Ibis-based architecture and Data Validation Tool connection patterns.
+  - Follow the repository's formatting and lint standards (Black and Flake8) and avoid adding broad dependencies unless needed.
+
+scripts:
+  - name: Setup dev environment
+    command: python -m pip install --upgrade pip && python -m pip install -e .
+    triggers:
+      - session.create
+  - name: Run unit tests
+    command: python -m pytest tests/unit --quiet
+  - name: Run lint checks
+    command: nox -s lint
+
+automation:
+  auto_issue_session: true
+  remote_control: false


### PR DESCRIPTION
## Description of changes
Add a repository-level `.github/github-app.yml` so Copilot sessions follow project conventions for setup, validation, and automation. This gives the workspace a consistent default for repo instructions and common dev tasks without altering runtime behavior.

## Issues to be closed
N/A

## Checklist

- [x] I have followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/professional-services-data-validator/blob/develop/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated any relevant documentation to reflect my changes, if applicable
- [x] I have added unit and/or integration tests relevant to my change as needed
- [x] I have already checked locally that all unit tests and linting are passing (use the `tests/local_check.sh` script)
- [x] I have manually executed end-to-end testing (E2E) with the affected databases/engines