### PR TITLE
fix: clean up Teradata connection parameters

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -180,13 +180,17 @@ data-validation connections add
     [--secret-manager-project-id SECRET_PROJECT_ID]     Secret Manager project ID
     --connection-name CONN_NAME Teradata                Connection name
     --host HOST                                         Teradata host
-    --port PORT                                         Teradata port, defaults to 1025
+    [--port PORT]                                       Teradata port; uses the driver default when omitted
     --user-name USER                                    Teradata user
     --password PASSWORD                                 Teradata password
-    [--logmech LOGMECH]                                 Teradata logmech, defaults to "TD2"
+    [--logmech LOGMECH]                                 Teradata logmech; uses the driver default when omitted
     [--use-no-lock-tables USE_NO_LOCK_TABLES]           Use access lock for queries, defaults to "False"
     [--json-params JSON_PARAMS]                         Additional teradatasql JSON string dict (Optional)
 ```
+
+Connection options supplied explicitly take precedence over equivalent
+`--json-params` values. The driver parameter names for `--port` and
+`--user-name` are `dbs_port` and `user`, respectively.
 
 ## Oracle
 

--- a/tests/unit/ibis_teradata/test_init.py
+++ b/tests/unit/ibis_teradata/test_init.py
@@ -79,6 +79,50 @@ def test_import(module_under_test):
 
 
 @pytest.mark.skipif(not get_module_under_test(), reason="No Teradata driver")
+@mock.patch("third_party.ibis.ibis_teradata.teradatasql.connect")
+def test_connect_uses_driver_defaults(mock_connect, module_under_test):
+    backend = module_under_test.Backend()
+
+    backend.do_connect(host="teradata.example", user_name="dvt_user")
+
+    mock_connect.assert_called_once_with(
+        host="teradata.example",
+        user="dvt_user",
+    )
+
+
+@pytest.mark.skipif(not get_module_under_test(), reason="No Teradata driver")
+@mock.patch("third_party.ibis.ibis_teradata.teradatasql.connect")
+def test_connect_explicit_params_override_json_params(mock_connect, module_under_test):
+    backend = module_under_test.Backend()
+
+    backend.do_connect(
+        host="teradata-staging",
+        user_name="cli_user",
+        password="cli_password",
+        port=2345,
+        logmech="LDAP",
+        json_params={
+            "host": "teradata-dev",
+            "user": "json_user",
+            "password": "json_password",
+            "dbs_port": 1234,
+            "logmech": "TD2",
+            "connect_timeout": 30,
+        },
+    )
+
+    mock_connect.assert_called_once_with(
+        host="teradata-staging",
+        user="cli_user",
+        password="cli_password",
+        dbs_port=2345,
+        logmech="LDAP",
+        connect_timeout=30,
+    )
+
+
+@pytest.mark.skipif(not get_module_under_test(), reason="No Teradata driver")
 def test_raw_column_metadata_no_args(module_under_test):
     backend = module_under_test.Backend()
     with pytest.raises(AssertionError):

--- a/third_party/ibis/ibis_teradata/__init__.py
+++ b/third_party/ibis/ibis_teradata/__init__.py
@@ -38,23 +38,25 @@ class Backend(BaseSQLBackend):
 
     def do_connect(
         self,
-        host: str = "localhost",
+        host: str = None,
         user_name: str = None,
         password: str = None,
-        port: int = 1025,
-        logmech: str = "TD2",
+        port: int = None,
+        logmech: str = None,
         use_no_lock_tables: str = "False",
         json_params: Mapping[str, Any] = None,
     ) -> None:
-        self.teradata_config = {
+        self.teradata_config = dict(json_params) if json_params else {}
+        explicit_config = {
             "host": host,
             "user": user_name,
             "password": password,
             "dbs_port": port,
             "logmech": logmech,
         }
-        if json_params:
-            self.teradata_config.update(json_params)
+        self.teradata_config.update(
+            {key: value for key, value in explicit_config.items() if value is not None}
+        )
 
         self.client = teradatasql.connect(**self.teradata_config)
         self.con = self.client.cursor()

--- a/third_party/ibis/ibis_teradata/api.py
+++ b/third_party/ibis/ibis_teradata/api.py
@@ -18,11 +18,11 @@ from data_validation.util import dvt_config_string_to_dict
 
 
 def teradata_connect(
-    host: str = "localhost",
+    host: str = None,
     user_name: str = None,
     password: str = None,
-    port: int = 1025,
-    logmech: str = "TD2",
+    port: int = None,
+    logmech: str = None,
     use_no_lock_tables: str = "False",
     json_params: str = None,
 ):


### PR DESCRIPTION
## Summary

- let the Teradata driver supply its own port and authentication defaults when those options are omitted
- apply explicit connection options after `json-params`, so command-line values take precedence
- document the precedence and driver parameter names, with regression tests for both behaviors

## Validation

- `python -m pytest tests/unit/ibis_teradata/test_init.py` (6 passed)
- `python -m black --check third_party/ibis/ibis_teradata/api.py third_party/ibis/ibis_teradata/__init__.py tests/unit/ibis_teradata/test_init.py`
- `python -m flake8 tests/unit/ibis_teradata/test_init.py`
- `git diff --check`

Fixes #1016
